### PR TITLE
docs: update README, CONTRIBUTING and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,70 @@ ArchiPulse uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Added
-- Initial project structure
-- README, CONTRIBUTING, ARCHITECTURE documentation
-- PostgreSQL schema — AOEF as tables (workspaces, elements, relationships, diagrams)
-- AOEF (XML) and AJX (JSON) parser in Go
-- Workspace CRUD API
-- Element, relationship, and diagram CRUD API with optimistic locking
-- AOEF and AJX export
-- CI pipeline
+### Planned
+- Capability Gap Analysis view
+- Technology Stack view
 
 ---
 
-_Releases will be tagged in GitHub and linked here as the project matures._
+## [0.4.0] — 2026-03-30
 
-[Unreleased]: https://github.com/DisruptiveWorks/archipulse/compare/HEAD
+### Added
+- Svelte 5 + Vite 6 frontend replacing single-file vanilla JS SPA
+- Component-based architecture: Nav, Sidebar, Home, WorkspaceOverview, TableView, GraphView, CapabilityTree, ViewRouter
+- Cytoscape moved from CDN to npm dependency
+- Node 22 build stage in Dockerfile and CI
+
+### Changed
+- `cmd/archipulse/web/` replaced by `cmd/archipulse/ui/` (Svelte project)
+- `embed.go` points to `ui/dist/` instead of `web/`
+- `frontend.go` serves `/assets/*` instead of `/static/*`
+
+---
+
+## [0.3.0] — 2026-03-29
+
+### Added
+- Integration Map view — application integration topology with components, services and data objects; edges colored by relationship type (Serving, Access, Flow, Triggering)
+- Capability Tree rebuilt with Cytoscape.js + dagre LR layout — rectangular nodes, left-to-right hierarchy, zoom/pan, hover tooltips
+- Application node sub-type differentiation: Component (solid), Service (dashed), Function (muted), Interface (teal)
+- Backend filters Capability Tree to only `Capability` type elements
+
+### Removed
+- App↔Business Matrix view
+
+---
+
+## [0.2.0] — 2026-03-28
+
+### Added
+- Embedded SPA frontend (`//go:embed`) — single binary with no runtime dependencies
+- Sidebar layout with views grouped by ArchiMate layer
+- Workspace overview with element counts by layer
+- EAM views: Element Catalogue, Application Catalogue, Application Landscape, Technology Catalogue, Capability Tree, Application Dependency Graph
+- Application Dependency Graph with Cytoscape.js
+- Docker Compose setup (postgres:17-alpine + app with healthcheck)
+- Multi-stage Dockerfile (golang:1.24-alpine → alpine:3.21)
+- ArchiPulse branding: orange hexagon logo, Trebuchet MS wordmark
+
+---
+
+## [0.1.0] — 2026-03-15
+
+### Added
+- Initial project structure
+- PostgreSQL schema — AOEF as tables (workspaces, elements, relationships, diagrams)
+- AOEF (XML) and AJX (JSON) parser with semantic validation
+- Workspace CRUD API
+- Element, relationship, and diagram CRUD API with optimistic locking
+- AOEF and AJX export
+- EAM viewer engine (`internal/viewer`) with SQL-based analytical views
+- CI pipeline (Go build, gofmt, go vet, tests)
+
+---
+
+[Unreleased]: https://github.com/DisruptiveWorks/archipulse/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/DisruptiveWorks/archipulse/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/DisruptiveWorks/archipulse/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/DisruptiveWorks/archipulse/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/DisruptiveWorks/archipulse/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,10 +168,10 @@ Documentation lives in `docs/` and `README.md`. No full dev environment needed �
 
 ### Prerequisites
 
