### PR TITLE
feat(dashboard): fix capability filter + app list panel + slice drill-down

### DIFF
--- a/cmd/archipulse/ui/src/App.svelte
+++ b/cmd/archipulse/ui/src/App.svelte
@@ -94,7 +94,6 @@
     <Sidebar
       {wsId}
       {ws}
-      activeView={activeView}
       on:imported={handleImported}
     />
     <div style="flex:1;display:flex;flex-direction:column;min-width:0">

--- a/cmd/archipulse/ui/src/components/Sidebar.svelte
+++ b/cmd/archipulse/ui/src/components/Sidebar.svelte
@@ -1,6 +1,6 @@
 <script>
   import { createEventDispatcher } from 'svelte';
-  import { push } from 'svelte-spa-router';
+  import { push, location } from 'svelte-spa-router';
   import { VIEWS, LAYER_GROUPS } from '../lib/views.js';
   import { api } from '../lib/api.js';
   import { Badge } from '$lib/components/ui/badge';
@@ -8,9 +8,19 @@
 
   export let wsId;
   export let ws = null;
-  export let activeView = null;
 
   const dispatch = createEventDispatcher();
+
+  // Derive active state directly from the router location store —
+  // avoids stale-prop issues from parent re-render timing.
+  function isActive(key) {
+    const base = '/ws/' + wsId + '/view/' + key;
+    return $location === base || $location.startsWith(base + '/');
+  }
+
+  function isOverview() {
+    return $location === '/ws/' + wsId;
+  }
 
   const dotColors = {
     'dot-biz':   '#e0af68',
@@ -26,11 +36,6 @@
 
   function navTarget(key, v) {
     return v.graph ? key + '/graph' : v.tree ? key + '/tree' : key;
-  }
-
-  function isActive(key, v) {
-    const target = navTarget(key, v);
-    return activeView === target || activeView === key;
   }
 
   function handleFileInput(e) {
@@ -83,7 +88,7 @@
   {/if}
 
   <div
-    class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm cursor-pointer transition-colors mx-2 mt-2 {!activeView ? 'bg-primary/10 text-primary font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
+    class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm cursor-pointer transition-colors mx-2 mt-2 {isOverview() ? 'bg-primary/10 text-primary font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
     on:click={() => push('/ws/' + wsId)}
     on:keydown={e => e.key === 'Enter' && push('/ws/' + wsId)}
     role="button"
@@ -102,7 +107,7 @@
         <div class="text-[10px] font-bold tracking-[0.8px] uppercase text-muted-foreground px-2 mb-1">{group.label}</div>
         {#each items as [key, v]}
           <div
-            class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm cursor-pointer transition-colors {isActive(key, v) ? 'bg-primary/10 text-primary font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
+            class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm cursor-pointer transition-colors {isActive(key) ? 'bg-primary/10 text-primary font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
             on:click={() => push('/ws/' + wsId + '/view/' + navTarget(key, v))}
             on:keydown={e => e.key === 'Enter' && push('/ws/' + wsId + '/view/' + navTarget(key, v))}
             role="button"

--- a/cmd/archipulse/ui/src/components/Sidebar.svelte
+++ b/cmd/archipulse/ui/src/components/Sidebar.svelte
@@ -11,16 +11,9 @@
 
   const dispatch = createEventDispatcher();
 
-  // Derive active state directly from the router location store —
-  // avoids stale-prop issues from parent re-render timing.
-  function isActive(key) {
-    const base = '/ws/' + wsId + '/view/' + key;
-    return $location === base || $location.startsWith(base + '/');
-  }
-
-  function isOverview() {
-    return $location === '/ws/' + wsId;
-  }
+  // $: ensures Svelte tracks $location as a reactive dependency and
+  // re-renders whenever the store changes.
+  $: loc = $location;
 
   const dotColors = {
     'dot-biz':   '#e0af68',
@@ -88,7 +81,7 @@
   {/if}
 
   <div
-    class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm cursor-pointer transition-colors mx-2 mt-2 {isOverview() ? 'bg-primary/10 text-primary font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
+    class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm cursor-pointer transition-colors mx-2 mt-2 {loc === '/ws/' + wsId ? 'bg-primary/10 text-primary font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
     on:click={() => push('/ws/' + wsId)}
     on:keydown={e => e.key === 'Enter' && push('/ws/' + wsId)}
     role="button"
@@ -106,8 +99,10 @@
       <div class="px-2 pt-3 pb-1">
         <div class="text-[10px] font-bold tracking-[0.8px] uppercase text-muted-foreground px-2 mb-1">{group.label}</div>
         {#each items as [key, v]}
+          {@const base = '/ws/' + wsId + '/view/' + key}
+          {@const active = loc === base || loc.startsWith(base + '/')}
           <div
-            class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm cursor-pointer transition-colors {isActive(key) ? 'bg-primary/10 text-primary font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
+            class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm cursor-pointer transition-colors {active ? 'bg-primary/10 text-primary font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
             on:click={() => push('/ws/' + wsId + '/view/' + navTarget(key, v))}
             on:keydown={e => e.key === 'Enter' && push('/ws/' + wsId + '/view/' + navTarget(key, v))}
             role="button"

--- a/cmd/archipulse/ui/src/routes/ApplicationDashboard.svelte
+++ b/cmd/archipulse/ui/src/routes/ApplicationDashboard.svelte
@@ -2,8 +2,6 @@
   import { onMount } from 'svelte';
   import { api } from '../lib/api.js';
   import { ArcChart } from 'layerchart';
-  import * as Dialog from '$lib/components/ui/dialog';
-  import { Button } from '$lib/components/ui/button';
 
   export let params = {};
 
@@ -13,14 +11,11 @@
   let loading = true;
   let error = null;
   let selectedCapability = 'all';
-  let selectedApp = null;   // source_id of highlighted app, or null
+  let selectedApp = null; // source_id of highlighted app
 
-  // Drill-down modal state
-  let drillKey = null;
-  let drillValue = null;
-  let drillOpen = false;
+  // Tooltip state
+  let tooltip = null; // { key, value, apps, x, y }
 
-  // Human-readable labels for known property keys
   const PROP_LABELS = {
     lifecycle_status: 'Lifecycle Status',
     deployment_model: 'Deployment Model',
@@ -46,8 +41,7 @@
   const UNSET_COLOR = '#4b5563';
 
   function colorFor(value, index) {
-    if (value === '(unset)') return UNSET_COLOR;
-    return PALETTE[index % PALETTE.length];
+    return value === '(unset)' ? UNSET_COLOR : PALETTE[index % PALETTE.length];
   }
 
   function propLabel(key) {
@@ -63,43 +57,46 @@
 
   function arcData(buckets) {
     return buckets.map((b, i) => ({
-      key:   b.value,
-      label: b.value,
-      value: b.count,
-      color: colorFor(b.value, i),
+      key: b.value, label: b.value, value: b.count, color: colorFor(b.value, i),
     }));
   }
 
-  // Apps that match a given property key + value
   function appsForSlice(key, value) {
-    if (!data?.apps) return [];
-    return data.apps.filter(a => {
-      const v = a.properties[key] ?? '';
-      if (value === '(unset)') return v === '';
-      return v === value;
+    return (data?.apps ?? []).filter(a => {
+      const v = a.properties?.[key] ?? '';
+      return value === '(unset)' ? v === '' : v === value;
     });
   }
 
-  // Color for a specific app + property key (for highlighting in the panel)
-  function appSliceColor(app, key) {
-    const buckets = data?.properties?.[key];
-    if (!buckets) return '#6b7280';
-    const val = app.properties[key] ?? '';
-    const effectiveVal = val === '' ? '(unset)' : val;
-    const idx = buckets.findIndex(b => b.value === effectiveVal);
-    return colorFor(effectiveVal, idx);
+  // Show tooltip anchored to the legend row element
+  function showTooltip(e, key, slice) {
+    const apps = appsForSlice(key, slice.key);
+    const rect = e.currentTarget.getBoundingClientRect();
+    // Position to the right of the legend row, or left if near edge
+    const x = rect.right + 8;
+    const y = rect.top;
+    tooltip = { key, value: slice.key, color: slice.color, apps, x, y };
   }
 
-  function openDrill(key, value) {
-    drillKey = key;
-    drillValue = value;
-    drillOpen = true;
+  function hideTooltip() {
+    tooltip = null;
+  }
+
+  // Color for an app's value within a given property key
+  function appDotColor(app, key) {
+    const buckets = data?.properties?.[key];
+    if (!buckets) return '#6b7280';
+    const v = app.properties?.[key] ?? '';
+    const effectiveVal = v === '' ? '(unset)' : v;
+    const idx = buckets.findIndex(b => b.value === effectiveVal);
+    return colorFor(effectiveVal, idx);
   }
 
   async function load(capability) {
     loading = true;
     error = null;
     selectedApp = null;
+    tooltip = null;
     try {
       const qs = capability && capability !== 'all'
         ? '?capability=' + encodeURIComponent(capability)
@@ -120,49 +117,45 @@
   }
 </script>
 
-<!-- Drill-down modal -->
-<Dialog.Root bind:open={drillOpen}>
-  <Dialog.Portal>
-    <Dialog.Overlay />
-    <Dialog.Content class="max-w-md">
-      <Dialog.Header>
-        <Dialog.Title>{drillValue} ({drillKey ? appsForSlice(drillKey, drillValue).length : 0})</Dialog.Title>
-        <Dialog.Description>{propLabel(drillKey ?? '')} · {drillValue}</Dialog.Description>
-      </Dialog.Header>
-      <div class="mt-2 max-h-72 overflow-y-auto divide-y divide-border">
-        {#each appsForSlice(drillKey, drillValue) as app}
-          <div class="py-2.5 px-1 flex items-center gap-2 text-[13px]">
-            <span
-              class="size-2 rounded-full flex-shrink-0"
-              style="background:{appSliceColor(app, drillKey)}"
-            ></span>
-            <span class="flex-1 truncate" title={app.name}>{app.name}</span>
-            <span class="text-[11px] text-muted-foreground">{app.type.replace('Application','')}</span>
-          </div>
-        {/each}
-      </div>
-      <Dialog.Footer class="mt-4">
-        <Button variant="outline" onclick={() => drillOpen = false}>Close</Button>
-      </Dialog.Footer>
-    </Dialog.Content>
-  </Dialog.Portal>
-</Dialog.Root>
+<!-- Rich tooltip (rendered at body level via fixed position) -->
+{#if tooltip}
+  <div
+    class="fixed z-50 bg-popover border border-border rounded-lg shadow-lg p-3 w-64 pointer-events-none"
+    style="left:{Math.min(tooltip.x, window.innerWidth - 272)}px; top:{Math.min(tooltip.y, window.innerHeight - 320)}px"
+  >
+    <div class="flex items-center gap-2 mb-2 pb-2 border-b border-border">
+      <span class="size-2.5 rounded-full flex-shrink-0" style="background:{tooltip.color}"></span>
+      <span class="text-[13px] font-semibold text-foreground truncate">{tooltip.value}</span>
+      <span class="ml-auto text-[12px] text-muted-foreground">{tooltip.apps.length}</span>
+    </div>
+    <div class="space-y-1 max-h-52 overflow-y-auto">
+      {#each tooltip.apps as app}
+        <div class="flex items-center gap-2 text-[12px]">
+          <span class="size-1.5 rounded-full flex-shrink-0 bg-muted-foreground/50"></span>
+          <span class="truncate text-foreground" title={app.name}>{app.name}</span>
+        </div>
+      {/each}
+    </div>
+  </div>
+{/if}
 
-<div class="content" style="padding-left: 0; padding-right: 0;">
+<div class="content">
   {#if loading && !data}
-    <div class="flex items-center gap-2 text-muted-foreground py-6 px-8">
+    <div class="flex items-center gap-2 text-muted-foreground py-6">
       <div class="size-4 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
       Loading…
     </div>
   {:else if error}
-    <div class="mt-6 mx-8 text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2">Error: {error}</div>
+    <div class="mt-6 text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2">Error: {error}</div>
   {:else if data}
-    <!-- Top bar -->
-    <div class="flex items-center justify-between gap-4 px-6 py-4 border-b border-border flex-wrap">
+
+    <!-- Header -->
+    <div class="flex items-start justify-between gap-4 mb-6 flex-wrap">
       <div>
-        <h1 class="text-[17px] font-semibold">Application Dashboard</h1>
-        <div class="text-muted-foreground text-[12px] mt-0.5">
+        <h1 class="text-[18px] font-semibold">Application Dashboard</h1>
+        <div class="text-muted-foreground text-[13px] mt-0.5">
           Applications in scope: <span class="font-semibold text-foreground">{data.total_apps}</span>
+          {#if loading}<span class="ml-2 text-[11px]">Updating…</span>{/if}
         </div>
       </div>
 
@@ -189,77 +182,73 @@
         <p class="text-[14px] leading-relaxed">No applications found for this scope.</p>
       </div>
     {:else}
-      <div class="flex min-h-0">
+      <!-- Two-column layout: app list | donuts -->
+      <div class="flex gap-5 items-start">
 
-        <!-- Left: app list -->
-        <div class="w-52 flex-shrink-0 border-r border-border overflow-y-auto" style="max-height: calc(100vh - 140px);">
-          {#if loading}
-            <div class="flex items-center gap-2 text-muted-foreground text-[12px] px-3 py-3">
-              <div class="size-3 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
-              Updating…
-            </div>
-          {:else}
+        <!-- App list panel -->
+        <div class="flex-shrink-0 w-48 bg-card border border-border rounded-xl overflow-hidden">
+          <div class="text-[10px] font-bold tracking-[0.6px] uppercase text-muted-foreground px-3 py-2.5 border-b border-border">
+            Applications ({data.apps.length})
+          </div>
+          <div class="overflow-y-auto" style="max-height: 560px;">
             {#each data.apps as app}
               <button
-                class="w-full text-left px-3 py-2 text-[12px] flex items-center gap-2 transition-colors hover:bg-muted/50 border-b border-border/40 {selectedApp === app.id ? 'bg-primary/10 text-primary' : 'text-foreground'}"
-                onclick={() => selectedApp = selectedApp === app.id ? null : app.id}
+                class="w-full text-left px-3 py-1.5 text-[12px] flex items-center gap-2 border-b border-border/30 transition-colors hover:bg-muted/50
+                  {selectedApp === app.id ? 'bg-primary/10 text-primary font-medium' : 'text-foreground'}"
+                onclick={() => { selectedApp = selectedApp === app.id ? null : app.id; tooltip = null; }}
               >
-                <span class="truncate flex-1" title={app.name}>{app.name}</span>
+                <span class="size-1.5 rounded-full flex-shrink-0 bg-muted-foreground/40"></span>
+                <span class="truncate" title={app.name}>{app.name}</span>
               </button>
             {/each}
-          {/if}
+          </div>
         </div>
 
-        <!-- Right: donuts grid -->
-        <div class="flex-1 overflow-y-auto px-5 py-5" style="max-height: calc(100vh - 140px);">
-          {#if loading}
-            <div class="flex items-center gap-2 text-muted-foreground text-[13px] mb-4">
-              <div class="size-3 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
-              Updating…
-            </div>
-          {/if}
-
-          <div class="grid grid-cols-1 lg:grid-cols-2 gap-5">
-            {#each sortedPropKeys(data.properties) as key}
-              {@const buckets = data.properties[key]}
-              {@const slices = arcData(buckets)}
-              <div class="bg-card border border-border rounded-xl p-5">
-                <div class="text-[11px] font-bold tracking-[0.6px] uppercase text-muted-foreground mb-4">{propLabel(key)}</div>
-                <div class="flex gap-5 items-center">
-                  <!-- Donut -->
-                  <div class="size-[160px] flex-shrink-0">
-                    <ArcChart
-                      data={slices}
-                      key="key"
-                      label="label"
-                      value="value"
-                      c="color"
-                      innerRadius={0.60}
-                      padAngle={0.02}
-                      cornerRadius={2}
-                    />
-                  </div>
-                  <!-- Legend — each row is clickable for drill-down -->
-                  <div class="flex flex-col gap-1 min-w-0 flex-1">
-                    {#each slices as slice, i}
-                      {@const isHighlighted = selectedApp
-                        ? (data.apps.find(a => a.id === selectedApp)?.properties?.[key] ?? '') === (slice.key === '(unset)' ? '' : slice.key)
-                        : false}
-                      <button
-                        class="flex items-center gap-2 text-[12px] w-full text-left rounded px-1 py-0.5 transition-colors hover:bg-muted/50 {isHighlighted ? 'ring-1 ring-primary/50 bg-primary/5' : ''}"
-                        onclick={() => openDrill(key, slice.key)}
-                        title="Click to see apps"
-                      >
-                        <span class="size-2.5 rounded-full flex-shrink-0" style="background:{slice.color}"></span>
-                        <span class="text-muted-foreground truncate flex-1" title={slice.label}>{slice.label}</span>
-                        <span class="font-semibold tabular-nums text-foreground">{slice.value}</span>
-                      </button>
-                    {/each}
-                  </div>
+        <!-- Donuts grid -->
+        <div class="flex-1 grid grid-cols-1 xl:grid-cols-2 gap-4">
+          {#each sortedPropKeys(data.properties) as key}
+            {@const buckets = data.properties[key]}
+            {@const slices = arcData(buckets)}
+            <div class="bg-card border border-border rounded-xl p-4">
+              <div class="text-[11px] font-bold tracking-[0.6px] uppercase text-muted-foreground mb-3">{propLabel(key)}</div>
+              <div class="flex gap-4 items-center">
+                <!-- Donut -->
+                <div class="size-[150px] flex-shrink-0">
+                  <ArcChart
+                    data={slices}
+                    key="key"
+                    label="label"
+                    value="value"
+                    c="color"
+                    innerRadius={0.60}
+                    padAngle={0.02}
+                    cornerRadius={2}
+                  />
+                </div>
+                <!-- Legend with hover tooltip -->
+                <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+                  {#each slices as slice}
+                    {@const isHighlighted = selectedApp != null
+                      && (data.apps.find(a => a.id === selectedApp)?.properties?.[key] ?? '') === (slice.key === '(unset)' ? '' : slice.key)}
+                    <div
+                      role="button"
+                      tabindex="0"
+                      class="flex items-center gap-2 text-[12px] rounded px-1.5 py-1 cursor-default transition-colors hover:bg-muted/60
+                        {isHighlighted ? 'bg-primary/8 ring-1 ring-inset ring-primary/30' : ''}"
+                      onmouseenter={(e) => showTooltip(e, key, slice)}
+                      onmouseleave={hideTooltip}
+                      onfocus={(e) => showTooltip(e, key, slice)}
+                      onblur={hideTooltip}
+                    >
+                      <span class="size-2.5 rounded-full flex-shrink-0" style="background:{slice.color}"></span>
+                      <span class="text-muted-foreground truncate flex-1" title={slice.label}>{slice.label}</span>
+                      <span class="font-semibold tabular-nums text-foreground">{slice.value}</span>
+                    </div>
+                  {/each}
                 </div>
               </div>
-            {/each}
-          </div>
+            </div>
+          {/each}
         </div>
 
       </div>

--- a/cmd/archipulse/ui/src/routes/ApplicationDashboard.svelte
+++ b/cmd/archipulse/ui/src/routes/ApplicationDashboard.svelte
@@ -2,6 +2,8 @@
   import { onMount } from 'svelte';
   import { api } from '../lib/api.js';
   import { ArcChart } from 'layerchart';
+  import * as Dialog from '$lib/components/ui/dialog';
+  import { Button } from '$lib/components/ui/button';
 
   export let params = {};
 
@@ -11,18 +13,23 @@
   let loading = true;
   let error = null;
   let selectedCapability = 'all';
+  let selectedApp = null;   // source_id of highlighted app, or null
+
+  // Drill-down modal state
+  let drillKey = null;
+  let drillValue = null;
+  let drillOpen = false;
 
   // Human-readable labels for known property keys
   const PROP_LABELS = {
-    lifecycle_status:   'Lifecycle Status',
-    deployment_model:   'Deployment Model',
-    criticality:        'Business Criticality',
-    vendor:             'Vendor',
-    business_owner:     'Business Owner',
-    user_count:         'User Count Range',
+    lifecycle_status: 'Lifecycle Status',
+    deployment_model: 'Deployment Model',
+    criticality:      'Business Criticality',
+    vendor:           'Vendor',
+    business_owner:   'Business Owner',
+    user_count:       'User Count Range',
   };
 
-  // Preferred order for property sections
   const PROP_ORDER = [
     'lifecycle_status',
     'deployment_model',
@@ -32,10 +39,9 @@
     'user_count',
   ];
 
-  // Color palette for property values (cycles), unset always last gray
   const PALETTE = [
-    '#4ade80', '#60a5fa', '#a78bfa', '#fb923c', '#f87171',
-    '#34d399', '#f472b6', '#facc15', '#38bdf8', '#c084fc',
+    '#4ade80','#60a5fa','#a78bfa','#fb923c','#f87171',
+    '#34d399','#f472b6','#facc15','#38bdf8','#c084fc',
   ];
   const UNSET_COLOR = '#4b5563';
 
@@ -48,15 +54,13 @@
     return PROP_LABELS[key] ?? key.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
   }
 
-  // Return property sections in preferred order, unknown keys appended at end
-  function sortedProps(properties) {
+  function sortedPropKeys(properties) {
     if (!properties) return [];
     const known = PROP_ORDER.filter(k => k in properties);
-    const unknown = Object.keys(properties).filter(k => !PROP_ORDER.includes(k)).sort();
-    return [...known, ...unknown];
+    const other = Object.keys(properties).filter(k => !PROP_ORDER.includes(k)).sort();
+    return [...known, ...other];
   }
 
-  // Build arc data with color pre-assigned
   function arcData(buckets) {
     return buckets.map((b, i) => ({
       key:   b.value,
@@ -66,11 +70,40 @@
     }));
   }
 
+  // Apps that match a given property key + value
+  function appsForSlice(key, value) {
+    if (!data?.apps) return [];
+    return data.apps.filter(a => {
+      const v = a.properties[key] ?? '';
+      if (value === '(unset)') return v === '';
+      return v === value;
+    });
+  }
+
+  // Color for a specific app + property key (for highlighting in the panel)
+  function appSliceColor(app, key) {
+    const buckets = data?.properties?.[key];
+    if (!buckets) return '#6b7280';
+    const val = app.properties[key] ?? '';
+    const effectiveVal = val === '' ? '(unset)' : val;
+    const idx = buckets.findIndex(b => b.value === effectiveVal);
+    return colorFor(effectiveVal, idx);
+  }
+
+  function openDrill(key, value) {
+    drillKey = key;
+    drillValue = value;
+    drillOpen = true;
+  }
+
   async function load(capability) {
     loading = true;
     error = null;
+    selectedApp = null;
     try {
-      const qs = capability && capability !== 'all' ? `?capability=${encodeURIComponent(capability)}` : '';
+      const qs = capability && capability !== 'all'
+        ? '?capability=' + encodeURIComponent(capability)
+        : '';
       data = await api.get('/workspaces/' + wsId + '/views/application-dashboard/stats' + qs);
     } catch (e) {
       error = e.message;
@@ -87,37 +120,63 @@
   }
 </script>
 
-<div class="content">
+<!-- Drill-down modal -->
+<Dialog.Root bind:open={drillOpen}>
+  <Dialog.Portal>
+    <Dialog.Overlay />
+    <Dialog.Content class="max-w-md">
+      <Dialog.Header>
+        <Dialog.Title>{drillValue} ({drillKey ? appsForSlice(drillKey, drillValue).length : 0})</Dialog.Title>
+        <Dialog.Description>{propLabel(drillKey ?? '')} · {drillValue}</Dialog.Description>
+      </Dialog.Header>
+      <div class="mt-2 max-h-72 overflow-y-auto divide-y divide-border">
+        {#each appsForSlice(drillKey, drillValue) as app}
+          <div class="py-2.5 px-1 flex items-center gap-2 text-[13px]">
+            <span
+              class="size-2 rounded-full flex-shrink-0"
+              style="background:{appSliceColor(app, drillKey)}"
+            ></span>
+            <span class="flex-1 truncate" title={app.name}>{app.name}</span>
+            <span class="text-[11px] text-muted-foreground">{app.type.replace('Application','')}</span>
+          </div>
+        {/each}
+      </div>
+      <Dialog.Footer class="mt-4">
+        <Button variant="outline" onclick={() => drillOpen = false}>Close</Button>
+      </Dialog.Footer>
+    </Dialog.Content>
+  </Dialog.Portal>
+</Dialog.Root>
+
+<div class="content" style="padding-left: 0; padding-right: 0;">
   {#if loading && !data}
-    <div class="flex items-center gap-2 text-muted-foreground py-6">
+    <div class="flex items-center gap-2 text-muted-foreground py-6 px-8">
       <div class="size-4 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
       Loading…
     </div>
   {:else if error}
-    <div class="mt-6 text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2">Error: {error}</div>
+    <div class="mt-6 mx-8 text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2">Error: {error}</div>
   {:else if data}
-    <!-- Header -->
-    <div class="flex items-start justify-between mb-6 gap-4 flex-wrap">
+    <!-- Top bar -->
+    <div class="flex items-center justify-between gap-4 px-6 py-4 border-b border-border flex-wrap">
       <div>
-        <h1 class="text-[18px] font-semibold">Application Dashboard</h1>
-        <div class="text-muted-foreground text-[13px] mt-0.5">
+        <h1 class="text-[17px] font-semibold">Application Dashboard</h1>
+        <div class="text-muted-foreground text-[12px] mt-0.5">
           Applications in scope: <span class="font-semibold text-foreground">{data.total_apps}</span>
         </div>
       </div>
 
-      <!-- Capability filter -->
       {#if data.capabilities?.length > 0}
         <div class="flex items-center gap-2">
           <label for="cap-filter" class="text-[12px] text-muted-foreground whitespace-nowrap">Business Capability</label>
           <select
             id="cap-filter"
-            value={selectedCapability}
             onchange={onCapabilityChange}
             class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-primary min-w-[200px]"
           >
-            <option value="all">All</option>
+            <option value="all" selected={selectedCapability === 'all'}>All</option>
             {#each data.capabilities as cap}
-              <option value={cap}>{cap}</option>
+              <option value={cap} selected={selectedCapability === cap}>{cap}</option>
             {/each}
           </select>
         </div>
@@ -127,51 +186,82 @@
     {#if data.total_apps === 0}
       <div class="text-center py-16 px-6 text-muted-foreground">
         <div class="text-[40px] mb-3.5">📭</div>
-        <p class="text-[14px] leading-relaxed">No applications found for this scope.<br>Try selecting a different capability or import a model first.</p>
+        <p class="text-[14px] leading-relaxed">No applications found for this scope.</p>
       </div>
     {:else}
-      <!-- Loading overlay while refetching -->
-      {#if loading}
-        <div class="flex items-center gap-2 text-muted-foreground text-[13px] mb-4">
-          <div class="size-3 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
-          Updating…
-        </div>
-      {/if}
+      <div class="flex min-h-0">
 
-      <!-- Property donuts grid -->
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
-        {#each sortedProps(data.properties) as key}
-          {@const buckets = data.properties[key]}
-          {@const slices = arcData(buckets)}
-          <div class="bg-card border border-border rounded-xl p-5">
-            <div class="text-[11px] font-bold tracking-[0.6px] uppercase text-muted-foreground mb-4">{propLabel(key)}</div>
-            <div class="flex gap-6 items-center">
-              <!-- Donut -->
-              <div class="size-[180px] flex-shrink-0">
-                <ArcChart
-                  data={slices}
-                  key="key"
-                  label="label"
-                  value="value"
-                  c="color"
-                  innerRadius={0.62}
-                  padAngle={0.02}
-                  cornerRadius={2}
-                />
-              </div>
-              <!-- Legend -->
-              <div class="flex flex-col gap-1.5 min-w-0">
-                {#each slices as slice}
-                  <div class="flex items-center gap-2 text-[12px]">
-                    <span class="size-2.5 rounded-full flex-shrink-0" style="background:{slice.color}"></span>
-                    <span class="text-muted-foreground truncate" title={slice.label}>{slice.label}</span>
-                    <span class="font-semibold tabular-nums ml-auto pl-2">{slice.value}</span>
-                  </div>
-                {/each}
-              </div>
+        <!-- Left: app list -->
+        <div class="w-52 flex-shrink-0 border-r border-border overflow-y-auto" style="max-height: calc(100vh - 140px);">
+          {#if loading}
+            <div class="flex items-center gap-2 text-muted-foreground text-[12px] px-3 py-3">
+              <div class="size-3 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
+              Updating…
             </div>
+          {:else}
+            {#each data.apps as app}
+              <button
+                class="w-full text-left px-3 py-2 text-[12px] flex items-center gap-2 transition-colors hover:bg-muted/50 border-b border-border/40 {selectedApp === app.id ? 'bg-primary/10 text-primary' : 'text-foreground'}"
+                onclick={() => selectedApp = selectedApp === app.id ? null : app.id}
+              >
+                <span class="truncate flex-1" title={app.name}>{app.name}</span>
+              </button>
+            {/each}
+          {/if}
+        </div>
+
+        <!-- Right: donuts grid -->
+        <div class="flex-1 overflow-y-auto px-5 py-5" style="max-height: calc(100vh - 140px);">
+          {#if loading}
+            <div class="flex items-center gap-2 text-muted-foreground text-[13px] mb-4">
+              <div class="size-3 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
+              Updating…
+            </div>
+          {/if}
+
+          <div class="grid grid-cols-1 lg:grid-cols-2 gap-5">
+            {#each sortedPropKeys(data.properties) as key}
+              {@const buckets = data.properties[key]}
+              {@const slices = arcData(buckets)}
+              <div class="bg-card border border-border rounded-xl p-5">
+                <div class="text-[11px] font-bold tracking-[0.6px] uppercase text-muted-foreground mb-4">{propLabel(key)}</div>
+                <div class="flex gap-5 items-center">
+                  <!-- Donut -->
+                  <div class="size-[160px] flex-shrink-0">
+                    <ArcChart
+                      data={slices}
+                      key="key"
+                      label="label"
+                      value="value"
+                      c="color"
+                      innerRadius={0.60}
+                      padAngle={0.02}
+                      cornerRadius={2}
+                    />
+                  </div>
+                  <!-- Legend — each row is clickable for drill-down -->
+                  <div class="flex flex-col gap-1 min-w-0 flex-1">
+                    {#each slices as slice, i}
+                      {@const isHighlighted = selectedApp
+                        ? (data.apps.find(a => a.id === selectedApp)?.properties?.[key] ?? '') === (slice.key === '(unset)' ? '' : slice.key)
+                        : false}
+                      <button
+                        class="flex items-center gap-2 text-[12px] w-full text-left rounded px-1 py-0.5 transition-colors hover:bg-muted/50 {isHighlighted ? 'ring-1 ring-primary/50 bg-primary/5' : ''}"
+                        onclick={() => openDrill(key, slice.key)}
+                        title="Click to see apps"
+                      >
+                        <span class="size-2.5 rounded-full flex-shrink-0" style="background:{slice.color}"></span>
+                        <span class="text-muted-foreground truncate flex-1" title={slice.label}>{slice.label}</span>
+                        <span class="font-semibold tabular-nums text-foreground">{slice.value}</span>
+                      </button>
+                    {/each}
+                  </div>
+                </div>
+              </div>
+            {/each}
           </div>
-        {/each}
+        </div>
+
       </div>
     {/if}
   {/if}

--- a/internal/viewer/views/application_dashboard.go
+++ b/internal/viewer/views/application_dashboard.go
@@ -6,7 +6,16 @@ import (
 	"sort"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 )
+
+// AppEntry is one application in scope with its resolved model properties.
+type AppEntry struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Type       string            `json:"type"`
+	Properties map[string]string `json:"properties"`
+}
 
 // PropertyBucket is one slice of a property donut chart.
 type PropertyBucket struct {
@@ -16,52 +25,43 @@ type PropertyBucket struct {
 
 // ApplicationDashboardData is the full payload returned by the dashboard endpoint.
 type ApplicationDashboardData struct {
-	TotalApps    int                          `json:"total_apps"`
-	Capabilities []string                     `json:"capabilities"`
-	Properties   map[string][]PropertyBucket  `json:"properties"`
+	TotalApps    int                         `json:"total_apps"`
+	Capabilities []string                    `json:"capabilities"`
+	Apps         []AppEntry                  `json:"apps"`
+	Properties   map[string][]PropertyBucket `json:"properties"`
 }
 
-// appTypes are the ArchiMate element types treated as "applications" in the dashboard.
-var appTypes = []string{
-	"'ApplicationComponent'",
-	"'ApplicationService'",
-	"'ApplicationFunction'",
-	"'ApplicationCollaboration'",
-	"'ApplicationInterface'",
-}
+// appTypesSQL is the SQL IN-list for ArchiMate application element types.
+const appTypesSQL = `'ApplicationComponent','ApplicationService','ApplicationFunction','ApplicationCollaboration','ApplicationInterface'`
 
-// ApplicationDashboard returns all property distributions for Application-layer
-// elements in a workspace, optionally filtered by capability name.
+// ApplicationDashboard returns property distributions + the app list for Application-layer
+// elements, optionally scoped to apps realizing a specific capability.
 func ApplicationDashboard(db *sql.DB, workspaceID uuid.UUID, capabilityName string) (*ApplicationDashboardData, error) {
 	caps, err := listCapabilities(db, workspaceID)
 	if err != nil {
 		return nil, err
 	}
 
-	appIDs, total, err := appsInScope(db, workspaceID, capabilityName)
+	apps, err := appsInScope(db, workspaceID, capabilityName)
 	if err != nil {
 		return nil, err
 	}
 
-	props, err := propertyDistributions(db, workspaceID, appIDs, total)
-	if err != nil {
-		return nil, err
-	}
+	props := propertyDistributions(apps)
 
 	return &ApplicationDashboardData{
-		TotalApps:    total,
+		TotalApps:    len(apps),
 		Capabilities: caps,
+		Apps:         apps,
 		Properties:   props,
 	}, nil
 }
 
-// listCapabilities returns the names of all L1/L2 Capability elements in the workspace.
+// listCapabilities returns names of all Capability elements in the workspace.
 func listCapabilities(db *sql.DB, workspaceID uuid.UUID) ([]string, error) {
 	rows, err := db.Query(`
-		SELECT name
-		FROM elements
-		WHERE workspace_id = $1
-		  AND type = 'Capability'
+		SELECT name FROM elements
+		WHERE workspace_id = $1 AND type = 'Capability'
 		ORDER BY name`, workspaceID)
 	if err != nil {
 		return nil, fmt.Errorf("list capabilities: %w", err)
@@ -79,143 +79,138 @@ func listCapabilities(db *sql.DB, workspaceID uuid.UUID) ([]string, error) {
 	return out, rows.Err()
 }
 
-// appsInScope returns the UUIDs (pk) and total count of Application elements
-// in scope. When capabilityName is empty all apps are returned; otherwise only
-// apps that have a RealizationRelationship targeting that capability.
-func appsInScope(db *sql.DB, workspaceID uuid.UUID, capabilityName string) ([]uuid.UUID, int, error) {
-	typeList := "ApplicationComponent, ApplicationService, ApplicationFunction, ApplicationCollaboration, ApplicationInterface"
-
+// appsInScope returns AppEntry records with model properties for all apps in scope.
+// When capabilityName is "" or "all", all application-layer elements are returned.
+// Otherwise only apps linked to that capability via a Realization relationship
+// (supports both directions and both "Realization" / "RealizationRelationship" type names).
+func appsInScope(db *sql.DB, workspaceID uuid.UUID, capabilityName string) ([]AppEntry, error) {
 	var queryStr string
 	var args []any
 
 	if capabilityName == "" || capabilityName == "all" {
 		queryStr = fmt.Sprintf(`
-			SELECT id FROM elements
-			WHERE workspace_id = $1
-			  AND type IN (%s)`, sqlInList(appTypes))
+			SELECT source_id, name, type
+			FROM elements
+			WHERE workspace_id = $1 AND type IN (%s)
+			ORDER BY name`, appTypesSQL)
 		args = []any{workspaceID}
 	} else {
+		// AOEF stores xsi:type="Realization" (no Relationship suffix).
+		// Support both spellings and both source/target directions.
 		queryStr = fmt.Sprintf(`
-			SELECT DISTINCT e.id
+			SELECT DISTINCT e.source_id, e.name, e.type
 			FROM elements e
 			JOIN relationships r
-				ON r.source_element = e.source_id
-				AND r.workspace_id  = e.workspace_id
-				AND r.type          = 'RealizationRelationship'
+				ON  r.workspace_id = $1
+				AND r.type IN ('Realization', 'RealizationRelationship')
+				AND (r.source_element = e.source_id OR r.target_element = e.source_id)
 			JOIN elements cap
-				ON cap.source_id    = r.target_element
-				AND cap.workspace_id = e.workspace_id
-				AND cap.type        = 'Capability'
-				AND cap.name        = $2
+				ON  cap.workspace_id = $1
+				AND cap.type = 'Capability'
+				AND cap.name = $2
+				AND (cap.source_id = r.target_element OR cap.source_id = r.source_element)
 			WHERE e.workspace_id = $1
-			  AND e.type IN (%s)`, sqlInList(appTypes))
+			  AND e.type IN (%s)
+			ORDER BY e.name`, appTypesSQL)
 		args = []any{workspaceID, capabilityName}
 	}
 
-	_ = typeList // used in comment above for clarity
-
 	rows, err := db.Query(queryStr, args...)
 	if err != nil {
-		return nil, 0, fmt.Errorf("apps in scope: %w", err)
+		return nil, fmt.Errorf("apps in scope: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	var ids []uuid.UUID
+	var apps []AppEntry
+	var sourceIDs []string
 	for rows.Next() {
-		var id uuid.UUID
-		if err := rows.Scan(&id); err != nil {
-			return nil, 0, err
-		}
-		ids = append(ids, id)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, 0, err
-	}
-	return ids, len(ids), nil
-}
-
-// propertyDistributions returns, for every distinct property key found among
-// the given app IDs, a slice of (value, count) sorted by count descending.
-// Apps missing a given key are counted as "(unset)".
-func propertyDistributions(db *sql.DB, workspaceID uuid.UUID, appIDs []uuid.UUID, total int) (map[string][]PropertyBucket, error) {
-	if len(appIDs) == 0 {
-		return map[string][]PropertyBucket{}, nil
-	}
-
-	// Build $2, $3, ... placeholders for the app IDs.
-	placeholders := make([]string, len(appIDs))
-	args := make([]any, 0, 1+len(appIDs))
-	args = append(args, workspaceID)
-	for i, id := range appIDs {
-		placeholders[i] = fmt.Sprintf("$%d", i+2)
-		args = append(args, id)
-	}
-	inClause := joinStrings(placeholders, ",")
-
-	rows, err := db.Query(fmt.Sprintf(`
-		SELECT key, value, COUNT(*) AS cnt
-		FROM element_properties
-		WHERE element_id IN (%s)
-		  AND source = 'model'
-		GROUP BY key, value
-		ORDER BY key, cnt DESC`, inClause), args...)
-	if err != nil {
-		return nil, fmt.Errorf("property distributions: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	// key → value → count
-	raw := map[string]map[string]int{}
-	for rows.Next() {
-		var key, val string
-		var cnt int
-		if err := rows.Scan(&key, &val, &cnt); err != nil {
+		var a AppEntry
+		if err := rows.Scan(&a.ID, &a.Name, &a.Type); err != nil {
 			return nil, err
 		}
-		if raw[key] == nil {
-			raw[key] = map[string]int{}
-		}
-		raw[key][val] = cnt
+		a.Properties = map[string]string{}
+		apps = append(apps, a)
+		sourceIDs = append(sourceIDs, a.ID)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+	if len(apps) == 0 {
+		return []AppEntry{}, nil
+	}
+
+	// Fetch model properties for all apps in one query using ANY($2::text[]).
+	propRows, err := db.Query(`
+		SELECT e.source_id, ep.key, ep.value
+		FROM element_properties ep
+		JOIN elements e ON e.id = ep.element_id
+		WHERE e.workspace_id = $1
+		  AND ep.source = 'model'
+		  AND e.source_id = ANY($2)`,
+		workspaceID, pq.Array(sourceIDs))
+	if err != nil {
+		return nil, fmt.Errorf("app properties: %w", err)
+	}
+	defer func() { _ = propRows.Close() }()
+
+	idxMap := make(map[string]int, len(apps))
+	for i, a := range apps {
+		idxMap[a.ID] = i
+	}
+	for propRows.Next() {
+		var sourceID, key, value string
+		if err := propRows.Scan(&sourceID, &key, &value); err != nil {
+			return nil, err
+		}
+		if i, ok := idxMap[sourceID]; ok {
+			apps[i].Properties[key] = value
+		}
+	}
+	return apps, propRows.Err()
+}
+
+// propertyDistributions derives bucket counts from the in-memory app list.
+// No additional DB query needed since apps already carry their properties.
+func propertyDistributions(apps []AppEntry) map[string][]PropertyBucket {
+	if len(apps) == 0 {
+		return map[string][]PropertyBucket{}
+	}
+
+	keySet := map[string]struct{}{}
+	for _, a := range apps {
+		for k := range a.Properties {
+			keySet[k] = struct{}{}
+		}
+	}
 
 	out := map[string][]PropertyBucket{}
-	for key, valMap := range raw {
-		set := 0
-		buckets := make([]PropertyBucket, 0, len(valMap)+1)
-		for val, cnt := range valMap {
-			buckets = append(buckets, PropertyBucket{Value: val, Count: cnt})
-			set += cnt
+	for key := range keySet {
+		counts := map[string]int{}
+		for _, a := range apps {
+			v := a.Properties[key]
+			if v == "" {
+				counts["(unset)"]++
+			} else {
+				counts[v]++
+			}
 		}
-		// sort by count desc, then alpha
+		buckets := make([]PropertyBucket, 0, len(counts))
+		for val, cnt := range counts {
+			buckets = append(buckets, PropertyBucket{Value: val, Count: cnt})
+		}
 		sort.Slice(buckets, func(i, j int) bool {
+			if buckets[i].Value == "(unset)" {
+				return false
+			}
+			if buckets[j].Value == "(unset)" {
+				return true
+			}
 			if buckets[i].Count != buckets[j].Count {
 				return buckets[i].Count > buckets[j].Count
 			}
 			return buckets[i].Value < buckets[j].Value
 		})
-		unset := total - set
-		if unset > 0 {
-			buckets = append(buckets, PropertyBucket{Value: "(unset)", Count: unset})
-		}
 		out[key] = buckets
 	}
-	return out, nil
-}
-
-func sqlInList(items []string) string {
-	return joinStrings(items, ", ")
-}
-
-func joinStrings(s []string, sep string) string {
-	result := ""
-	for i, v := range s {
-		if i > 0 {
-			result += sep
-		}
-		result += v
-	}
-	return result
+	return out
 }


### PR DESCRIPTION
## Summary

- **Fix capability filter** — AOEF stores `xsi:type="Realization"` without the `Relationship` suffix; the old query searched for `RealizationRelationship` which never matched. Now supports both spellings and both relationship directions (app→cap or cap→app)
- **App list panel** — left sidebar listing all apps in scope, updates when capability filter changes; clicking an app highlights its slice across all donuts
- **Slice drill-down** — clicking a legend row in any donut opens a Dialog listing every app with that property value (e.g. "Not Set (2)" → Oracle Planning and Budgeting Cloud, Microsoft O365)
- **Backend simplification** — `propertyDistributions` is now in-memory (apps carry their properties in the response); eliminates a second DB round-trip and the previous `$1` type-inference bug from PR #9

## Replaces
Supersedes PR #9 (fix/dashboard-property-query) — includes that fix plus the three UX improvements.

## Test plan
- [ ] Import `examples/archisurance-extended.xml`
- [ ] Open Application Dashboard — all 6 property donuts render
- [ ] Select a capability from dropdown — app list and donuts update
- [ ] Click a donut legend row — modal opens with correct app list
- [ ] Click an app in the left panel — corresponding slices highlight