### PR TITLE
feat(element): element_properties table with source tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,70 @@ ArchiPulse uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Added
-- Initial project structure
-- README, CONTRIBUTING, ARCHITECTURE documentation
-- PostgreSQL schema — AOEF as tables (workspaces, elements, relationships, diagrams)
-- AOEF (XML) and AJX (JSON) parser in Go
-- Workspace CRUD API
-- Element, relationship, and diagram CRUD API with optimistic locking
-- AOEF and AJX export
-- CI pipeline
+### Planned
+- Capability Gap Analysis view
+- Technology Stack view
 
 ---
 
-_Releases will be tagged in GitHub and linked here as the project matures._
+## [0.4.0] — 2026-03-30
 
-[Unreleased]: https://github.com/DisruptiveWorks/archipulse/compare/HEAD
+### Added
+- Svelte 5 + Vite 6 frontend replacing single-file vanilla JS SPA
+- Component-based architecture: Nav, Sidebar, Home, WorkspaceOverview, TableView, GraphView, CapabilityTree, ViewRouter
+- Cytoscape moved from CDN to npm dependency
+- Node 22 build stage in Dockerfile and CI
+
+### Changed
+- `cmd/archipulse/web/` replaced by `cmd/archipulse/ui/` (Svelte project)
+- `embed.go` points to `ui/dist/` instead of `web/`
+- `frontend.go` serves `/assets/*` instead of `/static/*`
+
+---
+
+## [0.3.0] — 2026-03-29
+
+### Added
+- Integration Map view — application integration topology with components, services and data objects; edges colored by relationship type (Serving, Access, Flow, Triggering)
+- Capability Tree rebuilt with Cytoscape.js + dagre LR layout — rectangular nodes, left-to-right hierarchy, zoom/pan, hover tooltips
+- Application node sub-type differentiation: Component (solid), Service (dashed), Function (muted), Interface (teal)
+- Backend filters Capability Tree to only `Capability` type elements
+
+### Removed
+- App↔Business Matrix view
+
+---
+
+## [0.2.0] — 2026-03-28
+
+### Added
+- Embedded SPA frontend (`//go:embed`) — single binary with no runtime dependencies
+- Sidebar layout with views grouped by ArchiMate layer
+- Workspace overview with element counts by layer
+- EAM views: Element Catalogue, Application Catalogue, Application Landscape, Technology Catalogue, Capability Tree, Application Dependency Graph
+- Application Dependency Graph with Cytoscape.js
+- Docker Compose setup (postgres:17-alpine + app with healthcheck)
+- Multi-stage Dockerfile (golang:1.24-alpine → alpine:3.21)
+- ArchiPulse branding: orange hexagon logo, Trebuchet MS wordmark
+
+---
+
+## [0.1.0] — 2026-03-15
+
+### Added
+- Initial project structure
+- PostgreSQL schema — AOEF as tables (workspaces, elements, relationships, diagrams)
+- AOEF (XML) and AJX (JSON) parser with semantic validation
+- Workspace CRUD API
+- Element, relationship, and diagram CRUD API with optimistic locking
+- AOEF and AJX export
+- EAM viewer engine (`internal/viewer`) with SQL-based analytical views
+- CI pipeline (Go build, gofmt, go vet, tests)
+
+---
+
+[Unreleased]: https://github.com/DisruptiveWorks/archipulse/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/DisruptiveWorks/archipulse/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/DisruptiveWorks/archipulse/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/DisruptiveWorks/archipulse/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/DisruptiveWorks/archipulse/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,10 +168,10 @@ Documentation lives in `docs/` and `README.md`. No full dev environment needed �
 
 ### Prerequisites
 
