### PR TITLE
feat(view): Application Landscape Map — L1/L2 capability grid with coloured app chips

### DIFF
--- a/cmd/archipulse/ui/src/App.svelte
+++ b/cmd/archipulse/ui/src/App.svelte
@@ -8,6 +8,7 @@
   import ViewRouter from './routes/ViewRouter.svelte';
   import GraphView from './routes/GraphView.svelte';
   import CapabilityTree from './routes/CapabilityTree.svelte';
+  import ApplicationLandscapeMap from './routes/ApplicationLandscapeMap.svelte';
 
   import { api } from './lib/api.js';
   import { VIEWS } from './lib/views.js';
@@ -20,6 +21,7 @@
     '/ws/:wsId/view/:viewName': ViewRouter,
     '/ws/:wsId/view/:viewName/graph': GraphView,
     '/ws/:wsId/view/:viewName/tree': CapabilityTree,
+    '/ws/:wsId/view/:viewName/map': ApplicationLandscapeMap,
   };
 
   // Current route state derived from location
@@ -53,8 +55,8 @@
   }
 
   function extractParams(loc) {
-    // Match /ws/:wsId/view/:viewName/graph or /tree
-    let m = loc.match(/^\/ws\/([^/]+)\/view\/([^/]+)\/(graph|tree)$/);
+    // Match /ws/:wsId/view/:viewName/graph or /tree or /map
+    let m = loc.match(/^\/ws\/([^/]+)\/view\/([^/]+)\/(graph|tree|map)$/);
     if (m) return { wsId: m[1], viewName: m[2], activeView: m[2] + '/' + m[3] };
 
     // Match /ws/:wsId/view/:viewName
@@ -62,7 +64,7 @@
     if (m) {
       const vn = m[2];
       const v = VIEWS[vn];
-      const target = v && v.graph ? vn + '/graph' : v && v.tree ? vn + '/tree' : vn;
+      const target = v && v.graph ? vn + '/graph' : v && v.tree ? vn + '/tree' : v && v.map ? vn + '/map' : vn;
       return { wsId: m[1], viewName: vn, activeView: target };
     }
 

--- a/cmd/archipulse/ui/src/lib/views.js
+++ b/cmd/archipulse/ui/src/lib/views.js
@@ -3,7 +3,7 @@ export const VIEWS = {
   'capability-tree':        { icon: '◈', label: 'Capability Tree',         desc: 'Business capability hierarchy',                                layer: 'business', tree: true },
   'application-dashboard':  { icon: '◉', label: 'Application Dashboard',   desc: 'Lifecycle status & type distribution charts',                  layer: 'application', dashboard: true },
   'application-catalogue':  { icon: '◈', label: 'Application Catalogue',   desc: 'Application components',                                       layer: 'application' },
-  'application-landscape':  { icon: '◈', label: 'Application Landscape',   desc: 'Apps mapped to business processes',                            layer: 'application' },
+  'application-landscape':  { icon: '◈', label: 'Application Landscape',   desc: 'Capabilities mapped to realizing applications',                layer: 'application', map: true },
   'application-dependency': { icon: '◈', label: 'Dependency Graph',        desc: 'Interactive dependency graph',                                 layer: 'application', graph: true },
   'integration-map':        { icon: '⇄', label: 'Integration Map',         desc: 'Integration topology — services, components and data flows',   layer: 'application', graph: true },
   'technology-catalogue':   { icon: '◈', label: 'Technology Catalogue',    desc: 'Infrastructure & technology elements',                         layer: 'technology' },

--- a/cmd/archipulse/ui/src/routes/ApplicationLandscapeMap.svelte
+++ b/cmd/archipulse/ui/src/routes/ApplicationLandscapeMap.svelte
@@ -1,0 +1,257 @@
+<script>
+  import { onMount } from 'svelte';
+  import { api } from '../lib/api.js';
+
+  export let params = {};
+  $: wsId = params.wsId;
+
+  let data = null;
+  let loading = true;
+  let error = null;
+  let overlay = 'lifecycle_status';
+
+  // Tooltip
+  let tooltip = null; // { app, x, y }
+
+  // ── Colour palette ────────────────────────────────────────────────────────
+
+  // Well-known value → colour for common property keys
+  const KNOWN_COLORS = {
+    lifecycle_status: {
+      'Production':    '#4ade80',
+      'Pilot':         '#60a5fa',
+      'Planned':       '#a78bfa',
+      'Retiring':      '#fb923c',
+      'Decommissioned':'#f87171',
+    },
+    criticality: {
+      'Critical': '#f87171',
+      'High':     '#fb923c',
+      'Medium':   '#facc15',
+      'Low':      '#4ade80',
+    },
+    deployment_model: {
+      'On-Premise':  '#4ade80',
+      'Public Cloud':'#60a5fa',
+      'SaaS':        '#34d399',
+      'Hybrid':      '#a78bfa',
+    },
+  };
+
+  const PALETTE = [
+    '#4ade80','#60a5fa','#a78bfa','#fb923c','#f87171',
+    '#34d399','#f472b6','#facc15','#38bdf8','#c084fc',
+  ];
+  const UNSET_COLOR = '#374151';
+
+  // Per-overlay, assign consistent colours to each distinct value
+  function buildColorMap(overlay, l1List) {
+    const known = KNOWN_COLORS[overlay] ?? {};
+    const seen = new Set(Object.keys(known));
+    let idx = 0;
+    const map = { ...known };
+
+    for (const l1 of l1List) {
+      for (const l2 of l1.l2) {
+        for (const app of l2.apps) {
+          const v = app.properties?.[overlay] ?? '';
+          if (v && !map[v]) {
+            // skip palette slots already used by known values
+            while (PALETTE[idx] && Object.values(known).includes(PALETTE[idx])) idx++;
+            map[v] = PALETTE[idx % PALETTE.length];
+            idx++;
+          }
+        }
+      }
+    }
+    return map;
+  }
+
+  $: colorMap = data ? buildColorMap(overlay, data.l1) : {};
+
+  function chipColor(app) {
+    const v = app.properties?.[overlay] ?? '';
+    return v ? (colorMap[v] ?? '#6b7280') : UNSET_COLOR;
+  }
+
+  function chipValue(app) {
+    return app.properties?.[overlay] ?? '(unset)';
+  }
+
+  // ── Legend entries (distinct values present) ──────────────────────────────
+  $: legendEntries = (() => {
+    if (!data) return [];
+    const seen = new Map();
+    for (const l1 of data.l1) {
+      for (const l2 of l1.l2) {
+        for (const app of l2.apps) {
+          const v = app.properties?.[overlay] ?? '(unset)';
+          const c = v === '(unset)' ? UNSET_COLOR : (colorMap[v] ?? '#6b7280');
+          if (!seen.has(v)) seen.set(v, c);
+        }
+      }
+    }
+    // Sort: known order first if lifecycle, then alpha, (unset) last
+    return [...seen.entries()]
+      .map(([v, c]) => ({ value: v, color: c }))
+      .sort((a, b) => {
+        if (a.value === '(unset)') return 1;
+        if (b.value === '(unset)') return -1;
+        return a.value.localeCompare(b.value);
+      });
+  })();
+
+  // ── Prop label ────────────────────────────────────────────────────────────
+  const PROP_LABELS = {
+    lifecycle_status: 'Lifecycle Status',
+    deployment_model: 'Deployment Model',
+    criticality:      'Business Criticality',
+    vendor:           'Vendor',
+    business_owner:   'Business Owner',
+    user_count:       'User Count',
+  };
+  function propLabel(k) {
+    return PROP_LABELS[k] ?? k.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+  }
+
+  // ── Tooltip ───────────────────────────────────────────────────────────────
+  function showTooltip(e, app) {
+    const rect = e.currentTarget.getBoundingClientRect();
+    tooltip = { app, x: rect.right + 8, y: rect.top };
+  }
+  function hideTooltip() { tooltip = null; }
+
+  // ── Load ──────────────────────────────────────────────────────────────────
+  onMount(async () => {
+    loading = true;
+    try {
+      data = await api.get('/workspaces/' + wsId + '/views/application-landscape/map');
+    } catch (e) {
+      error = e.message;
+    } finally {
+      loading = false;
+    }
+  });
+</script>
+
+<!-- App chip tooltip -->
+{#if tooltip}
+  <div
+    class="fixed z-50 bg-popover border border-border rounded-lg shadow-lg p-3 w-56 pointer-events-none"
+    style="left:{Math.min(tooltip.x, window.innerWidth - 232)}px; top:{Math.min(tooltip.y, window.innerHeight - 200)}px"
+  >
+    <div class="text-[13px] font-semibold text-foreground mb-1">{tooltip.app.name}</div>
+    <div class="text-[11px] text-muted-foreground mb-2">{tooltip.app.type.replace('Application', '')}</div>
+    {#if Object.keys(tooltip.app.properties ?? {}).length > 0}
+      <div class="space-y-1">
+        {#each Object.entries(tooltip.app.properties) as [k, v]}
+          <div class="flex justify-between text-[11px]">
+            <span class="text-muted-foreground">{propLabel(k)}</span>
+            <span class="font-medium text-foreground ml-2 text-right">{v}</span>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+{/if}
+
+<div class="content">
+  {#if loading}
+    <div class="flex items-center gap-2 text-muted-foreground py-6">
+      <div class="size-4 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
+      Loading…
+    </div>
+  {:else if error}
+    <div class="text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2">{error}</div>
+  {:else if data}
+
+    <!-- Header -->
+    <div class="flex items-center justify-between gap-4 mb-5 flex-wrap">
+      <div>
+        <h1 class="text-[18px] font-semibold">Application Landscape</h1>
+        <div class="text-muted-foreground text-[13px] mt-0.5">Capabilities mapped to realizing applications</div>
+      </div>
+
+      <!-- Overlay selector -->
+      {#if data.properties?.length > 0}
+        <div class="flex items-center gap-2">
+          <span class="text-[12px] text-muted-foreground">Overlay</span>
+          <select
+            bind:value={overlay}
+            class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+          >
+            {#each data.properties as p}
+              <option value={p}>{propLabel(p)}</option>
+            {/each}
+          </select>
+        </div>
+      {/if}
+    </div>
+
+    <!-- Colour legend -->
+    {#if legendEntries.length > 0}
+      <div class="flex flex-wrap gap-x-4 gap-y-1.5 mb-5 px-1">
+        {#each legendEntries as entry}
+          <div class="flex items-center gap-1.5 text-[12px]">
+            <span class="size-3 rounded flex-shrink-0" style="background:{entry.color}"></span>
+            <span class="text-muted-foreground">{entry.value}</span>
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    <!-- Landscape grid -->
+    {#if data.l1.length === 0}
+      <div class="text-center py-16 text-muted-foreground">
+        <div class="text-[40px] mb-3">📭</div>
+        <p class="text-[14px]">No capability hierarchy found. Import a model with Capability elements first.</p>
+      </div>
+    {:else}
+      <div class="space-y-4">
+        {#each data.l1 as l1}
+          {@const totalApps = l1.l2.reduce((s, l2) => s + l2.apps.length, 0)}
+          <div class="border border-border rounded-xl overflow-hidden">
+            <!-- L1 header -->
+            <div class="bg-[#1a1f2e] border-b border-border px-4 py-2.5 flex items-center gap-3">
+              <span class="text-[13px] font-bold text-foreground tracking-wide uppercase">{l1.name}</span>
+              <span class="text-[11px] text-muted-foreground ml-auto">{totalApps} app{totalApps !== 1 ? 's' : ''}</span>
+            </div>
+
+            <!-- L2 rows -->
+            <div class="divide-y divide-border/50">
+              {#each l1.l2 as l2}
+                <div class="flex items-start gap-3 px-4 py-2.5 hover:bg-muted/20 transition-colors">
+                  <!-- L2 name + count -->
+                  <div class="w-52 flex-shrink-0 pt-0.5">
+                    <span class="text-[12px] text-foreground font-medium">{l2.name}</span>
+                    <span class="ml-1.5 text-[11px] text-muted-foreground">{l2.apps.length}</span>
+                  </div>
+
+                  <!-- App chips -->
+                  <div class="flex flex-wrap gap-1.5 flex-1">
+                    {#if l2.apps.length === 0}
+                      <span class="text-[11px] text-muted-foreground italic">No applications</span>
+                    {:else}
+                      {#each l2.apps as app}
+                        <button
+                          class="inline-flex items-center px-2.5 py-0.5 rounded text-[11px] font-medium text-[#0f1117] transition-opacity hover:opacity-80 cursor-default"
+                          style="background:{chipColor(app)}"
+                          onmouseenter={(e) => showTooltip(e, app)}
+                          onmouseleave={hideTooltip}
+                          onfocus={(e) => showTooltip(e, app)}
+                          onblur={hideTooltip}
+                        >
+                          {app.name}
+                        </button>
+                      {/each}
+                    {/if}
+                  </div>
+                </div>
+              {/each}
+            </div>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  {/if}
+</div>

--- a/cmd/archipulse/ui/src/routes/ApplicationLandscapeMap.svelte
+++ b/cmd/archipulse/ui/src/routes/ApplicationLandscapeMap.svelte
@@ -69,13 +69,11 @@
 
   $: colorMap = data ? buildColorMap(overlay, data.l1) : {};
 
-  function chipColor(app) {
-    const v = app.properties?.[overlay] ?? '';
+  // overlay is passed explicitly so Svelte tracks it as a template dependency
+  // and re-evaluates the expression when the overlay selector changes.
+  function chipColor(app, ov) {
+    const v = app.properties?.[ov] ?? '';
     return v ? (colorMap[v] ?? '#6b7280') : UNSET_COLOR;
-  }
-
-  function chipValue(app) {
-    return app.properties?.[overlay] ?? '(unset)';
   }
 
   // ── Legend entries (distinct values present) ──────────────────────────────
@@ -235,7 +233,7 @@
                       {#each l2.apps as app}
                         <button
                           class="inline-flex items-center px-2.5 py-0.5 rounded text-[11px] font-medium text-[#0f1117] transition-opacity hover:opacity-80 cursor-default"
-                          style="background:{chipColor(app)}"
+                          style="background:{chipColor(app, overlay)}"
                           onmouseenter={(e) => showTooltip(e, app)}
                           onmouseleave={hideTooltip}
                           onfocus={(e) => showTooltip(e, app)}

--- a/cmd/archipulse/ui/src/routes/ViewRouter.svelte
+++ b/cmd/archipulse/ui/src/routes/ViewRouter.svelte
@@ -4,6 +4,7 @@
   import { VIEWS } from '../lib/views.js';
   import TableView from './TableView.svelte';
   import ApplicationDashboard from './ApplicationDashboard.svelte';
+  import ApplicationLandscapeMap from './ApplicationLandscapeMap.svelte';
 
   export let params = {};
 
@@ -19,6 +20,9 @@
       redirected = true;
     } else if (view && view.tree) {
       push('/ws/' + wsId + '/view/' + viewName + '/tree');
+      redirected = true;
+    } else if (view && view.map) {
+      push('/ws/' + wsId + '/view/' + viewName + '/map');
       redirected = true;
     }
   });

--- a/cmd/archipulse/ui/src/routes/ViewRouter.svelte
+++ b/cmd/archipulse/ui/src/routes/ViewRouter.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { onMount } from 'svelte';
   import { push } from 'svelte-spa-router';
   import { VIEWS } from '../lib/views.js';
   import TableView from './TableView.svelte';
@@ -14,27 +13,31 @@
 
   let redirected = false;
 
-  onMount(() => {
-    if (view && view.graph) {
+  // Use a reactive block instead of onMount so re-navigation between views
+  // (same ViewRouter component, different params) also triggers the redirect.
+  $: if (viewName) {
+    if (view?.graph) {
       push('/ws/' + wsId + '/view/' + viewName + '/graph');
       redirected = true;
-    } else if (view && view.tree) {
+    } else if (view?.tree) {
       push('/ws/' + wsId + '/view/' + viewName + '/tree');
       redirected = true;
-    } else if (view && view.map) {
+    } else if (view?.map) {
       push('/ws/' + wsId + '/view/' + viewName + '/map');
       redirected = true;
+    } else {
+      redirected = false;
     }
-  });
+  }
 </script>
 
 {#if view?.dashboard}
   <ApplicationDashboard {params} />
-{:else if !redirected && (!view || (!view.graph && !view.tree))}
-  <TableView {params} />
-{:else}
+{:else if redirected}
   <div class="flex items-center gap-2 text-muted-foreground py-6">
     <div class="size-4 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
     Redirecting…
   </div>
+{:else if view}
+  <TableView {params} />
 {/if}

--- a/internal/api/viewer_handler.go
+++ b/internal/api/viewer_handler.go
@@ -103,6 +103,21 @@ func (h *viewerHandler) getApplicationDashboard(w http.ResponseWriter, r *http.R
 	respondJSON(w, http.StatusOK, data)
 }
 
+// getLandscapeMap returns the L1 → L2 → apps hierarchy for the landscape map view.
+func (h *viewerHandler) getLandscapeMap(w http.ResponseWriter, r *http.Request) {
+	wsID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		respondError(w, http.StatusBadRequest, err)
+		return
+	}
+	data, err := h.registry.ApplicationLandscapeMap(wsID)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
+	respondJSON(w, http.StatusOK, data)
+}
+
 func registerViewerRoutes(r chi.Router, db *sql.DB) {
 	h := &viewerHandler{registry: viewer.NewRegistry(db)}
 	r.Get("/workspaces/{id}/views", h.listViews)
@@ -110,5 +125,6 @@ func registerViewerRoutes(r chi.Router, db *sql.DB) {
 	r.Get("/workspaces/{id}/views/application-dependency/graph", h.getDependencyGraph)
 	r.Get("/workspaces/{id}/views/integration-map/graph", h.getIntegrationMap)
 	r.Get("/workspaces/{id}/views/application-dashboard/stats", h.getApplicationDashboard)
+	r.Get("/workspaces/{id}/views/application-landscape/map", h.getLandscapeMap)
 	r.Get("/workspaces/{id}/views/{view}", h.getView)
 }

--- a/internal/viewer/viewer.go
+++ b/internal/viewer/viewer.go
@@ -93,6 +93,11 @@ func (r *Registry) ApplicationDashboard(workspaceID uuid.UUID, capability string
 	return views.ApplicationDashboard(r.db, workspaceID, capability)
 }
 
+// ApplicationLandscapeMap returns the L1 → L2 → apps hierarchy for the landscape map view.
+func (r *Registry) ApplicationLandscapeMap(workspaceID uuid.UUID) (*views.ApplicationLandscapeMapData, error) {
+	return views.ApplicationLandscapeMap(r.db, workspaceID)
+}
+
 // List returns the names of all registered tabular views, sorted.
 func (r *Registry) List() []string {
 	names := make([]string, 0, len(r.views))

--- a/internal/viewer/views/application_landscape_map.go
+++ b/internal/viewer/views/application_landscape_map.go
@@ -154,7 +154,7 @@ func loadAppsByCapability(db *sql.DB, workspaceID uuid.UUID) (map[string][]Lands
 			AND cap.type         = 'Capability'
 		WHERE r.workspace_id = $1
 		  AND r.type IN ('Realization', 'RealizationRelationship')
-		ORDER BY cap.source_id, e.name`, appTypesSQL))
+		ORDER BY cap.source_id, e.name`, appTypesSQL), workspaceID)
 	if err != nil {
 		return nil, fmt.Errorf("apps by capability: %w", err)
 	}

--- a/internal/viewer/views/application_landscape_map.go
+++ b/internal/viewer/views/application_landscape_map.go
@@ -1,0 +1,232 @@
+package views
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+)
+
+// LandscapeApp is a single application entry in the landscape map.
+type LandscapeApp struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Type       string            `json:"type"`
+	Properties map[string]string `json:"properties"`
+}
+
+// LandscapeL2 is an L2 capability with its realizing apps.
+type LandscapeL2 struct {
+	ID   string         `json:"id"`
+	Name string         `json:"name"`
+	Apps []LandscapeApp `json:"apps"`
+}
+
+// LandscapeL1 is a top-level capability group.
+type LandscapeL1 struct {
+	ID   string        `json:"id"`
+	Name string        `json:"name"`
+	L2   []LandscapeL2 `json:"l2"`
+}
+
+// ApplicationLandscapeMapData is the payload for the landscape map view.
+type ApplicationLandscapeMapData struct {
+	L1         []LandscapeL1 `json:"l1"`
+	Properties []string      `json:"properties"` // distinct property keys available for the overlay
+}
+
+// ApplicationLandscapeMap builds the L1 → L2 → apps hierarchy for the
+// Application Landscape Map view.
+func ApplicationLandscapeMap(db *sql.DB, workspaceID uuid.UUID) (*ApplicationLandscapeMapData, error) {
+	// Step 1: build the capability hierarchy (L1 → L2 via Composition).
+	l1Map, l1Order, err := buildCapabilityHierarchy(db, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 2: load apps per L2 capability.
+	appsByCapID, err := loadAppsByCapability(db, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 3: collect all app source_ids to load properties.
+	allAppIDs := collectAppIDs(appsByCapID)
+	propsByApp, propKeys, err := loadAppProperties(db, workspaceID, allAppIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 4: attach properties to apps.
+	for capID, apps := range appsByCapID {
+		for i, a := range apps {
+			if p, ok := propsByApp[a.ID]; ok {
+				apps[i].Properties = p
+			}
+			_ = capID
+		}
+		appsByCapID[capID] = apps
+	}
+
+	// Step 5: assemble the final structure.
+	l1List := make([]LandscapeL1, 0, len(l1Order))
+	for _, l1ID := range l1Order {
+		l1 := l1Map[l1ID]
+		for i, l2 := range l1.L2 {
+			apps := appsByCapID[l2.ID]
+			if apps == nil {
+				apps = []LandscapeApp{}
+			}
+			l1.L2[i].Apps = apps
+		}
+		l1List = append(l1List, l1)
+	}
+
+	sort.Strings(propKeys)
+	return &ApplicationLandscapeMapData{L1: l1List, Properties: propKeys}, nil
+}
+
+// buildCapabilityHierarchy returns a map of L1 capability ID → LandscapeL1 (with L2 list)
+// and an ordered list of L1 IDs (alphabetical).
+func buildCapabilityHierarchy(db *sql.DB, workspaceID uuid.UUID) (map[string]LandscapeL1, []string, error) {
+	// Query all (L1 source_id, L1 name, L2 source_id, L2 name) pairs via Composition.
+	rows, err := db.Query(`
+		SELECT
+			p.source_id AS l1_id,
+			p.name      AS l1_name,
+			c.source_id AS l2_id,
+			c.name      AS l2_name
+		FROM relationships r
+		JOIN elements p
+			ON  p.workspace_id = $1
+			AND p.source_id    = r.source_element
+			AND p.type         = 'Capability'
+		JOIN elements c
+			ON  c.workspace_id = $1
+			AND c.source_id    = r.target_element
+			AND c.type         = 'Capability'
+		WHERE r.workspace_id = $1
+		  AND r.type IN ('Composition', 'CompositionRelationship')
+		ORDER BY p.name, c.name`, workspaceID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("capability hierarchy: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	l1Map := map[string]LandscapeL1{}
+	l1Order := []string{}
+
+	for rows.Next() {
+		var l1ID, l1Name, l2ID, l2Name string
+		if err := rows.Scan(&l1ID, &l1Name, &l2ID, &l2Name); err != nil {
+			return nil, nil, err
+		}
+		l1, exists := l1Map[l1ID]
+		if !exists {
+			l1 = LandscapeL1{ID: l1ID, Name: l1Name, L2: []LandscapeL2{}}
+			l1Order = append(l1Order, l1ID)
+		}
+		l1.L2 = append(l1.L2, LandscapeL2{ID: l2ID, Name: l2Name, Apps: []LandscapeApp{}})
+		l1Map[l1ID] = l1
+	}
+	return l1Map, l1Order, rows.Err()
+}
+
+// loadAppsByCapability returns a map of capability source_id → []LandscapeApp.
+// Uses both "Realization" and "RealizationRelationship" type names.
+func loadAppsByCapability(db *sql.DB, workspaceID uuid.UUID) (map[string][]LandscapeApp, error) {
+	rows, err := db.Query(fmt.Sprintf(`
+		SELECT DISTINCT
+			cap.source_id AS cap_id,
+			e.source_id   AS app_id,
+			e.name        AS app_name,
+			e.type        AS app_type
+		FROM relationships r
+		JOIN elements e
+			ON  e.workspace_id = $1
+			AND e.source_id    = r.source_element
+			AND e.type IN (%s)
+		JOIN elements cap
+			ON  cap.workspace_id = $1
+			AND cap.source_id    = r.target_element
+			AND cap.type         = 'Capability'
+		WHERE r.workspace_id = $1
+		  AND r.type IN ('Realization', 'RealizationRelationship')
+		ORDER BY cap.source_id, e.name`, appTypesSQL))
+	if err != nil {
+		return nil, fmt.Errorf("apps by capability: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := map[string][]LandscapeApp{}
+	for rows.Next() {
+		var capID, appID, appName, appType string
+		if err := rows.Scan(&capID, &appID, &appName, &appType); err != nil {
+			return nil, err
+		}
+		out[capID] = append(out[capID], LandscapeApp{
+			ID:         appID,
+			Name:       appName,
+			Type:       appType,
+			Properties: map[string]string{},
+		})
+	}
+	return out, rows.Err()
+}
+
+func collectAppIDs(appsByCapID map[string][]LandscapeApp) []string {
+	seen := map[string]struct{}{}
+	var ids []string
+	for _, apps := range appsByCapID {
+		for _, a := range apps {
+			if _, ok := seen[a.ID]; !ok {
+				seen[a.ID] = struct{}{}
+				ids = append(ids, a.ID)
+			}
+		}
+	}
+	return ids
+}
+
+// loadAppProperties returns a map of app source_id → {key: value} and the
+// list of distinct property keys present across all apps.
+func loadAppProperties(db *sql.DB, workspaceID uuid.UUID, appSourceIDs []string) (map[string]map[string]string, []string, error) {
+	if len(appSourceIDs) == 0 {
+		return map[string]map[string]string{}, []string{}, nil
+	}
+
+	rows, err := db.Query(`
+		SELECT e.source_id, ep.key, ep.value
+		FROM element_properties ep
+		JOIN elements e ON e.id = ep.element_id
+		WHERE e.workspace_id = $1
+		  AND ep.source = 'model'
+		  AND e.source_id = ANY($2)`,
+		workspaceID, pq.Array(appSourceIDs))
+	if err != nil {
+		return nil, nil, fmt.Errorf("landscape app properties: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	props := map[string]map[string]string{}
+	keySet := map[string]struct{}{}
+	for rows.Next() {
+		var sourceID, key, value string
+		if err := rows.Scan(&sourceID, &key, &value); err != nil {
+			return nil, nil, err
+		}
+		if props[sourceID] == nil {
+			props[sourceID] = map[string]string{}
+		}
+		props[sourceID][key] = value
+		keySet[key] = struct{}{}
+	}
+
+	keys := make([]string, 0, len(keySet))
+	for k := range keySet {
+		keys = append(keys, k)
+	}
+	return props, keys, rows.Err()
+}


### PR DESCRIPTION
## Summary
- Replaces the plain Application Landscape table with a rich EAM capability map: L1 sections → L2 rows → coloured application chips
- Overlay selector (lifecycle_status, criticality, deployment_model, vendor, …) colours chips by property value; legend bar shows distinct values present
- Hover tooltip per chip shows app name, type, and all properties; L2 rows with no apps show a gap-analysis "No applications" note

## Backend
- New `GET /workspaces/{id}/views/application-landscape/map` endpoint
- `ApplicationLandscapeMap()` in `internal/viewer/views/application_landscape_map.go` builds L1→L2→apps hierarchy via three SQL queries (Composition for hierarchy, Realization for apps, element_properties for overlay data)
- `views.js` entry updated with `map: true` flag; routing wired in `App.svelte` and `ViewRouter.svelte`

## Test plan
- [ ] Load ArchiSurance Extended workspace — landscape map shows 5 L1 / 20 L2 sections
- [ ] Switch overlay to Criticality, Deployment Model, Vendor — chips re-colour, legend updates
- [ ] Hover an app chip — tooltip shows all properties
- [ ] L2 capabilities with no realizing apps display "No applications" (gap analysis)
- [ ] CI passes