### PR TITLE
feat(view): rich Application & Technology Catalogue views

### DIFF
--- a/cmd/archipulse/ui/src/lib/views.js
+++ b/cmd/archipulse/ui/src/lib/views.js
@@ -2,11 +2,11 @@ export const VIEWS = {
   'element-catalogue':      { icon: '◈', label: 'Element Catalogue',      desc: 'All elements across layers',                                   layer: 'cross' },
   'capability-tree':        { icon: '◈', label: 'Capability Tree',         desc: 'Business capability hierarchy',                                layer: 'business', tree: true },
   'application-dashboard':  { icon: '◉', label: 'Application Dashboard',   desc: 'Lifecycle status & type distribution charts',                  layer: 'application', dashboard: true },
-  'application-catalogue':  { icon: '◈', label: 'Application Catalogue',   desc: 'Application components',                                       layer: 'application' },
   'application-landscape':  { icon: '◈', label: 'Application Landscape',   desc: 'Capabilities mapped to realizing applications',                layer: 'application', map: true },
   'application-dependency': { icon: '◈', label: 'Dependency Graph',        desc: 'Interactive dependency graph',                                 layer: 'application', graph: true },
   'integration-map':        { icon: '⇄', label: 'Integration Map',         desc: 'Integration topology — services, components and data flows',   layer: 'application', graph: true },
-  'technology-catalogue':   { icon: '◈', label: 'Technology Catalogue',    desc: 'Infrastructure & technology elements',                         layer: 'technology' },
+  'application-catalogue':  { icon: '◈', label: 'Application Catalogue',   desc: 'Application components with properties',                       layer: 'catalogue', catalogue: 'application' },
+  'technology-catalogue':   { icon: '◈', label: 'Technology Catalogue',    desc: 'Infrastructure & technology elements',                         layer: 'catalogue', catalogue: 'technology' },
 };
 
 export const LAYER_GROUPS = [
@@ -14,4 +14,5 @@ export const LAYER_GROUPS = [
   { key: 'business',    label: 'Business',      dot: 'dot-biz'   },
   { key: 'application', label: 'Application',   dot: 'dot-app'   },
   { key: 'technology',  label: 'Technology',    dot: 'dot-tech'  },
+  { key: 'catalogue',   label: 'Catalogues',    dot: 'dot-cross' },
 ];

--- a/cmd/archipulse/ui/src/routes/ApplicationCatalogueView.svelte
+++ b/cmd/archipulse/ui/src/routes/ApplicationCatalogueView.svelte
@@ -1,0 +1,276 @@
+<script>
+  import { onMount } from 'svelte';
+  import { api } from '../lib/api.js';
+
+  export let params = {};
+  $: wsId = params.wsId;
+
+  let entries = [];
+  let propertyKeys = [];
+  let loading = true;
+  let error = null;
+
+  // ── Search & sort ──────────────────────────────────────────────────────────
+  let search = '';
+  let sortCol = 'name';   // 'name' | 'type' | any propKey
+  let sortDir = 'asc';    // 'asc' | 'desc'
+
+  // ── Column visibility ──────────────────────────────────────────────────────
+  // Fixed columns always visible; property columns togglable.
+  const FIXED_COLS = ['name', 'type'];
+  // These property keys are shown by default when present.
+  const DEFAULT_PROP_COLS = ['vendor', 'lifecycle_status', 'criticality', 'deployment_model', 'business_owner', 'user_count'];
+
+  let visibleProps = new Set();
+  let colMenuOpen = false;
+
+  const PROP_LABELS = {
+    lifecycle_status: 'Lifecycle Status',
+    deployment_model: 'Deployment Model',
+    criticality:      'Criticality',
+    vendor:           'Vendor',
+    business_owner:   'Business Owner',
+    user_count:       'User Count',
+  };
+  function propLabel(k) {
+    return PROP_LABELS[k] ?? k.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+  }
+
+  const LIFECYCLE_COLORS = {
+    'Production':    'bg-[#14301e] text-[#4ade80]',
+    'Pilot':         'bg-[#1e2f55] text-[#60a5fa]',
+    'Planned':       'bg-[#2a1f4a] text-[#a78bfa]',
+    'Retiring':      'bg-[#3a2010] text-[#fb923c]',
+    'Decommissioned':'bg-[#3a1010] text-[#f87171]',
+  };
+  const CRIT_COLORS = {
+    'Critical': 'bg-[#3a1010] text-[#f87171]',
+    'High':     'bg-[#3a2010] text-[#fb923c]',
+    'Medium':   'bg-[#3a3010] text-[#facc15]',
+    'Low':      'bg-[#14301e] text-[#4ade80]',
+  };
+  const DEPLOY_COLORS = {
+    'On-Premise':   'bg-[#1a2a1a] text-[#4ade80]',
+    'Public Cloud': 'bg-[#1e2f55] text-[#60a5fa]',
+    'SaaS':         'bg-[#14302a] text-[#34d399]',
+    'Hybrid':       'bg-[#2a1f4a] text-[#a78bfa]',
+  };
+
+  function badgeClass(key, val) {
+    if (key === 'lifecycle_status') return LIFECYCLE_COLORS[val] ?? 'bg-muted text-muted-foreground';
+    if (key === 'criticality')      return CRIT_COLORS[val]      ?? 'bg-muted text-muted-foreground';
+    if (key === 'deployment_model') return DEPLOY_COLORS[val]    ?? 'bg-muted text-muted-foreground';
+    return null;
+  }
+
+  // ── Type display ───────────────────────────────────────────────────────────
+  function typeLabel(t) {
+    return t.replace(/^Application/, '').replace(/([A-Z])/g, ' $1').trim();
+  }
+
+  // ── Filtering & sorting ────────────────────────────────────────────────────
+  $: activePropCols = propertyKeys.filter(k => visibleProps.has(k));
+
+  $: filtered = (() => {
+    if (!search) return entries;
+    const q = search.toLowerCase();
+    return entries.filter(e =>
+      e.name.toLowerCase().includes(q) ||
+      e.type.toLowerCase().includes(q) ||
+      e.documentation.toLowerCase().includes(q) ||
+      Object.values(e.properties).some(v => v.toLowerCase().includes(q))
+    );
+  })();
+
+  $: sorted = (() => {
+    const dir = sortDir === 'asc' ? 1 : -1;
+    return [...filtered].sort((a, b) => {
+      const av = sortCol === 'name' ? a.name : sortCol === 'type' ? a.type : (a.properties[sortCol] ?? '');
+      const bv = sortCol === 'name' ? b.name : sortCol === 'type' ? b.type : (b.properties[sortCol] ?? '');
+      return av.localeCompare(bv) * dir;
+    });
+  })();
+
+  function setSort(col) {
+    if (sortCol === col) {
+      sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+    } else {
+      sortCol = col;
+      sortDir = 'asc';
+    }
+  }
+
+  function sortIcon(col) {
+    if (sortCol !== col) return '↕';
+    return sortDir === 'asc' ? '↑' : '↓';
+  }
+
+  function toggleProp(k) {
+    const next = new Set(visibleProps);
+    if (next.has(k)) next.delete(k); else next.add(k);
+    visibleProps = next;
+  }
+
+  function exportCSV() {
+    const cols = ['Name', 'Type', ...activePropCols.map(propLabel), 'Description'];
+    const lines = [cols.join(',')];
+    sorted.forEach(e => {
+      const vals = [
+        e.name,
+        typeLabel(e.type),
+        ...activePropCols.map(k => e.properties[k] ?? ''),
+        e.documentation,
+      ];
+      lines.push(vals.map(v => '"' + String(v).replace(/"/g, '""') + '"').join(','));
+    });
+    const blob = new Blob([lines.join('\n')], { type: 'text/csv' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'application-catalogue.csv';
+    a.click();
+  }
+
+  onMount(async () => {
+    try {
+      const data = await api.get('/workspaces/' + wsId + '/views/application-catalogue/entries');
+      entries = data.entries ?? [];
+      propertyKeys = data.property_keys ?? [];
+      // Default-visible: keys present in data that are in DEFAULT_PROP_COLS, in that order.
+      visibleProps = new Set(DEFAULT_PROP_COLS.filter(k => propertyKeys.includes(k)));
+    } catch (e) {
+      error = e.message;
+    } finally {
+      loading = false;
+    }
+  });
+</script>
+
+<svelte:window on:click={() => { colMenuOpen = false; }} />
+
+<div class="content">
+  {#if loading}
+    <div class="flex items-center gap-2 text-muted-foreground py-6">
+      <div class="size-4 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
+      Loading…
+    </div>
+  {:else if error}
+    <div class="text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2">{error}</div>
+  {:else}
+
+    <!-- Header -->
+    <div class="flex items-center justify-between gap-4 mb-5 flex-wrap">
+      <div>
+        <h1 class="text-[18px] font-semibold">Application Catalogue</h1>
+        <div class="text-muted-foreground text-[13px] mt-0.5">
+          Showing {sorted.length} of {entries.length} applications
+        </div>
+      </div>
+
+      <!-- Toolbar -->
+      <div class="flex items-center gap-2 flex-wrap">
+        <!-- Search -->
+        <input
+          type="search"
+          bind:value={search}
+          placeholder="Search…"
+          class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary w-48"
+        />
+
+        <!-- Column visibility -->
+        <div class="relative" on:click|stopPropagation>
+          <button
+            class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] text-foreground hover:bg-muted transition-colors"
+            on:click={() => colMenuOpen = !colMenuOpen}
+          >
+            Columns ▾
+          </button>
+          {#if colMenuOpen}
+            <div class="absolute right-0 top-full mt-1 z-30 bg-popover border border-border rounded-lg shadow-lg p-2 w-52">
+              <div class="text-[11px] font-semibold text-muted-foreground uppercase tracking-wide px-2 mb-1.5">Property Columns</div>
+              {#each propertyKeys as k}
+                <label class="flex items-center gap-2 px-2 py-1 rounded hover:bg-muted cursor-pointer">
+                  <input type="checkbox" checked={visibleProps.has(k)} on:change={() => toggleProp(k)} class="accent-primary" />
+                  <span class="text-[12px] text-foreground">{propLabel(k)}</span>
+                </label>
+              {/each}
+            </div>
+          {/if}
+        </div>
+
+        <!-- Export -->
+        <button
+          class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] text-foreground hover:bg-muted transition-colors"
+          on:click={exportCSV}
+        >↓ CSV</button>
+      </div>
+    </div>
+
+    {#if entries.length === 0}
+      <div class="text-center py-16 text-muted-foreground">
+        <div class="text-[40px] mb-3">📭</div>
+        <p class="text-[14px]">No applications found. Import a model first.</p>
+      </div>
+    {:else}
+      <div class="overflow-x-auto border border-border rounded-lg">
+        <table class="w-full text-[13px]">
+          <thead>
+            <tr class="border-b border-border bg-muted/60">
+              <!-- Name -->
+              <th
+                class="text-left px-3 py-2.5 font-semibold text-muted-foreground whitespace-nowrap cursor-pointer hover:text-foreground select-none"
+                on:click={() => setSort('name')}
+              >Name <span class="text-[11px] opacity-60">{sortIcon('name')}</span></th>
+
+              <!-- Type -->
+              <th
+                class="text-left px-3 py-2.5 font-semibold text-muted-foreground whitespace-nowrap cursor-pointer hover:text-foreground select-none"
+                on:click={() => setSort('type')}
+              >Type <span class="text-[11px] opacity-60">{sortIcon('type')}</span></th>
+
+              <!-- Active property columns -->
+              {#each activePropCols as k}
+                <th
+                  class="text-left px-3 py-2.5 font-semibold text-muted-foreground whitespace-nowrap cursor-pointer hover:text-foreground select-none"
+                  on:click={() => setSort(k)}
+                >{propLabel(k)} <span class="text-[11px] opacity-60">{sortIcon(k)}</span></th>
+              {/each}
+
+              <!-- Description (not sortable, last) -->
+              <th class="text-left px-3 py-2.5 font-semibold text-muted-foreground">Description</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-border/50">
+            {#each sorted as entry}
+              <tr class="hover:bg-muted/30 transition-colors">
+                <td class="px-3 py-2.5 font-medium text-foreground whitespace-nowrap">{entry.name}</td>
+                <td class="px-3 py-2.5 text-muted-foreground whitespace-nowrap">{typeLabel(entry.type)}</td>
+
+                {#each activePropCols as k}
+                  {@const val = entry.properties[k] ?? ''}
+                  {@const bc = val ? badgeClass(k, val) : null}
+                  <td class="px-3 py-2.5 whitespace-nowrap">
+                    {#if bc}
+                      <span class="inline-block px-2 py-0.5 rounded text-[11px] font-medium {bc}">{val}</span>
+                    {:else if val}
+                      <span class="text-foreground">{val}</span>
+                    {:else}
+                      <span class="text-muted-foreground">—</span>
+                    {/if}
+                  </td>
+                {/each}
+
+                <td class="px-3 py-2.5 text-muted-foreground max-w-xs truncate" title={entry.documentation}>
+                  {entry.documentation || '—'}
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+
+      <div class="mt-3 text-[12px] text-muted-foreground">
+        Showing {sorted.length} of {entries.length} entries
+      </div>
+    {/if}
+  {/if}
+</div>

--- a/cmd/archipulse/ui/src/routes/TechnologyCatalogueView.svelte
+++ b/cmd/archipulse/ui/src/routes/TechnologyCatalogueView.svelte
@@ -1,0 +1,198 @@
+<script>
+  import { onMount } from 'svelte';
+  import { api } from '../lib/api.js';
+
+  export let params = {};
+  $: wsId = params.wsId;
+
+  let entries = [];
+  let loading = true;
+  let error = null;
+
+  // ── Search & sort ──────────────────────────────────────────────────────────
+  let search = '';
+  let sortCol = 'name';   // 'name' | 'type' | 'apps'
+  let sortDir = 'asc';
+
+  // ── Type → category label ──────────────────────────────────────────────────
+  const TYPE_CATEGORY = {
+    'Node':              'Infrastructure Node',
+    'Device':            'Device',
+    'SystemSoftware':    'System Software',
+    'TechnologyService': 'Technology Service',
+    'Artifact':          'Artifact',
+    'Path':              'Network Path',
+    'CommunicationNetwork': 'Network',
+  };
+  function categoryLabel(t) {
+    return TYPE_CATEGORY[t] ?? t.replace(/([A-Z])/g, ' $1').trim();
+  }
+
+  const CATEGORY_BADGE = {
+    'Node':              'bg-[#1e2f55] text-[#7aa2f7]',
+    'Device':            'bg-[#1e2f55] text-[#7aa2f7]',
+    'SystemSoftware':    'bg-[#14302a] text-[#34d399]',
+    'TechnologyService': 'bg-[#2a2414] text-[#e0af68]',
+    'Artifact':          'bg-[#2a1f4a] text-[#a78bfa]',
+  };
+  function categoryBadgeClass(t) {
+    return CATEGORY_BADGE[t] ?? 'bg-muted text-muted-foreground';
+  }
+
+  // ── Filtering & sorting ────────────────────────────────────────────────────
+  $: filtered = (() => {
+    if (!search) return entries;
+    const q = search.toLowerCase();
+    return entries.filter(e =>
+      e.name.toLowerCase().includes(q) ||
+      e.type.toLowerCase().includes(q) ||
+      e.documentation.toLowerCase().includes(q) ||
+      e.used_by_apps.some(a => a.toLowerCase().includes(q))
+    );
+  })();
+
+  $: sorted = (() => {
+    const dir = sortDir === 'asc' ? 1 : -1;
+    return [...filtered].sort((a, b) => {
+      const av = sortCol === 'name' ? a.name : sortCol === 'type' ? a.type : String(a.used_by_apps.length);
+      const bv = sortCol === 'name' ? b.name : sortCol === 'type' ? b.type : String(b.used_by_apps.length);
+      return av.localeCompare(bv) * dir;
+    });
+  })();
+
+  function setSort(col) {
+    if (sortCol === col) {
+      sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+    } else {
+      sortCol = col;
+      sortDir = 'asc';
+    }
+  }
+
+  function sortIcon(col) {
+    if (sortCol !== col) return '↕';
+    return sortDir === 'asc' ? '↑' : '↓';
+  }
+
+  function exportCSV() {
+    const cols = ['Name', 'Category', 'Description', 'Hosted Applications'];
+    const lines = [cols.join(',')];
+    sorted.forEach(e => {
+      const vals = [e.name, categoryLabel(e.type), e.documentation, e.used_by_apps.join('; ')];
+      lines.push(vals.map(v => '"' + String(v).replace(/"/g, '""') + '"').join(','));
+    });
+    const blob = new Blob([lines.join('\n')], { type: 'text/csv' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'technology-catalogue.csv';
+    a.click();
+  }
+
+  onMount(async () => {
+    try {
+      const data = await api.get('/workspaces/' + wsId + '/views/technology-catalogue/entries');
+      entries = data.entries ?? [];
+    } catch (e) {
+      error = e.message;
+    } finally {
+      loading = false;
+    }
+  });
+</script>
+
+<div class="content">
+  {#if loading}
+    <div class="flex items-center gap-2 text-muted-foreground py-6">
+      <div class="size-4 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
+      Loading…
+    </div>
+  {:else if error}
+    <div class="text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2">{error}</div>
+  {:else}
+
+    <!-- Header -->
+    <div class="flex items-center justify-between gap-4 mb-5 flex-wrap">
+      <div>
+        <h1 class="text-[18px] font-semibold">Technology Catalogue</h1>
+        <div class="text-muted-foreground text-[13px] mt-0.5">
+          Showing {sorted.length} of {entries.length} technology elements
+        </div>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <input
+          type="search"
+          bind:value={search}
+          placeholder="Search…"
+          class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary w-48"
+        />
+        <button
+          class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] text-foreground hover:bg-muted transition-colors"
+          on:click={exportCSV}
+        >↓ CSV</button>
+      </div>
+    </div>
+
+    {#if entries.length === 0}
+      <div class="text-center py-16 text-muted-foreground">
+        <div class="text-[40px] mb-3">📭</div>
+        <p class="text-[14px]">No technology elements found. Import a model first.</p>
+      </div>
+    {:else}
+      <div class="overflow-x-auto border border-border rounded-lg">
+        <table class="w-full text-[13px]">
+          <thead>
+            <tr class="border-b border-border bg-muted/60">
+              <th
+                class="text-left px-3 py-2.5 font-semibold text-muted-foreground whitespace-nowrap cursor-pointer hover:text-foreground select-none"
+                on:click={() => setSort('name')}
+              >Name <span class="text-[11px] opacity-60">{sortIcon('name')}</span></th>
+
+              <th
+                class="text-left px-3 py-2.5 font-semibold text-muted-foreground whitespace-nowrap cursor-pointer hover:text-foreground select-none"
+                on:click={() => setSort('type')}
+              >Category <span class="text-[11px] opacity-60">{sortIcon('type')}</span></th>
+
+              <th class="text-left px-3 py-2.5 font-semibold text-muted-foreground">Description</th>
+
+              <th
+                class="text-left px-3 py-2.5 font-semibold text-muted-foreground whitespace-nowrap cursor-pointer hover:text-foreground select-none"
+                on:click={() => setSort('apps')}
+              >Hosted Applications <span class="text-[11px] opacity-60">{sortIcon('apps')}</span></th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-border/50">
+            {#each sorted as entry}
+              <tr class="hover:bg-muted/30 transition-colors">
+                <td class="px-3 py-2.5 font-medium text-foreground whitespace-nowrap">{entry.name}</td>
+                <td class="px-3 py-2.5 whitespace-nowrap">
+                  <span class="inline-block px-2 py-0.5 rounded text-[11px] font-medium {categoryBadgeClass(entry.type)}">
+                    {categoryLabel(entry.type)}
+                  </span>
+                </td>
+                <td class="px-3 py-2.5 text-muted-foreground max-w-xs truncate" title={entry.documentation}>
+                  {entry.documentation || '—'}
+                </td>
+                <td class="px-3 py-2.5">
+                  {#if entry.used_by_apps.length === 0}
+                    <span class="text-muted-foreground">—</span>
+                  {:else}
+                    <div class="flex flex-wrap gap-1">
+                      {#each entry.used_by_apps as app}
+                        <span class="inline-block px-1.5 py-0.5 rounded text-[11px] bg-[#1e2f55] text-[#7aa2f7]">{app}</span>
+                      {/each}
+                    </div>
+                  {/if}
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+
+      <div class="mt-3 text-[12px] text-muted-foreground">
+        Showing {sorted.length} of {entries.length} entries
+      </div>
+    {/if}
+  {/if}
+</div>

--- a/cmd/archipulse/ui/src/routes/ViewRouter.svelte
+++ b/cmd/archipulse/ui/src/routes/ViewRouter.svelte
@@ -4,6 +4,8 @@
   import TableView from './TableView.svelte';
   import ApplicationDashboard from './ApplicationDashboard.svelte';
   import ApplicationLandscapeMap from './ApplicationLandscapeMap.svelte';
+  import ApplicationCatalogueView from './ApplicationCatalogueView.svelte';
+  import TechnologyCatalogueView from './TechnologyCatalogueView.svelte';
 
   export let params = {};
 
@@ -33,6 +35,10 @@
 
 {#if view?.dashboard}
   <ApplicationDashboard {params} />
+{:else if view?.catalogue === 'application'}
+  <ApplicationCatalogueView {params} />
+{:else if view?.catalogue === 'technology'}
+  <TechnologyCatalogueView {params} />
 {:else if redirected}
   <div class="flex items-center gap-2 text-muted-foreground py-6">
     <div class="size-4 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>

--- a/internal/api/viewer_handler.go
+++ b/internal/api/viewer_handler.go
@@ -118,6 +118,36 @@ func (h *viewerHandler) getLandscapeMap(w http.ResponseWriter, r *http.Request) 
 	respondJSON(w, http.StatusOK, data)
 }
 
+// getAppCatalogueEntries returns the rich application catalogue payload.
+func (h *viewerHandler) getAppCatalogueEntries(w http.ResponseWriter, r *http.Request) {
+	wsID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		respondError(w, http.StatusBadRequest, err)
+		return
+	}
+	data, err := h.registry.AppCatalogueEntries(wsID)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
+	respondJSON(w, http.StatusOK, data)
+}
+
+// getTechCatalogueEntries returns the rich technology catalogue payload.
+func (h *viewerHandler) getTechCatalogueEntries(w http.ResponseWriter, r *http.Request) {
+	wsID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		respondError(w, http.StatusBadRequest, err)
+		return
+	}
+	data, err := h.registry.TechCatalogueEntries(wsID)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
+	respondJSON(w, http.StatusOK, data)
+}
+
 func registerViewerRoutes(r chi.Router, db *sql.DB) {
 	h := &viewerHandler{registry: viewer.NewRegistry(db)}
 	r.Get("/workspaces/{id}/views", h.listViews)
@@ -126,5 +156,7 @@ func registerViewerRoutes(r chi.Router, db *sql.DB) {
 	r.Get("/workspaces/{id}/views/integration-map/graph", h.getIntegrationMap)
 	r.Get("/workspaces/{id}/views/application-dashboard/stats", h.getApplicationDashboard)
 	r.Get("/workspaces/{id}/views/application-landscape/map", h.getLandscapeMap)
+	r.Get("/workspaces/{id}/views/application-catalogue/entries", h.getAppCatalogueEntries)
+	r.Get("/workspaces/{id}/views/technology-catalogue/entries", h.getTechCatalogueEntries)
 	r.Get("/workspaces/{id}/views/{view}", h.getView)
 }

--- a/internal/viewer/viewer.go
+++ b/internal/viewer/viewer.go
@@ -98,6 +98,16 @@ func (r *Registry) ApplicationLandscapeMap(workspaceID uuid.UUID) (*views.Applic
 	return views.ApplicationLandscapeMap(r.db, workspaceID)
 }
 
+// AppCatalogueEntries returns all application elements with properties for the rich catalogue view.
+func (r *Registry) AppCatalogueEntries(workspaceID uuid.UUID) (*views.AppCatalogueData, error) {
+	return views.AppCatalogueEntries(r.db, workspaceID)
+}
+
+// TechCatalogueEntries returns all technology elements with assigned apps for the rich catalogue view.
+func (r *Registry) TechCatalogueEntries(workspaceID uuid.UUID) (*views.TechCatalogueData, error) {
+	return views.TechCatalogueEntries(r.db, workspaceID)
+}
+
 // List returns the names of all registered tabular views, sorted.
 func (r *Registry) List() []string {
 	names := make([]string, 0, len(r.views))

--- a/internal/viewer/views/app_catalogue_entries.go
+++ b/internal/viewer/views/app_catalogue_entries.go
@@ -1,0 +1,75 @@
+package views
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+
+	"github.com/google/uuid"
+)
+
+// AppCatalogueEntry is a single row in the Application Catalogue rich view.
+type AppCatalogueEntry struct {
+	ID            string            `json:"id"`
+	Name          string            `json:"name"`
+	Type          string            `json:"type"`
+	Documentation string            `json:"documentation"`
+	Properties    map[string]string `json:"properties"`
+}
+
+// AppCatalogueData is the payload for the application catalogue rich view.
+type AppCatalogueData struct {
+	Entries      []AppCatalogueEntry `json:"entries"`
+	PropertyKeys []string            `json:"property_keys"`
+}
+
+// AppCatalogueEntries returns all application-layer elements with their
+// model properties, ready for the rich catalogue view.
+func AppCatalogueEntries(db *sql.DB, workspaceID uuid.UUID) (*AppCatalogueData, error) {
+	// Step 1: fetch all application elements.
+	rows, err := db.Query(fmt.Sprintf(`
+		SELECT source_id, type, name, documentation
+		FROM elements
+		WHERE workspace_id = $1
+		  AND layer = 'Application'
+		  AND type IN (%s)
+		ORDER BY name`, appTypesSQL), workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("app catalogue elements: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []AppCatalogueEntry
+	var ids []string
+	for rows.Next() {
+		var e AppCatalogueEntry
+		if err := rows.Scan(&e.ID, &e.Type, &e.Name, &e.Documentation); err != nil {
+			return nil, err
+		}
+		e.Properties = map[string]string{}
+		entries = append(entries, e)
+		ids = append(ids, e.ID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if len(ids) == 0 {
+		return &AppCatalogueData{Entries: []AppCatalogueEntry{}, PropertyKeys: []string{}}, nil
+	}
+
+	// Step 2: fetch model properties for all entries.
+	propsByID, propKeys, err := loadAppProperties(db, workspaceID, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, e := range entries {
+		if p, ok := propsByID[e.ID]; ok {
+			entries[i].Properties = p
+		}
+	}
+
+	sort.Strings(propKeys)
+	return &AppCatalogueData{Entries: entries, PropertyKeys: propKeys}, nil
+}

--- a/internal/viewer/views/tech_catalogue_entries.go
+++ b/internal/viewer/views/tech_catalogue_entries.go
@@ -1,0 +1,106 @@
+package views
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+)
+
+// TechCatalogueEntry is a single row in the Technology Catalogue rich view.
+type TechCatalogueEntry struct {
+	ID            string   `json:"id"`
+	Name          string   `json:"name"`
+	Type          string   `json:"type"`
+	Documentation string   `json:"documentation"`
+	UsedByApps    []string `json:"used_by_apps"`
+}
+
+// TechCatalogueData is the payload for the technology catalogue rich view.
+type TechCatalogueData struct {
+	Entries []TechCatalogueEntry `json:"entries"`
+}
+
+// TechCatalogueEntries returns all technology-layer elements with the list of
+// application elements they host/run (via Assignment relationships).
+func TechCatalogueEntries(db *sql.DB, workspaceID uuid.UUID) (*TechCatalogueData, error) {
+	// Step 1: fetch all technology elements.
+	rows, err := db.Query(`
+		SELECT source_id, type, name, documentation
+		FROM elements
+		WHERE workspace_id = $1
+		  AND layer = 'Technology'
+		ORDER BY type, name`, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("tech catalogue elements: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []TechCatalogueEntry
+	var ids []string
+	idxByID := map[string]int{}
+	for rows.Next() {
+		var e TechCatalogueEntry
+		if err := rows.Scan(&e.ID, &e.Type, &e.Name, &e.Documentation); err != nil {
+			return nil, err
+		}
+		e.UsedByApps = []string{}
+		idxByID[e.ID] = len(entries)
+		entries = append(entries, e)
+		ids = append(ids, e.ID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if len(ids) == 0 {
+		return &TechCatalogueData{Entries: []TechCatalogueEntry{}}, nil
+	}
+
+	// Step 2: find which application elements are assigned to each tech element.
+	// Assignment: tech element (source) → app element (target), or reverse.
+	asgRows, err := db.Query(fmt.Sprintf(`
+		SELECT
+			CASE
+				WHEN e_tech.source_id = ANY($2) THEN e_tech.source_id
+				ELSE e_app.source_id
+			END AS tech_id,
+			CASE
+				WHEN e_tech.source_id = ANY($2) THEN e_app.name
+				ELSE e_tech.name
+			END AS app_name
+		FROM relationships r
+		JOIN elements e_tech
+			ON e_tech.workspace_id = $1
+			AND e_tech.source_id   = r.source_element
+			AND e_tech.layer       = 'Technology'
+		JOIN elements e_app
+			ON e_app.workspace_id = $1
+			AND e_app.source_id   = r.target_element
+			AND e_app.type IN (%s)
+		WHERE r.workspace_id = $1
+		  AND r.type IN ('Assignment', 'AssignmentRelationship')
+		  AND e_tech.source_id = ANY($2)
+		ORDER BY tech_id, app_name`, appTypesSQL),
+		workspaceID, pq.Array(ids))
+	if err != nil {
+		return nil, fmt.Errorf("tech catalogue assignments: %w", err)
+	}
+	defer func() { _ = asgRows.Close() }()
+
+	for asgRows.Next() {
+		var techID, appName string
+		if err := asgRows.Scan(&techID, &appName); err != nil {
+			return nil, err
+		}
+		if idx, ok := idxByID[techID]; ok {
+			entries[idx].UsedByApps = append(entries[idx].UsedByApps, appName)
+		}
+	}
+	if err := asgRows.Err(); err != nil {
+		return nil, err
+	}
+
+	return &TechCatalogueData{Entries: entries}, nil
+}


### PR DESCRIPTION
## Summary
- Moves both catalogues to a dedicated **Catalogues** sidebar section (no longer mixed into Application/Technology layers)
- **Application Catalogue**: sortable table with Name, Type, property columns (Vendor, Lifecycle, Criticality, Deployment, Business Owner, User Count), colour-coded badges, column visibility toggle, global search, CSV export
- **Technology Catalogue**: sortable table with Name, Category badge (Node/SystemSoftware/TechnologyService), Description, Hosted Applications chips (via Assignment relationships), global search, CSV export

## Backend
- `GET /views/application-catalogue/entries` → all app elements + model properties
- `GET /views/technology-catalogue/entries` → all tech elements + assigned application names
- Both return structured JSON (not the generic tabular format)

## Test plan
- [ ] Sidebar shows "Catalogues" section with both entries, no longer under Application/Technology
- [ ] Application Catalogue loads all 40 apps with properties (Vendor, Lifecycle etc.)
- [ ] Column visibility dropdown shows/hides property columns correctly
- [ ] Sorting by Name, Type, any property column works (asc/desc toggle)
- [ ] Search filters across name, type, description and all properties
- [ ] Technology Catalogue shows Node/SystemSoftware/TechnologyService with correct category badges
- [ ] "Hosted Applications" chips show which apps each tech element supports
- [ ] CSV export produces correct output with active columns
- [ ] CI passes