### PR TITLE
feat: Cytoscape capability tree, integration map, remove matrix

### DIFF
--- a/internal/api/viewer_handler.go
+++ b/internal/api/viewer_handler.go
@@ -94,4 +94,3 @@ func registerViewerRoutes(r chi.Router, db *sql.DB) {
 	r.Get("/workspaces/{id}/views/integration-map/graph", h.getIntegrationMap)
 	r.Get("/workspaces/{id}/views/{view}", h.getView)
 }
-

--- a/internal/viewer/views/capability_tree_data.go
+++ b/internal/viewer/views/capability_tree_data.go
@@ -9,11 +9,11 @@ import (
 
 // CapabilityNode is a single node in the capability tree.
 type CapabilityNode struct {
-	ID             string               `json:"id"`
-	Name           string               `json:"name"`
-	Type           string               `json:"type"`
-	ParentID       string               `json:"parent_id"`
-	SupportingApps []CapabilitySuppApp  `json:"supporting_apps"`
+	ID             string              `json:"id"`
+	Name           string              `json:"name"`
+	Type           string              `json:"type"`
+	ParentID       string              `json:"parent_id"`
+	SupportingApps []CapabilitySuppApp `json:"supporting_apps"`
 }
 
 // CapabilitySuppApp is an application element that serves a capability or process.


### PR DESCRIPTION
## Summary

- **Capability Tree** rewritten with Cytoscape.js + dagre LR layout: rectangular nodes, left-to-right hierarchy, zoom/pan, hover tooltips. Backend now returns only `Capability` type elements. Application nodes visually differentiated by sub-type (Component, Service, Function, Interface).
- **Integration Map** new view showing application integration topology — components, services and data objects connected by integration relationships only (Serving, Access, Flow). Structural relationships (Composition, Realization) excluded. Edge colors encode relationship type.
- **Removed** App↔Business Matrix view (backend, routes, frontend, CSS).
- **Fix** gofmt formatting on `viewer_handler.go` and `capability_tree_data.go`.

## Test plan

- [ ] Capability Tree loads and renders as LR dagre graph with capability hierarchy
- [ ] Only `Capability` type nodes appear (no BusinessProcess/BusinessFunction)
- [ ] Application nodes show correct color per sub-type on hover tooltip
- [ ] Integration Map loads and shows components + data objects
- [ ] Edge colors match relationship type
- [ ] App↔Business Matrix route returns 404
- [ ] CI passes (gofmt, build, tests)