-- [Go](https://go.dev/dl/) 1.22 or higher
-- [PostgreSQL](https://www.postgresql.org/download/) 16 or higher
+- [Go](https://go.dev/dl/) 1.24 or higher
+- [Node.js](https://nodejs.org/) 22 or higher
+- [PostgreSQL](https://www.postgresql.org/download/) 17 or higher
 - Git
-- Make (optional)
 
 ### Steps
 
@@ -187,7 +187,10 @@ git remote add upstream https://github.com/DisruptiveWorks/archipulse.git
 cp .env.example .env
 # Edit .env — set DATABASE_URL
 
-# Install dependencies
+# Build the frontend
+cd cmd/archipulse/ui && npm install && npm run build && cd ../../..
+
+# Install Go dependencies
 go mod download
 
 # Run migrations
@@ -222,21 +225,21 @@ curl -X POST http://localhost:8080/api/v1/workspaces/{id}/import \
 
 ```
 archipulse/
-├── cmd/                  # CLI entrypoints
+├── cmd/
+│   └── archipulse/
+│       ├── ui/           # Svelte 5 + Vite 6 frontend
+│       │   └── src/      # Components, routes, lib
+│       ├── embed.go      # //go:embed ui/dist
+│       └── main.go
 ├── internal/
-│   ├── parser/           # AOEF and AJX parsers (Go, against official XSD)
+│   ├── parser/           # AOEF and AJX parsers
 │   ├── workspace/        # Workspace manager and CRUD operations
-│   ├── catalog/          # Catalog storage and API
-│   ├── pipeline/         # Extraction engine
-│   │   ├── extractor/    # Source-specific data collectors
-│   │   └── mapper/       # ArchiMate type mapping engine
 │   ├── viewer/           # EAM view generation
-│   │   └── views/        # SQL view definitions
+│   │   └── views/        # Individual view implementations
 │   └── api/              # REST API handlers
-├── web/                  # Web frontend (Cytoscape.js)
 ├── migrations/           # PostgreSQL migrations (one file per version)
 ├── examples/             # Sample ArchiMate models (ArchiSurance, etc.)
-└── docs/                 # Documentation and architecture decisions
+└── tests/                # Integration tests
 ```
 
 For the full design rationale see [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md). Read it before opening proposals that affect the schema, API, or core architecture.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Built on ArchiMate · Powered by Go · PostgreSQL · Open Source
 
 [![Build](https://img.shields.io/github/actions/workflow/status/DisruptiveWorks/archipulse/ci.yml?branch=main&style=flat-square)](https://github.com/DisruptiveWorks/archipulse/actions)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](./LICENSE)
-[![Go Version](https://img.shields.io/badge/go-1.22%2B-00ADD8?style=flat-square&logo=go)](https://go.dev)
-[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-16%2B-336791?style=flat-square&logo=postgresql)](https://www.postgresql.org)
+[![Go Version](https://img.shields.io/badge/go-1.24%2B-00ADD8?style=flat-square&logo=go)](https://go.dev)
+[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-17%2B-336791?style=flat-square&logo=postgresql)](https://www.postgresql.org)
 [![ArchiMate](https://img.shields.io/badge/ArchiMate-3.2-orange?style=flat-square)](https://www.opengroup.org/archimate-forum)
 [![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen?style=flat-square)](./CONTRIBUTING.md)
 
@@ -111,7 +111,7 @@ flowchart TD
 
 ## Screenshots
 
-> Screenshots and demo coming in v0.2. Follow the project or join the [Discussions](https://github.com/DisruptiveWorks/archipulse/discussions) to get notified.
+> Full screenshots coming soon. Follow the project or join the [Discussions](https://github.com/DisruptiveWorks/archipulse/discussions) to get notified.
 
 ---
 
@@ -119,32 +119,40 @@ flowchart TD
 
 ### Prerequisites
 
-- [Go](https://go.dev/dl/) 1.22 or higher
-- [PostgreSQL](https://www.postgresql.org/download/) 16 or higher
-- Git
+- [Docker](https://docs.docker.com/get-docker/) and Docker Compose — recommended
+- Or: [Go](https://go.dev/dl/) 1.24+, [Node.js](https://nodejs.org/) 22+, [PostgreSQL](https://www.postgresql.org/download/) 17+
 
-### Installation
+### Docker (recommended)
+
+```bash
+git clone https://github.com/DisruptiveWorks/archipulse.git
+cd archipulse
+docker compose up
+```
+
+The web interface will be available at `http://localhost:8080`.
+
+### Manual Installation
 
 ```bash
 # Clone the repository
 git clone https://github.com/DisruptiveWorks/archipulse.git
 cd archipulse
 
-# Copy and configure environment
+# Build the frontend
+cd cmd/archipulse/ui && npm install && npm run build && cd ../../..
+
+# Configure environment
 cp .env.example .env
-# Edit .env — set DATABASE_URL and other settings
+# Edit .env — set DATABASE_URL
 
 # Run database migrations
 go run ./cmd/archipulse migrate
 
-# Build
+# Build and run
 go build -o archipulse ./cmd/archipulse
-
-# Run
 ./archipulse serve
 ```
-
-The web interface will be available at `http://localhost:8080`.
 
 ### Quick Start
 
@@ -154,7 +162,7 @@ curl -X POST http://localhost:8080/api/v1/workspaces \
   -H "Content-Type: application/json" \
   -d '{"name": "Q1-2026-AS-IS", "purpose": "as-is"}'
 
-# Import an ArchiMate model (AOEF format)
+# Import an ArchiMate model
 curl -X POST http://localhost:8080/api/v1/workspaces/{id}/import \
   -F "file=@examples/archisurance.xml"
 
@@ -163,12 +171,6 @@ open http://localhost:8080
 ```
 
 ArchiPulse ships with the **ArchiSurance** example model from The Open Group so you can explore the viewer immediately.
-
-#### Docker (coming in v0.2)
-
-```bash
-docker compose up
-```
 
 ---
 
@@ -189,62 +191,59 @@ ArchiPulse is built around a single core insight: **the ArchiMate Open Exchange 
 
 This means export is a SELECT, import is an INSERT, and collaboration is database-native. No custom metamodel, no graph database, no vendor lock-in.
 
-For the full design rationale, schema, API design, and decision log see [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md).
-
 **Repository structure:**
 
 ```
 archipulse/
-├── cmd/                  # CLI entrypoints
+├── cmd/
+│   └── archipulse/
+│       ├── ui/           # Svelte 5 + Vite 6 frontend
+│       │   └── src/      # Components, routes, lib
+│       ├── embed.go      # //go:embed ui/dist
+│       └── main.go
 ├── internal/
 │   ├── parser/           # AOEF and AJX parsers
 │   ├── workspace/        # Workspace manager and CRUD
-│   ├── catalog/          # Catalog storage and API
-│   ├── pipeline/         # Extraction engine
-│   │   ├── extractor/    # Source-specific collectors
-│   │   └── mapper/       # ArchiMate type mapping engine
 │   ├── viewer/           # EAM view generation (SQL queries)
+│   │   └── views/        # Individual view implementations
 │   └── api/              # REST API handlers
-├── web/                  # Web frontend (Cytoscape.js)
 ├── migrations/           # PostgreSQL migrations
-├── examples/             # Sample ArchiMate models
-└── docs/                 # Documentation and architecture decisions
+├── examples/             # Sample ArchiMate models (ArchiSurance)
+└── tests/                # Integration tests
 ```
 
 ---
 
 ## Roadmap
 
-### v0.1 — Foundation _(current)_
-- [x] AOEF parser
-- [x] AJX parser
+### v0.1 — Foundation ✅
+- [x] AOEF and AJX parser with semantic validation
 - [x] PostgreSQL schema (AOEF as tables)
-- [x] Workspace CRUD API
-- [x] Element, relationship, diagram CRUD API
+- [x] Workspace, element, relationship, diagram CRUD API
 - [x] Optimistic locking on all editable resources
 - [x] AOEF and AJX export
 - [x] CI pipeline and test suite
-- [ ] AOEF XSD validation — deferred to v0.2 (see [#1](https://github.com/DisruptiveWorks/archipulse/issues/1))
 
-### v0.2 — Viewer & Navigation
-- [ ] Static ArchiMate viewer
-- [ ] Basic EAM views (capability map, application landscape)
-- [ ] Graph explorer with Cytoscape.js
-- [ ] Docker Compose setup
-- [ ] Screenshots and demo
+### v0.2 — Viewer & Navigation ✅
+- [x] Embedded SPA frontend (single binary, no runtime deps)
+- [x] EAM views: Element Catalogue, Application Catalogue, Application Landscape, Technology Catalogue
+- [x] Application Dependency Graph (Cytoscape.js)
+- [x] Capability Tree view
+- [x] Docker Compose setup
 
-### v0.3 — Enrichment Pipeline
-- [ ] Catalog storage and API
-- [ ] Extractor plugin system
-- [ ] Mapper engine with field mapping rules
-- [ ] First-party extractors: AWS Lambda, CSV/Excel
-- [ ] Semantic diff UI for AOEF uploads
+### v0.3 — EAM Views ✅
+- [x] Integration Map view (application integration topology)
+- [x] Capability Tree rebuilt with Cytoscape dagre LR + tooltips
+- [x] Application node sub-type differentiation
 
-### v0.4 — Analysis & Collaboration
-- [ ] Full EAM view suite
-- [ ] Overlap visibility (elements touched by multiple architects)
-- [ ] Dependency analysis and gap detection
-- [ ] Report generation
+### v0.4 — Frontend ✅
+- [x] Svelte 5 + Vite 6 component-based frontend
+- [x] Cytoscape as npm dependency
+
+### v0.5 — Analysis _(in progress)_
+- [ ] Capability Gap Analysis (coverage heatmap)
+- [ ] Technology Stack view (app → infrastructure mapping)
+- [ ] Interface Catalogue
 
 ### v1.0 — Stable Platform
 - [ ] Stable REST API


### PR DESCRIPTION
## Summary

Brings all markdown documentation up to date with the current codebase.

**README:**
- Go 1.22 → 1.24, PostgreSQL 16 → 17
- Docker as the recommended install path (it works now)
- Manual install instructions include `npm install && npm run build` step
- Repository structure reflects `cmd/archipulse/ui/` replacing `web/`
- Roadmap marks v0.1–v0.4 as done, adds v0.5 with next planned views
- Removed reference to `docs/ARCHITECTURE.md` (doesn't exist)

**CONTRIBUTING:**
- Same version bumps
- Dev setup includes npm frontend build step
- Project structure tree updated

**CHANGELOG:**
- Added entries for v0.1, v0.2, v0.3, v0.4 with accurate descriptions