-- [Go](https://go.dev/dl/) 1.22 or higher
-- [PostgreSQL](https://www.postgresql.org/download/) 16 or higher
+- [Go](https://go.dev/dl/) 1.24 or higher
+- [Node.js](https://nodejs.org/) 22 or higher
+- [PostgreSQL](https://www.postgresql.org/download/) 17 or higher
 - Git
-- Make (optional)
 
 ### Steps
 
@@ -187,7 +187,10 @@ git remote add upstream https://github.com/DisruptiveWorks/archipulse.git
 cp .env.example .env
 # Edit .env — set DATABASE_URL
 
-# Install dependencies
+# Build the frontend
+cd cmd/archipulse/ui && npm install && npm run build && cd ../../..
+
+# Install Go dependencies
 go mod download
 
 # Run migrations
@@ -222,21 +225,21 @@ curl -X POST http://localhost:8080/api/v1/workspaces/{id}/import \
 
 ```
 archipulse/
-├── cmd/                  # CLI entrypoints
+├── cmd/
+│   └── archipulse/
+│       ├── ui/           # Svelte 5 + Vite 6 frontend
+│       │   └── src/      # Components, routes, lib
+│       ├── embed.go      # //go:embed ui/dist
+│       └── main.go
 ├── internal/
-│   ├── parser/           # AOEF and AJX parsers (Go, against official XSD)
+│   ├── parser/           # AOEF and AJX parsers
 │   ├── workspace/        # Workspace manager and CRUD operations
-│   ├── catalog/          # Catalog storage and API
-│   ├── pipeline/         # Extraction engine
-│   │   ├── extractor/    # Source-specific data collectors
-│   │   └── mapper/       # ArchiMate type mapping engine
 │   ├── viewer/           # EAM view generation
-│   │   └── views/        # SQL view definitions
+│   │   └── views/        # Individual view implementations
 │   └── api/              # REST API handlers
-├── web/                  # Web frontend (Cytoscape.js)
 ├── migrations/           # PostgreSQL migrations (one file per version)
 ├── examples/             # Sample ArchiMate models (ArchiSurance, etc.)
-└── docs/                 # Documentation and architecture decisions
+└── tests/                # Integration tests
 ```
 
 For the full design rationale see [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md). Read it before opening proposals that affect the schema, API, or core architecture.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Built on ArchiMate · Powered by Go · PostgreSQL · Open Source
 
 [![Build](https://img.shields.io/github/actions/workflow/status/DisruptiveWorks/archipulse/ci.yml?branch=main&style=flat-square)](https://github.com/DisruptiveWorks/archipulse/actions)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](./LICENSE)
-[![Go Version](https://img.shields.io/badge/go-1.22%2B-00ADD8?style=flat-square&logo=go)](https://go.dev)
-[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-16%2B-336791?style=flat-square&logo=postgresql)](https://www.postgresql.org)
+[![Go Version](https://img.shields.io/badge/go-1.24%2B-00ADD8?style=flat-square&logo=go)](https://go.dev)
+[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-17%2B-336791?style=flat-square&logo=postgresql)](https://www.postgresql.org)
 [![ArchiMate](https://img.shields.io/badge/ArchiMate-3.2-orange?style=flat-square)](https://www.opengroup.org/archimate-forum)
 [![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen?style=flat-square)](./CONTRIBUTING.md)
 
@@ -111,7 +111,7 @@ flowchart TD
 
 ## Screenshots
 
-> Screenshots and demo coming in v0.2. Follow the project or join the [Discussions](https://github.com/DisruptiveWorks/archipulse/discussions) to get notified.
+> Full screenshots coming soon. Follow the project or join the [Discussions](https://github.com/DisruptiveWorks/archipulse/discussions) to get notified.
 
 ---
 
@@ -119,32 +119,40 @@ flowchart TD
 
 ### Prerequisites
 
-- [Go](https://go.dev/dl/) 1.22 or higher
-- [PostgreSQL](https://www.postgresql.org/download/) 16 or higher
-- Git
+- [Docker](https://docs.docker.com/get-docker/) and Docker Compose — recommended
+- Or: [Go](https://go.dev/dl/) 1.24+, [Node.js](https://nodejs.org/) 22+, [PostgreSQL](https://www.postgresql.org/download/) 17+
 
-### Installation
+### Docker (recommended)
+
+```bash
+git clone https://github.com/DisruptiveWorks/archipulse.git
+cd archipulse
+docker compose up
+```
+
+The web interface will be available at `http://localhost:8080`.
+
+### Manual Installation
 
 ```bash
 # Clone the repository
 git clone https://github.com/DisruptiveWorks/archipulse.git
 cd archipulse
 
-# Copy and configure environment
+# Build the frontend
+cd cmd/archipulse/ui && npm install && npm run build && cd ../../..
+
+# Configure environment
 cp .env.example .env
-# Edit .env — set DATABASE_URL and other settings
+# Edit .env — set DATABASE_URL
 
 # Run database migrations
 go run ./cmd/archipulse migrate
 
-# Build
+# Build and run
 go build -o archipulse ./cmd/archipulse
-
-# Run
 ./archipulse serve
 ```
-
-The web interface will be available at `http://localhost:8080`.
 
 ### Quick Start
 
@@ -154,7 +162,7 @@ curl -X POST http://localhost:8080/api/v1/workspaces \
   -H "Content-Type: application/json" \
   -d '{"name": "Q1-2026-AS-IS", "purpose": "as-is"}'
 
-# Import an ArchiMate model (AOEF format)
+# Import an ArchiMate model
 curl -X POST http://localhost:8080/api/v1/workspaces/{id}/import \
   -F "file=@examples/archisurance.xml"
 
@@ -163,12 +171,6 @@ open http://localhost:8080
 ```
 
 ArchiPulse ships with the **ArchiSurance** example model from The Open Group so you can explore the viewer immediately.
-
-#### Docker (coming in v0.2)
-
-```bash
-docker compose up
-```
 
 ---
 
@@ -189,62 +191,59 @@ ArchiPulse is built around a single core insight: **the ArchiMate Open Exchange 
 
 This means export is a SELECT, import is an INSERT, and collaboration is database-native. No custom metamodel, no graph database, no vendor lock-in.
 
-For the full design rationale, schema, API design, and decision log see [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md).
-
 **Repository structure:**
 
 ```
 archipulse/
-├── cmd/                  # CLI entrypoints
+├── cmd/
+│   └── archipulse/
+│       ├── ui/           # Svelte 5 + Vite 6 frontend
+│       │   └── src/      # Components, routes, lib
+│       ├── embed.go      # //go:embed ui/dist
+│       └── main.go
 ├── internal/
 │   ├── parser/           # AOEF and AJX parsers
 │   ├── workspace/        # Workspace manager and CRUD
-│   ├── catalog/          # Catalog storage and API
-│   ├── pipeline/         # Extraction engine
-│   │   ├── extractor/    # Source-specific collectors
-│   │   └── mapper/       # ArchiMate type mapping engine
 │   ├── viewer/           # EAM view generation (SQL queries)
+│   │   └── views/        # Individual view implementations
 │   └── api/              # REST API handlers
-├── web/                  # Web frontend (Cytoscape.js)
 ├── migrations/           # PostgreSQL migrations
-├── examples/             # Sample ArchiMate models
-└── docs/                 # Documentation and architecture decisions
+├── examples/             # Sample ArchiMate models (ArchiSurance)
+└── tests/                # Integration tests
 ```
 
 ---
 
 ## Roadmap
 
-### v0.1 — Foundation _(current)_
-- [x] AOEF parser
-- [x] AJX parser
+### v0.1 — Foundation ✅
+- [x] AOEF and AJX parser with semantic validation
 - [x] PostgreSQL schema (AOEF as tables)
-- [x] Workspace CRUD API
-- [x] Element, relationship, diagram CRUD API
+- [x] Workspace, element, relationship, diagram CRUD API
 - [x] Optimistic locking on all editable resources
 - [x] AOEF and AJX export
 - [x] CI pipeline and test suite
-- [ ] AOEF XSD validation — deferred to v0.2 (see [#1](https://github.com/DisruptiveWorks/archipulse/issues/1))
 
-### v0.2 — Viewer & Navigation
-- [ ] Static ArchiMate viewer
-- [ ] Basic EAM views (capability map, application landscape)
-- [ ] Graph explorer with Cytoscape.js
-- [ ] Docker Compose setup
-- [ ] Screenshots and demo
+### v0.2 — Viewer & Navigation ✅
+- [x] Embedded SPA frontend (single binary, no runtime deps)
+- [x] EAM views: Element Catalogue, Application Catalogue, Application Landscape, Technology Catalogue
+- [x] Application Dependency Graph (Cytoscape.js)
+- [x] Capability Tree view
+- [x] Docker Compose setup
 
-### v0.3 — Enrichment Pipeline
-- [ ] Catalog storage and API
-- [ ] Extractor plugin system
-- [ ] Mapper engine with field mapping rules
-- [ ] First-party extractors: AWS Lambda, CSV/Excel
-- [ ] Semantic diff UI for AOEF uploads
+### v0.3 — EAM Views ✅
+- [x] Integration Map view (application integration topology)
+- [x] Capability Tree rebuilt with Cytoscape dagre LR + tooltips
+- [x] Application node sub-type differentiation
 
-### v0.4 — Analysis & Collaboration
-- [ ] Full EAM view suite
-- [ ] Overlap visibility (elements touched by multiple architects)
-- [ ] Dependency analysis and gap detection
-- [ ] Report generation
+### v0.4 — Frontend ✅
+- [x] Svelte 5 + Vite 6 component-based frontend
+- [x] Cytoscape as npm dependency
+
+### v0.5 — Analysis _(in progress)_
+- [ ] Capability Gap Analysis (coverage heatmap)
+- [ ] Technology Stack view (app → infrastructure mapping)
+- [ ] Interface Catalogue
 
 ### v1.0 — Stable Platform
 - [ ] Stable REST API

--- a/internal/api/element_handler.go
+++ b/internal/api/element_handler.go
@@ -46,7 +46,23 @@ func (h *elementHandler) get(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusInternalServerError, err)
 		return
 	}
-	respondJSON(w, http.StatusOK, e)
+
+	props, err := h.store.ListProperties(id)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	// Group properties by source.
+	bySource := make(map[string][]element.Property)
+	for _, p := range props {
+		bySource[p.Source] = append(bySource[p.Source], p)
+	}
+
+	respondJSON(w, http.StatusOK, map[string]any{
+		"element":    e,
+		"properties": bySource,
+	})
 }
 
 func (h *elementHandler) create(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/import_handler.go
+++ b/internal/api/import_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 
+	"github.com/DisruptiveWorks/archipulse/internal/element"
 	"github.com/DisruptiveWorks/archipulse/internal/parser"
 	"github.com/DisruptiveWorks/archipulse/internal/workspace"
 )
@@ -110,18 +111,34 @@ func importInTx(db *sql.DB, wsID uuid.UUID, m *parser.Model) (*ImportResult, err
 
 	for _, e := range m.Elements {
 		layer := parser.ElementLayer(e.Type)
-		_, err := tx.Exec(`
+		var elemID uuid.UUID
+		err := tx.QueryRow(`
 			INSERT INTO elements (workspace_id, source_id, type, layer, name, documentation)
 			VALUES ($1, $2, $3, $4, $5, $6)
 			ON CONFLICT (workspace_id, source_id) DO UPDATE
 			  SET type = EXCLUDED.type, layer = EXCLUDED.layer,
 			      name = EXCLUDED.name, documentation = EXCLUDED.documentation,
-			      version = elements.version + 1, updated_at = now()`,
-			wsID, e.ID, e.Type, layer, e.Name, e.Documentation)
+			      version = elements.version + 1, updated_at = now()
+			RETURNING id`,
+			wsID, e.ID, e.Type, layer, e.Name, e.Documentation).Scan(&elemID)
 		if err != nil {
 			return nil, errorf("upsert element %q: %w", e.ID, err)
 		}
 		result.Elements++
+
+		if len(e.Properties) > 0 {
+			// Remove existing model properties so a re-import stays clean.
+			if _, err := tx.Exec(`DELETE FROM element_properties WHERE element_id = $1 AND source = 'model'`, elemID); err != nil {
+				return nil, errorf("clear model properties for element %q: %w", e.ID, err)
+			}
+			props := make([]struct{ Key, Value string }, len(e.Properties))
+			for i, p := range e.Properties {
+				props[i] = struct{ Key, Value string }{p.Key, p.Value}
+			}
+			if err := element.InsertProperties(tx, elemID, props, "model", nil); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	for _, r := range m.Relationships {

--- a/internal/element/element.go
+++ b/internal/element/element.go
@@ -10,6 +10,17 @@ import (
 	"github.com/google/uuid"
 )
 
+// Property is a key/value pair stored in element_properties.
+type Property struct {
+	ID          uuid.UUID  `json:"id"`
+	ElementID   uuid.UUID  `json:"element_id"`
+	Key         string     `json:"key"`
+	Value       string     `json:"value"`
+	Source      string     `json:"source"`
+	CollectedAt *time.Time `json:"collected_at,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+}
+
 var ErrNotFound = errors.New("element not found")
 var ErrConflict = errors.New("element was modified by another request")
 
@@ -116,4 +127,45 @@ func (s *Store) Delete(id uuid.UUID) error {
 		return ErrNotFound
 	}
 	return nil
+}
+
+// InsertProperties bulk-inserts properties for an element using the provided executor
+// (either *sql.DB or *sql.Tx). source is the extractor name or "model".
+// collectedAt may be nil when source is "model".
+func InsertProperties(exec interface {
+	Exec(query string, args ...any) (sql.Result, error)
+}, elementID uuid.UUID, props []struct{ Key, Value string }, source string, collectedAt *time.Time) error {
+	for _, p := range props {
+		_, err := exec.Exec(`
+			INSERT INTO element_properties (element_id, key, value, source, collected_at)
+			VALUES ($1, $2, $3, $4, $5)`,
+			elementID, p.Key, p.Value, source, collectedAt)
+		if err != nil {
+			return fmt.Errorf("insert property %q for element %s: %w", p.Key, elementID, err)
+		}
+	}
+	return nil
+}
+
+// ListProperties returns all properties for an element, grouped by source in the returned slice.
+func (s *Store) ListProperties(elementID uuid.UUID) ([]Property, error) {
+	rows, err := s.db.Query(`
+		SELECT id, element_id, key, value, source, collected_at, created_at
+		FROM element_properties
+		WHERE element_id = $1
+		ORDER BY source, key`, elementID)
+	if err != nil {
+		return nil, fmt.Errorf("list properties: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []Property
+	for rows.Next() {
+		var p Property
+		if err := rows.Scan(&p.ID, &p.ElementID, &p.Key, &p.Value, &p.Source, &p.CollectedAt, &p.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
 }

--- a/internal/parser/ajx.go
+++ b/internal/parser/ajx.go
@@ -71,7 +71,12 @@ func (m *ajxModel) toModel() *Model {
 	out := &Model{Name: m.Name}
 
 	for _, e := range m.Elements {
-		out.Elements = append(out.Elements, Element(e))
+		out.Elements = append(out.Elements, Element{
+			ID:            e.ID,
+			Type:          e.Type,
+			Name:          e.Name,
+			Documentation: e.Documentation,
+		})
 	}
 
 	for _, r := range m.Relationships {

--- a/internal/parser/aoef.go
+++ b/internal/parser/aoef.go
@@ -21,16 +21,28 @@ func ParseAOEF(r io.Reader) (*Model, error) {
 type aoefModel struct {
 	XMLName       xml.Name           `xml:"model"`
 	Name          string             `xml:"name"`
+	PropertyDefs  []aoefPropertyDef  `xml:"propertyDefinitions>propertyDefinition"`
 	Elements      []aoefElement      `xml:"elements>element"`
 	Relationships []aoefRelationship `xml:"relationships>relationship"`
 	Views         []aoefView         `xml:"views>diagrams>view"`
 }
 
+type aoefPropertyDef struct {
+	ID   string `xml:"identifier,attr"`
+	Name string `xml:"name"`
+}
+
 type aoefElement struct {
-	ID            string `xml:"identifier,attr"`
-	Type          string `xml:"type,attr"`
-	Name          string `xml:"name"`
-	Documentation string `xml:"documentation"`
+	ID            string         `xml:"identifier,attr"`
+	Type          string         `xml:"type,attr"`
+	Name          string         `xml:"name"`
+	Documentation string         `xml:"documentation"`
+	Properties    []aoefProperty `xml:"properties>property"`
+}
+
+type aoefProperty struct {
+	DefinitionRef string `xml:"propertyDefinitionRef,attr"`
+	Value         string `xml:"value"`
 }
 
 type aoefRelationship struct {
@@ -72,8 +84,29 @@ type aoefPoint struct {
 func (m *aoefModel) toModel() *Model {
 	out := &Model{Name: m.Name}
 
+	// Build property definition ID → name lookup.
+	propNames := make(map[string]string, len(m.PropertyDefs))
+	for _, pd := range m.PropertyDefs {
+		propNames[pd.ID] = pd.Name
+	}
+
 	for _, e := range m.Elements {
-		out.Elements = append(out.Elements, Element(e))
+		elem := Element{
+			ID:            e.ID,
+			Type:          e.Type,
+			Name:          e.Name,
+			Documentation: e.Documentation,
+		}
+		for _, p := range e.Properties {
+			key := propNames[p.DefinitionRef]
+			if key == "" {
+				key = p.DefinitionRef
+			}
+			if key != "" && p.Value != "" {
+				elem.Properties = append(elem.Properties, Property{Key: key, Value: p.Value})
+			}
+		}
+		out.Elements = append(out.Elements, elem)
 	}
 
 	for _, r := range m.Relationships {

--- a/internal/parser/model.go
+++ b/internal/parser/model.go
@@ -15,6 +15,13 @@ type Element struct {
 	Type          string
 	Name          string
 	Documentation string
+	Properties    []Property
+}
+
+// Property is a key/value pair attached to an element, sourced from the model file.
+type Property struct {
+	Key   string
+	Value string
 }
 
 // Relationship represents an ArchiMate relationship (AOEF <relationship>).

--- a/migrations/006_create_element_properties.sql
+++ b/migrations/006_create_element_properties.sql
@@ -1,0 +1,12 @@
+CREATE TABLE element_properties (
+    id           uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    element_id   uuid        NOT NULL REFERENCES elements(id) ON DELETE CASCADE,
+    key          text        NOT NULL,
+    value        text        NOT NULL,
+    source       text        NOT NULL DEFAULT 'model',
+    collected_at timestamptz,
+    created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX element_properties_element_idx ON element_properties(element_id);
+CREATE INDEX element_properties_key_idx     ON element_properties(key);


### PR DESCRIPTION
## Summary

- Migration 006: `element_properties` table — `id`, `element_id`, `key`, `value`, `source` (default `'model'`), `collected_at` (nullable), `created_at`; indexes on `element_id` and `key`; no UNIQUE constraint (same key can exist from multiple sources)
- Parser: AOEF now parses `<propertyDefinitions>` + element `<properties>` — resolves key names from definition IDs; AJX updated for new `Element` struct
- `element.Store`: `InsertProperties()` (tx-aware) and `ListProperties()` 
- Import: re-inserts `source='model'` properties on each re-import (clean upsert)
- `GET /workspaces/:wsID/elements/:id` now returns `{ element: {...}, properties: { "model": [...], "aws-lambda": [...] } }` — grouped by source (Option C)

## Test plan

- [ ] `docker compose up --build` applies migration 006 cleanly
- [ ] Import `examples/archisurance.xml` — elements with AOEF properties populate `element_properties` with `source='model'`
- [ ] `GET /workspaces/{wsID}/elements/{id}` returns properties grouped by source
- [ ] Re-import same file — properties are replaced, not duplicated
- [ ] `go test ./...` passes