### PR TITLE
feat(view): redesign Application Dependency Graph

### DIFF
--- a/cmd/archipulse/ui/package-lock.json
+++ b/cmd/archipulse/ui/package-lock.json
@@ -6,8 +6,10 @@
     "": {
       "name": "archipulse-ui",
       "dependencies": {
+        "@dagrejs/dagre": "^3.0.0",
         "@lucide/svelte": "^1.7.0",
         "@tailwindcss/vite": "^4.2.2",
+        "@xyflow/svelte": "^1.5.2",
         "bits-ui": "^2.16.5",
         "clsx": "^2.1.1",
         "cytoscape": "^3.29.2",
@@ -27,18 +29,18 @@
       }
     },
     "node_modules/@dagrejs/dagre": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-2.0.4.tgz",
-      "integrity": "sha512-J6vCWTNpicHF4zFlZG1cS5DkGzMr9941gddYkakjrg3ZNev4bbqEgLHFTWiFrcJm7UCRu7olO3K6IRDd9gSGhA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
+      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
       "license": "MIT",
       "dependencies": {
-        "@dagrejs/graphlib": "3.0.4"
+        "@dagrejs/graphlib": "4.0.1"
       }
     },
     "node_modules/@dagrejs/graphlib": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-3.0.4.tgz",
-      "integrity": "sha512-HxZ7fCvAwTLCWCO0WjDkzAFQze8LdC6iOpKbetDKHIuDfIgMlIzYzqZ4nxwLlclQX+3ZVeZ1K2OuaOE2WWcyOg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
+      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -914,6 +916,15 @@
         "win32"
       ]
     },
+    "node_modules/@svelte-put/shortcut": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@svelte-put/shortcut/-/shortcut-4.1.0.tgz",
+      "integrity": "sha512-wImNEIkbxAIWFqlfuhcbC+jRPDeRa/uJGIXHMEVVD+jqL9xCwWNnkGQJ6Qb2XVszuRLHlb8SGZDL3Io/h3vs8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "svelte": "^5.1.0"
+      }
+    },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
@@ -1236,6 +1247,12 @@
       "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-contour": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
@@ -1244,6 +1261,49 @@
       "dependencies": {
         "@types/d3-array": "*",
         "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -1275,6 +1335,36 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@xyflow/svelte": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/svelte/-/svelte-1.5.2.tgz",
+      "integrity": "sha512-jPLc2cwRmrkXSv/jvsNDQqTGCsNyTWURKtBl28UCH3BdOAA3CIc0/oQ0EvIcjPdzr0NwvWMgq9TmLdjOIccCEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@svelte-put/shortcut": "^4.1.0",
+        "@xyflow/system": "0.0.76"
+      },
+      "peerDependencies": {
+        "svelte": "^5.25.0"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
       }
     },
     "node_modules/acorn": {
@@ -1436,6 +1526,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-dsv": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
@@ -1457,6 +1560,15 @@
         "tsv2csv": "bin/dsv2dsv.js",
         "tsv2json": "bin/dsv2json.js"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12"
       }
@@ -1634,6 +1746,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-shape": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
@@ -1685,6 +1806,25 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
     "node_modules/d3-tricontour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/d3-tricontour/-/d3-tricontour-1.1.0.tgz",
@@ -1693,6 +1833,22 @@
       "dependencies": {
         "d3-delaunay": "6",
         "d3-scale": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
       },
       "engines": {
         "node": ">=12"
@@ -1979,6 +2135,21 @@
       "peerDependencies": {
         "svelte": "^5.0.0"
       }
+    },
+    "node_modules/layerchart/node_modules/@dagrejs/dagre": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-2.0.4.tgz",
+      "integrity": "sha512-J6vCWTNpicHF4zFlZG1cS5DkGzMr9941gddYkakjrg3ZNev4bbqEgLHFTWiFrcJm7UCRu7olO3K6IRDd9gSGhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "3.0.4"
+      }
+    },
+    "node_modules/layerchart/node_modules/@dagrejs/graphlib": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-3.0.4.tgz",
+      "integrity": "sha512-HxZ7fCvAwTLCWCO0WjDkzAFQze8LdC6iOpKbetDKHIuDfIgMlIzYzqZ4nxwLlclQX+3ZVeZ1K2OuaOE2WWcyOg==",
+      "license": "MIT"
     },
     "node_modules/layerchart/node_modules/runed": {
       "version": "0.37.1",

--- a/cmd/archipulse/ui/package.json
+++ b/cmd/archipulse/ui/package.json
@@ -8,8 +8,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "@lucide/svelte": "^1.7.0",
     "@tailwindcss/vite": "^4.2.2",
+    "@xyflow/svelte": "^1.5.2",
     "bits-ui": "^2.16.5",
     "clsx": "^2.1.1",
     "cytoscape": "^3.29.2",

--- a/cmd/archipulse/ui/src/App.svelte
+++ b/cmd/archipulse/ui/src/App.svelte
@@ -7,6 +7,7 @@
   import WorkspaceOverview from './routes/WorkspaceOverview.svelte';
   import ViewRouter from './routes/ViewRouter.svelte';
   import GraphView from './routes/GraphView.svelte';
+  import DependencyGraphView from './routes/dependency/DependencyGraphView.svelte';
   import CapabilityTree from './routes/CapabilityTree.svelte';
   import ApplicationLandscapeMap from './routes/ApplicationLandscapeMap.svelte';
 
@@ -19,6 +20,7 @@
     '/': Home,
     '/ws/:wsId': WorkspaceOverview,
     '/ws/:wsId/view/:viewName': ViewRouter,
+    '/ws/:wsId/view/application-dependency/graph': DependencyGraphView,
     '/ws/:wsId/view/:viewName/graph': GraphView,
     '/ws/:wsId/view/:viewName/tree': CapabilityTree,
     '/ws/:wsId/view/:viewName/map': ApplicationLandscapeMap,

--- a/cmd/archipulse/ui/src/lib/cytoscape.js
+++ b/cmd/archipulse/ui/src/lib/cytoscape.js
@@ -10,6 +10,252 @@ function ensureRegistered() {
   }
 }
 
+// ── Relationship metadata ────────────────────────────────────────────────────
+
+const REL_META = {
+  serving:     { label: 'Serves',         color: '#7aa2f7', dash: false },
+  flow:        { label: 'Data Flow',       color: '#9ece6a', dash: true  },
+  access:      { label: 'Accesses',        color: '#bb9af7', dash: true  },
+  association: { label: 'Associated with', color: '#6b7280', dash: true  },
+  triggering:  { label: 'Triggers',        color: '#E85D3A', dash: false },
+};
+
+function relKey(rel) {
+  const r = (rel || '').toLowerCase();
+  if (r.includes('serving'))     return 'serving';
+  if (r.includes('flow'))        return 'flow';
+  if (r.includes('access'))      return 'access';
+  if (r.includes('triggering'))  return 'triggering';
+  if (r.includes('association')) return 'association';
+  return 'association';
+}
+
+function relMeta(rel) {
+  return REL_META[relKey(rel)] ?? REL_META.association;
+}
+
+// ── Lifecycle → node color ────────────────────────────────────────────────────
+
+const LIFECYCLE_COLOR = {
+  'Production':     { bg: '#0d2a1a', border: '#4ade80', text: '#4ade80' },
+  'Pilot':          { bg: '#0d1f38', border: '#60a5fa', text: '#60a5fa' },
+  'Planned':        { bg: '#1a1228', border: '#a78bfa', text: '#a78bfa' },
+  'Retiring':       { bg: '#2a1800', border: '#fb923c', text: '#fb923c' },
+  'Decommissioned': { bg: '#2a0d0d', border: '#f87171', text: '#f87171' },
+};
+
+function nodeColors(lifecycleStatus) {
+  return LIFECYCLE_COLOR[lifecycleStatus] ?? { bg: '#131929', border: '#3d59a1', text: '#7aa2f7' };
+}
+
+// ── Type visual tier ──────────────────────────────────────────────────────────
+
+function nodeTier(type) {
+  if (type === 'ApplicationComponent') return 'component';
+  if (type === 'ApplicationService')   return 'service';
+  if (type === 'ApplicationInterface') return 'interface';
+  if (type === 'ApplicationFunction')  return 'function';
+  return 'other';
+}
+
+function nodeSize(tier) {
+  if (tier === 'component')  return { w: 160, h: 44 };
+  if (tier === 'service')    return { w: 140, h: 38 };
+  if (tier === 'interface')  return { w: 130, h: 36 };
+  if (tier === 'function')   return { w: 130, h: 36 };
+  return { w: 140, h: 38 };
+}
+
+function typeBadge(type) {
+  return type.replace('Application', '');
+}
+
+// ── Dependency Graph ──────────────────────────────────────────────────────────
+
+export function makeDependencyGraph(container, data, { onEdgeHover, onEdgeLeave, onNodeClick } = {}) {
+  ensureRegistered();
+
+  const elements = [
+    ...(data.nodes || []).map(n => {
+      const tier = nodeTier(n.type);
+      const sz   = nodeSize(tier);
+      const clr  = nodeColors(n.lifecycle_status);
+      return {
+        data: {
+          id:        n.id,
+          label:     n.name,
+          badge:     typeBadge(n.type),
+          tier,
+          lifecycle: n.lifecycle_status || '',
+          bg:        clr.bg,
+          border:    clr.border,
+          textColor: clr.text,
+          w:         sz.w,
+          h:         sz.h,
+        },
+      };
+    }),
+    ...(data.edges || []).map(e => {
+      const meta = relMeta(e.relationship);
+      const rk   = relKey(e.relationship);
+      return {
+        data: {
+          id:       e.id,
+          source:   e.source,
+          target:   e.target,
+          relKey:   rk,
+          relLabel: meta.label,
+          color:    meta.color,
+          dashed:   meta.dash,
+          // Raw names filled in after nodes are indexed
+          sourceName: '',
+          targetName: '',
+        },
+      };
+    }),
+  ];
+
+  // Index node names for edge tooltips
+  const nameById = {};
+  (data.nodes || []).forEach(n => { nameById[n.id] = n.name; });
+  elements.forEach(el => {
+    if (el.data.relKey) {
+      el.data.sourceName = nameById[el.data.source] ?? el.data.source;
+      el.data.targetName = nameById[el.data.target] ?? el.data.target;
+    }
+  });
+
+  const cy = cytoscape({
+    container,
+    elements,
+    style: [
+      // ── Nodes ──
+      {
+        selector: 'node',
+        style: {
+          shape: 'round-rectangle',
+          label: 'data(label)',
+          'text-valign': 'center',
+          'text-halign': 'center',
+          'font-size': '11px',
+          'font-family': 'system-ui, sans-serif',
+          color: 'data(textColor)',
+          'text-wrap': 'wrap',
+          'text-max-width': '140px',
+          width: 'data(w)',
+          height: 'data(h)',
+          'background-color': 'data(bg)',
+          'border-color': 'data(border)',
+          'border-width': 2,
+          'transition-property': 'opacity, border-width',
+          'transition-duration': '150ms',
+        },
+      },
+      {
+        selector: 'node[tier="component"]',
+        style: { 'border-width': 2.5, 'font-size': '12px', 'font-weight': 'bold' },
+      },
+      {
+        selector: 'node[tier="service"]',
+        style: { 'border-style': 'dashed', 'font-size': '11px' },
+      },
+      {
+        selector: 'node[tier="interface"]',
+        style: { 'border-style': 'dotted', 'font-size': '10px' },
+      },
+      {
+        selector: 'node[tier="function"]',
+        style: { 'border-style': 'dotted', 'font-size': '10px' },
+      },
+      {
+        selector: 'node.selected',
+        style: { 'border-width': 4, 'border-color': '#fff' },
+      },
+      {
+        selector: 'node.faded',
+        style: { opacity: 0.15 },
+      },
+      // ── Edges ──
+      {
+        selector: 'edge',
+        style: {
+          width: 1.5,
+          'line-color': 'data(color)',
+          'target-arrow-color': 'data(color)',
+          'target-arrow-shape': 'triangle',
+          'curve-style': 'bezier',
+          opacity: 0.75,
+          'transition-property': 'opacity, width',
+          'transition-duration': '150ms',
+        },
+      },
+      {
+        selector: 'edge[?dashed]',
+        style: { 'line-style': 'dashed', 'line-dash-pattern': [6, 3] },
+      },
+      {
+        selector: 'edge.faded',
+        style: { opacity: 0.06 },
+      },
+      {
+        selector: 'edge.hovered',
+        style: { width: 3, opacity: 1 },
+      },
+    ],
+    layout: {
+      name: 'dagre',
+      rankDir: 'LR',
+      nodeSep: 28,
+      rankSep: 90,
+      edgeSep: 10,
+      align: 'UL',
+      animate: false,
+      padding: 48,
+    },
+    userZoomingEnabled: true,
+    userPanningEnabled: true,
+    boxSelectionEnabled: false,
+    minZoom: 0.2,
+    maxZoom: 3,
+  });
+
+  // ── Interactions ──────────────────────────────────────────────────────────
+
+  // Node click → highlight neighbourhood
+  cy.on('tap', 'node', evt => {
+    const n = evt.target;
+    cy.elements().addClass('faded');
+    n.removeClass('faded').addClass('selected');
+    n.neighborhood().removeClass('faded');
+    if (onNodeClick) onNodeClick(n.data());
+  });
+
+  // Tap background → clear selection
+  cy.on('tap', evt => {
+    if (evt.target === cy) {
+      cy.elements().removeClass('faded selected');
+      if (onNodeClick) onNodeClick(null);
+    }
+  });
+
+  // Edge hover → tooltip
+  cy.on('mouseover', 'edge', evt => {
+    evt.target.addClass('hovered');
+    if (onEdgeHover) onEdgeHover(evt.target.data(), evt.originalEvent);
+  });
+  cy.on('mouseout', 'edge', evt => {
+    evt.target.removeClass('hovered');
+    if (onEdgeLeave) onEdgeLeave();
+  });
+  cy.on('mousemove', 'edge', evt => {
+    if (onEdgeHover) onEdgeHover(evt.target.data(), evt.originalEvent);
+  });
+
+  return cy;
+}
+
+// ── Legacy graph (integration map) ───────────────────────────────────────────
+
 function relColor(rel) {
   const r = (rel || '').toLowerCase();
   if (r.includes('serving'))     return '#7aa2f7';
@@ -100,6 +346,8 @@ export function makeGraph(container, data) {
   return cy;
 }
 
+// ── Capability Tree ───────────────────────────────────────────────────────────
+
 function appSubtype(t) {
   if (!t) return 'other';
   if (t === 'ApplicationComponent') return 'component';
@@ -164,118 +412,19 @@ export function makeCapabilityTree(container, nodes) {
           padding: '10px',
         },
       },
-      {
-        selector: 'node[kind="capability"]',
-        style: {
-          'background-color': '#2a2010',
-          'border-color': '#e0af68',
-          'border-width': 2,
-          color: '#e0af68',
-        },
-      },
-      {
-        selector: 'node[kind="app"][appSub="component"]',
-        style: {
-          'background-color': '#0d1f2e',
-          'border-color': '#7aa2f7',
-          'border-width': 2,
-          color: '#7aa2f7',
-          width: 150,
-          height: 44,
-          'font-size': '11px',
-        },
-      },
-      {
-        selector: 'node[kind="app"][appSub="service"]',
-        style: {
-          'background-color': '#0d1a28',
-          'border-color': '#4a9eff',
-          'border-width': 1.5,
-          color: '#4a9eff',
-          width: 140,
-          height: 40,
-          'font-size': '11px',
-          'border-style': 'dashed',
-        },
-      },
-      {
-        selector: 'node[kind="app"][appSub="function"]',
-        style: {
-          'background-color': '#0d1520',
-          'border-color': '#3a5a80',
-          'border-width': 1,
-          color: '#5a80a8',
-          width: 130,
-          height: 38,
-          'font-size': '10px',
-        },
-      },
-      {
-        selector: 'node[kind="app"][appSub="interface"]',
-        style: {
-          'background-color': '#0a1e20',
-          'border-color': '#3a9a9a',
-          'border-width': 1.5,
-          color: '#3a9a9a',
-          width: 130,
-          height: 38,
-          'font-size': '10px',
-        },
-      },
-      {
-        selector: 'node[kind="app"][appSub="other"]',
-        style: {
-          'background-color': '#111827',
-          'border-color': '#4b5563',
-          'border-width': 1,
-          color: '#6b7280',
-          width: 130,
-          height: 38,
-          'font-size': '10px',
-        },
-      },
-      {
-        selector: 'node:selected',
-        style: { 'border-width': 3, 'border-color': '#fff' },
-      },
-      {
-        selector: 'edge',
-        style: {
-          'curve-style': 'taxi',
-          'taxi-direction': 'horizontal',
-          width: 1.5,
-          opacity: 0.6,
-        },
-      },
-      {
-        selector: 'edge[kind="composition"]',
-        style: {
-          'line-color': '#a87c36',
-          'target-arrow-color': '#a87c36',
-          'target-arrow-shape': 'triangle',
-        },
-      },
-      {
-        selector: 'edge[kind="serving"]',
-        style: {
-          'line-color': '#4a6fa5',
-          'line-style': 'dashed',
-          'line-dash-pattern': [5, 3],
-          'target-arrow-color': '#4a6fa5',
-          'target-arrow-shape': 'triangle',
-        },
-      },
+      { selector: 'node[kind="capability"]', style: { 'background-color': '#2a2010', 'border-color': '#e0af68', 'border-width': 2, color: '#e0af68' } },
+      { selector: 'node[kind="app"][appSub="component"]',  style: { 'background-color': '#0d1f2e', 'border-color': '#7aa2f7', 'border-width': 2,   color: '#7aa2f7', width: 150, height: 44, 'font-size': '11px' } },
+      { selector: 'node[kind="app"][appSub="service"]',    style: { 'background-color': '#0d1a28', 'border-color': '#4a9eff', 'border-width': 1.5, color: '#4a9eff', width: 140, height: 40, 'font-size': '11px', 'border-style': 'dashed' } },
+      { selector: 'node[kind="app"][appSub="function"]',   style: { 'background-color': '#0d1520', 'border-color': '#3a5a80', 'border-width': 1,   color: '#5a80a8', width: 130, height: 38, 'font-size': '10px' } },
+      { selector: 'node[kind="app"][appSub="interface"]',  style: { 'background-color': '#0a1e20', 'border-color': '#3a9a9a', 'border-width': 1.5, color: '#3a9a9a', width: 130, height: 38, 'font-size': '10px' } },
+      { selector: 'node[kind="app"][appSub="other"]',      style: { 'background-color': '#111827', 'border-color': '#4b5563', 'border-width': 1,   color: '#6b7280', width: 130, height: 38, 'font-size': '10px' } },
+      { selector: 'node:selected', style: { 'border-width': 3, 'border-color': '#fff' } },
+      { selector: 'edge', style: { 'curve-style': 'taxi', 'taxi-direction': 'horizontal', width: 1.5, opacity: 0.6 } },
+      { selector: 'edge[kind="composition"]', style: { 'line-color': '#a87c36', 'target-arrow-color': '#a87c36', 'target-arrow-shape': 'triangle' } },
+      { selector: 'edge[kind="serving"]',     style: { 'line-color': '#4a6fa5', 'line-style': 'dashed', 'line-dash-pattern': [5, 3], 'target-arrow-color': '#4a6fa5', 'target-arrow-shape': 'triangle' } },
       { selector: '.faded', style: { opacity: 0.15 } },
     ],
-    layout: {
-      name: 'dagre',
-      rankDir: 'LR',
-      nodeSep: 30,
-      rankSep: 100,
-      align: 'UL',
-      animate: false,
-      padding: 40,
-    },
+    layout: { name: 'dagre', rankDir: 'LR', nodeSep: 30, rankSep: 100, align: 'UL', animate: false, padding: 40 },
     userZoomingEnabled: true,
     userPanningEnabled: true,
     boxSelectionEnabled: false,

--- a/cmd/archipulse/ui/src/routes/GraphView.svelte
+++ b/cmd/archipulse/ui/src/routes/GraphView.svelte
@@ -88,21 +88,28 @@
     applyRelFilter();
   }
 
+  const DAGRE_OPTS = { name: 'dagre', rankDir: 'LR', nodeSep: 28, rankSep: 90, animate: false, padding: 48 };
+
   function focusNode(id) {
     if (!cy) return;
     selectedId = id;
     const node = cy.$id(id);
-    cy.elements().addClass('faded').removeClass('selected');
-    node.removeClass('faded').addClass('selected');
-    node.neighborhood().removeClass('faded');
-    cy.animate({ fit: { eles: node.neighborhood().union(node), padding: 80 }, duration: 350 });
+    const visible = node.union(node.neighborhood());
+    // Hide everything outside the neighbourhood and re-layout the subgraph.
+    cy.elements().style('display', 'none').removeClass('selected faded');
+    visible.style('display', 'element');
+    node.addClass('selected');
+    visible.layout({ ...DAGRE_OPTS, animate: true, animationDuration: 350 }).run();
+    cy.once('layoutstop', () => cy.fit(visible, 60));
   }
 
   function clearFocus() {
     if (!cy) return;
     selectedId = null;
-    cy.elements().removeClass('faded selected');
-    cy.fit(undefined, 48);
+    cy.elements().style('display', 'element').removeClass('selected faded');
+    applyRelFilter();
+    cy.layout({ ...DAGRE_OPTS, animate: true, animationDuration: 350 }).run();
+    cy.once('layoutstop', () => cy.fit(undefined, 48));
   }
 
   onMount(async () => {
@@ -147,12 +154,11 @@
   function fit()      { if (cy) cy.fit(undefined, 48); }
   function relayout() {
     if (!cy) return;
-    cy.layout({
-      name: isDependency ? 'dagre' : 'cose',
-      ...(isDependency
-        ? { rankDir: 'LR', nodeSep: 28, rankSep: 90, animate: true, animationDuration: 400, padding: 48 }
-        : { animate: true, padding: 40, nodeRepulsion: 8000 }),
-    }).run();
+    if (isDependency) {
+      clearFocus();
+    } else {
+      cy.layout({ name: 'cose', animate: true, padding: 40, nodeRepulsion: 8000 }).run();
+    }
   }
 </script>
 

--- a/cmd/archipulse/ui/src/routes/GraphView.svelte
+++ b/cmd/archipulse/ui/src/routes/GraphView.svelte
@@ -95,12 +95,12 @@
     selectedId = id;
     const node = cy.$id(id);
     const visible = node.union(node.neighborhood());
-    // Hide everything outside the neighbourhood and re-layout the subgraph.
     cy.elements().style('display', 'none').removeClass('selected faded');
     visible.style('display', 'element');
     node.addClass('selected');
-    visible.layout({ ...DAGRE_OPTS, animate: true, animationDuration: 350 }).run();
-    cy.once('layoutstop', () => cy.fit(visible, 60));
+    // Layout without animation so positions are final before fit.
+    visible.layout(DAGRE_OPTS).run();
+    cy.animate({ fit: { eles: visible, padding: 60 }, duration: 300 });
   }
 
   function clearFocus() {
@@ -108,8 +108,8 @@
     selectedId = null;
     cy.elements().style('display', 'element').removeClass('selected faded');
     applyRelFilter();
-    cy.layout({ ...DAGRE_OPTS, animate: true, animationDuration: 350 }).run();
-    cy.once('layoutstop', () => cy.fit(undefined, 48));
+    cy.layout(DAGRE_OPTS).run();
+    cy.animate({ fit: { eles: cy.elements(), padding: 48 }, duration: 300 });
   }
 
   onMount(async () => {

--- a/cmd/archipulse/ui/src/routes/GraphView.svelte
+++ b/cmd/archipulse/ui/src/routes/GraphView.svelte
@@ -2,7 +2,7 @@
   import { onMount, onDestroy } from 'svelte';
   import { api } from '../lib/api.js';
   import { VIEWS } from '../lib/views.js';
-  import { makeGraph } from '../lib/cytoscape.js';
+  import { makeGraph, makeDependencyGraph } from '../lib/cytoscape.js';
   import { Button } from '$lib/components/ui/button';
 
   export let params = {};
@@ -13,50 +13,165 @@
   let error = null;
   let empty = false;
 
-  $: wsId = params.wsId;
+  $: wsId     = params.wsId;
   $: viewName = params.viewName;
-  $: meta = VIEWS[viewName] || { label: viewName, desc: '' };
+  $: meta     = VIEWS[viewName] || { label: viewName, desc: '' };
+  $: isDependency = viewName === 'application-dependency';
 
-  onMount(async () => {
-    loading = true;
-    error = null;
-    empty = false;
-    try {
-      const data = await api.get('/workspaces/' + wsId + '/views/' + viewName + '/graph');
-      if ((data.nodes || []).length === 0) {
-        empty = true;
-        loading = false;
-        return;
-      }
-      loading = false;
-      // Wait for container to be in DOM
-      await tick();
-      cy = makeGraph(container, data);
-    } catch (e) {
-      error = e.message;
-      loading = false;
-    }
-  });
+  // ── Dependency-specific state ────────────────────────────────────────────
+  let allNodes   = [];   // { id, name, type, lifecycle_status }
+  let searchQ    = '';
+  let selectedId = null; // currently focused node id
 
-  onDestroy(() => {
-    if (cy) cy.destroy();
-  });
+  // Relationship type filters
+  const REL_TYPES = [
+    { key: 'serving',     label: 'Serves',    color: '#7aa2f7' },
+    { key: 'flow',        label: 'Data Flow',  color: '#9ece6a' },
+    { key: 'access',      label: 'Accesses',   color: '#bb9af7' },
+    { key: 'triggering',  label: 'Triggers',   color: '#E85D3A' },
+    { key: 'association', label: 'Associated', color: '#6b7280' },
+  ];
+  let activeRels = new Set(REL_TYPES.map(r => r.key));
 
-  function fit() {
-    if (cy) cy.fit(undefined, 40);
-  }
+  // Edge tooltip
+  let edgeTooltip = null; // { relLabel, sourceName, targetName, x, y }
 
-  function relayout() {
-    if (cy) cy.layout({ name: 'cose', animate: true, padding: 40, nodeRepulsion: 8000 }).run();
-  }
+  // Node type legend
+  const TIERS = [
+    { key: 'component',  label: 'Component',  style: 'solid',  color: '#7aa2f7' },
+    { key: 'service',    label: 'Service',     style: 'dashed', color: '#60a5fa' },
+    { key: 'interface',  label: 'Interface',   style: 'dotted', color: '#38bdf8' },
+    { key: 'function',   label: 'Function',    style: 'dotted', color: '#818cf8' },
+  ];
+
+  const LIFECYCLE_COLORS = {
+    'Production':     '#4ade80',
+    'Pilot':          '#60a5fa',
+    'Planned':        '#a78bfa',
+    'Retiring':       '#fb923c',
+    'Decommissioned': '#f87171',
+  };
+
+  $: filteredNodes = searchQ
+    ? allNodes.filter(n => n.name.toLowerCase().includes(searchQ.toLowerCase()))
+    : allNodes;
+
+  // ── Async helpers ──────────────────────────────────────────────────────────
 
   async function tick() {
     return new Promise(resolve => requestAnimationFrame(resolve));
   }
+
+  // ── Graph build ─────────────────────────────────────────────────────────────
+
+  function applyRelFilter() {
+    if (!cy) return;
+    cy.edges().forEach(edge => {
+      const rk = edge.data('relKey');
+      if (activeRels.has(rk)) {
+        edge.style({ display: 'element' });
+      } else {
+        edge.style({ display: 'none' });
+      }
+    });
+  }
+
+  function toggleRel(key) {
+    const next = new Set(activeRels);
+    if (next.has(key)) {
+      if (next.size === 1) return; // keep at least one active
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    activeRels = next;
+    applyRelFilter();
+  }
+
+  function focusNode(id) {
+    if (!cy) return;
+    selectedId = id;
+    const node = cy.$id(id);
+    cy.elements().addClass('faded').removeClass('selected');
+    node.removeClass('faded').addClass('selected');
+    node.neighborhood().removeClass('faded');
+    cy.animate({ fit: { eles: node.neighborhood().union(node), padding: 80 }, duration: 350 });
+  }
+
+  function clearFocus() {
+    if (!cy) return;
+    selectedId = null;
+    cy.elements().removeClass('faded selected');
+    cy.fit(undefined, 48);
+  }
+
+  onMount(async () => {
+    loading = true;
+    error   = null;
+    empty   = false;
+    try {
+      const data = await api.get('/workspaces/' + wsId + '/views/' + viewName + '/graph');
+      if ((data.nodes || []).length === 0) { empty = true; loading = false; return; }
+
+      allNodes = data.nodes || [];
+      loading = false;
+      await tick();
+
+      if (isDependency) {
+        cy = makeDependencyGraph(container, data, {
+          onEdgeHover(edgeData, mouseEvent) {
+            edgeTooltip = {
+              relLabel:   edgeData.relLabel,
+              sourceName: edgeData.sourceName,
+              targetName: edgeData.targetName,
+              x: mouseEvent.clientX + 14,
+              y: mouseEvent.clientY - 10,
+            };
+          },
+          onEdgeLeave() { edgeTooltip = null; },
+          onNodeClick(nodeData) {
+            selectedId = nodeData ? nodeData.id : null;
+          },
+        });
+      } else {
+        cy = makeGraph(container, data);
+      }
+    } catch (e) {
+      error   = e.message;
+      loading = false;
+    }
+  });
+
+  onDestroy(() => { if (cy) cy.destroy(); });
+
+  function fit()      { if (cy) cy.fit(undefined, 48); }
+  function relayout() {
+    if (!cy) return;
+    cy.layout({
+      name: isDependency ? 'dagre' : 'cose',
+      ...(isDependency
+        ? { rankDir: 'LR', nodeSep: 28, rankSep: 90, animate: true, animationDuration: 400, padding: 48 }
+        : { animate: true, padding: 40, nodeRepulsion: 8000 }),
+    }).run();
+  }
 </script>
 
-<div class="content">
-  <div class="flex items-start justify-between mb-6 gap-4">
+<!-- Edge tooltip (fixed, pointer-events: none) -->
+{#if edgeTooltip}
+  <div
+    class="fixed z-50 pointer-events-none bg-popover border border-border rounded-lg shadow-lg px-3 py-2 text-[12px]"
+    style="left:{Math.min(edgeTooltip.x, window.innerWidth - 240)}px; top:{Math.min(edgeTooltip.y, window.innerHeight - 100)}px"
+  >
+    <span class="font-semibold text-foreground">{edgeTooltip.sourceName}</span>
+    <span class="text-muted-foreground mx-1.5">→ {edgeTooltip.relLabel} →</span>
+    <span class="font-semibold text-foreground">{edgeTooltip.targetName}</span>
+  </div>
+{/if}
+
+<div class="content" style="padding:0; display:flex; flex-direction:column; height:100%;">
+
+  <!-- Header bar -->
+  <div class="flex items-center justify-between gap-4 px-6 pt-5 pb-4 flex-shrink-0 flex-wrap">
     <div>
       <h1 class="text-[18px] font-semibold">{meta.label}</h1>
       <div class="text-muted-foreground text-[13px] mt-0.5">{meta.desc}</div>
@@ -68,20 +183,107 @@
   </div>
 
   {#if loading}
-    <div class="flex items-center gap-2 text-muted-foreground py-6">
+    <div class="flex items-center gap-2 text-muted-foreground py-6 px-6">
       <div class="size-4 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
       Loading…
     </div>
   {:else if error}
-    <div class="text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2">Error: {error}</div>
+    <div class="mx-6 text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2">{error}</div>
   {:else if empty}
     <div class="text-center py-16 px-6 text-muted-foreground">
       <div class="text-[40px] mb-3.5">📭</div>
       <p class="text-[14px] leading-relaxed">No application elements — import a model first.</p>
     </div>
+  {:else if isDependency}
+
+    <!-- Dependency layout: left panel + graph -->
+    <div class="flex flex-1 min-h-0 gap-0">
+
+      <!-- Left panel -->
+      <div class="flex flex-col border-r border-border w-52 flex-shrink-0 bg-card/50">
+
+        <!-- Search -->
+        <div class="px-3 pt-3 pb-2 flex-shrink-0">
+          <input
+            type="search"
+            bind:value={searchQ}
+            placeholder="Find application…"
+            class="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-[12px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+
+        <!-- Node list -->
+        <div class="overflow-y-auto flex-1 px-2 pb-2">
+          {#if selectedId}
+            <button
+              class="w-full text-left px-2 py-1 rounded text-[11px] text-primary hover:bg-primary/10 mb-1.5"
+              on:click={clearFocus}
+            >← Show all</button>
+          {/if}
+          {#each filteredNodes as node}
+            {@const lc = node.lifecycle_status}
+            {@const color = LIFECYCLE_COLORS[lc] ?? '#6b7280'}
+            <button
+              class="w-full text-left flex items-center gap-1.5 px-2 py-1.5 rounded text-[12px] transition-colors {selectedId === node.id ? 'bg-primary/10 text-primary' : 'text-foreground hover:bg-muted/50'}"
+              on:click={() => selectedId === node.id ? clearFocus() : focusNode(node.id)}
+            >
+              <span class="size-2 rounded-full flex-shrink-0" style="background:{color}"></span>
+              <span class="truncate">{node.name}</span>
+            </button>
+          {/each}
+        </div>
+
+        <!-- Relationship filter -->
+        <div class="border-t border-border px-3 py-2.5 flex-shrink-0">
+          <div class="text-[10px] font-bold uppercase tracking-wide text-muted-foreground mb-2">Relationships</div>
+          {#each REL_TYPES as rt}
+            <label class="flex items-center gap-2 py-0.5 cursor-pointer">
+              <span
+                class="size-2.5 rounded-sm flex-shrink-0 transition-opacity {activeRels.has(rt.key) ? '' : 'opacity-25'}"
+                style="background:{rt.color}"
+              ></span>
+              <input
+                type="checkbox"
+                class="sr-only"
+                checked={activeRels.has(rt.key)}
+                on:change={() => toggleRel(rt.key)}
+              />
+              <span class="text-[11px] {activeRels.has(rt.key) ? 'text-foreground' : 'text-muted-foreground'}">{rt.label}</span>
+            </label>
+          {/each}
+        </div>
+
+        <!-- Node type legend -->
+        <div class="border-t border-border px-3 py-2.5 flex-shrink-0">
+          <div class="text-[10px] font-bold uppercase tracking-wide text-muted-foreground mb-2">Node types</div>
+          {#each TIERS as tier}
+            <div class="flex items-center gap-2 py-0.5">
+              <span
+                class="w-5 h-2.5 flex-shrink-0 rounded-sm"
+                style="
+                  background: transparent;
+                  border: 1.5px {tier.style === 'dotted' ? 'dotted' : tier.style === 'dashed' ? 'dashed' : 'solid'} {tier.color};
+                "
+              ></span>
+              <span class="text-[11px] text-muted-foreground">{tier.label}</span>
+            </div>
+          {/each}
+        </div>
+      </div>
+
+      <!-- Graph canvas -->
+      <div class="flex-1 flex flex-col min-w-0">
+        <div class="cy-container flex-1" bind:this={container}></div>
+        <div class="px-4 py-1.5 text-muted-foreground text-[11px] flex-shrink-0 border-t border-border/50">
+          Scroll to zoom · Drag to pan · Click a node to highlight · Hover an edge for details
+        </div>
+      </div>
+    </div>
+
   {:else}
-    <div class="cy-container" bind:this={container}></div>
-    <div class="mt-2.5 text-muted-foreground text-[11px]">
+    <!-- Integration map (full width) -->
+    <div class="cy-container flex-1 mx-6 mb-4" bind:this={container}></div>
+    <div class="px-6 pb-3 text-muted-foreground text-[11px]">
       Scroll to zoom · Drag to pan · Click a node to highlight connections
     </div>
   {/if}

--- a/cmd/archipulse/ui/src/routes/dependency/AppNode.svelte
+++ b/cmd/archipulse/ui/src/routes/dependency/AppNode.svelte
@@ -4,44 +4,43 @@
   let { data = {} } = $props();
 
   const LIFECYCLE_STYLE = {
-    'Production':     { border: '#4ade80', text: '#4ade80', bg: '#0d2a1a' },
-    'Pilot':          { border: '#60a5fa', text: '#60a5fa', bg: '#0d1f38' },
-    'Planned':        { border: '#a78bfa', text: '#a78bfa', bg: '#1a1228' },
-    'Retiring':       { border: '#fb923c', text: '#fb923c', bg: '#2a1800' },
-    'Decommissioned': { border: '#f87171', text: '#f87171', bg: '#2a0d0d' },
+    'Production':     { border: '#22c55e', text: '#86efac', bg: '#14352a' },
+    'Pilot':          { border: '#3b82f6', text: '#93c5fd', bg: '#172444' },
+    'Planned':        { border: '#8b5cf6', text: '#c4b5fd', bg: '#22173a' },
+    'Retiring':       { border: '#f97316', text: '#fdba74', bg: '#3a2010' },
+    'Decommissioned': { border: '#ef4444', text: '#fca5a5', bg: '#3a1414' },
   };
-  const DEFAULT_STYLE = { border: '#3d59a1', text: '#7aa2f7', bg: '#131929' };
+  const DEFAULT_STYLE = { border: '#4a6fa5', text: '#93b4f0', bg: '#1e2d45' };
 
   const style       = $derived(LIFECYCLE_STYLE[data.lifecycle] ?? DEFAULT_STYLE);
   const isComponent = $derived(data.tier === 'component');
-  const borderStyle = $derived(
+  const bw          = $derived(isComponent ? '2.5px' : '1.5px');
+  const bs          = $derived(
     data.tier === 'service'   ? 'dashed' :
     data.tier === 'interface' || data.tier === 'function' ? 'dotted' : 'solid'
   );
 </script>
 
-<div
-  style="
-    background: {style.bg};
-    border: {isComponent ? '2.5px' : '1.5px'} {borderStyle} {style.border};
-    color: {style.text};
-    font-weight: {isComponent ? '700' : '400'};
-    font-size: {isComponent ? '12px' : '11px'};
-    min-width: {isComponent ? '140px' : '110px'};
-    max-width: {isComponent ? '180px' : '156px'};
-    padding: {isComponent ? '9px 13px' : '6px 10px'};
-    border-radius: 8px;
-    text-align: center;
-    line-height: 1.3;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.4);
-    cursor: default;
-    user-select: none;
-  "
->
-  <Handle type="target" position={Position.Left}  style="background:{style.border}; width:8px; height:8px; border:none;" />
+<div style="
+  background:{style.bg};
+  border:{bw} {bs} {style.border};
+  color:{style.text};
+  font-weight:{isComponent ? 700 : 400};
+  font-size:{isComponent ? '12px' : '11px'};
+  min-width:{isComponent ? '148px' : '118px'};
+  max-width:{isComponent ? '190px' : '160px'};
+  padding:{isComponent ? '10px 14px' : '7px 11px'};
+  border-radius:8px;
+  text-align:center;
+  line-height:1.35;
+  box-shadow:0 2px 12px rgba(0,0,0,0.5);
+  cursor:default;
+  user-select:none;
+">
+  <Handle type="target" position={Position.Left}  style="background:{style.border}; width:9px; height:9px; border:none; border-radius:50%;" />
   <div style="word-break:break-word;">{data.label}</div>
   {#if data.badge && data.badge !== 'Component'}
-    <div style="font-size:9px; opacity:0.55; margin-top:2px; font-weight:400;">{data.badge}</div>
+    <div style="font-size:9px; opacity:0.6; margin-top:3px; font-weight:400; letter-spacing:0.3px;">{data.badge}</div>
   {/if}
-  <Handle type="source" position={Position.Right} style="background:{style.border}; width:8px; height:8px; border:none;" />
+  <Handle type="source" position={Position.Right} style="background:{style.border}; width:9px; height:9px; border:none; border-radius:50%;" />
 </div>

--- a/cmd/archipulse/ui/src/routes/dependency/AppNode.svelte
+++ b/cmd/archipulse/ui/src/routes/dependency/AppNode.svelte
@@ -1,0 +1,47 @@
+<script>
+  import { Handle, Position } from '@xyflow/svelte';
+
+  let { data = {} } = $props();
+
+  const LIFECYCLE_STYLE = {
+    'Production':     { border: '#4ade80', text: '#4ade80', bg: '#0d2a1a' },
+    'Pilot':          { border: '#60a5fa', text: '#60a5fa', bg: '#0d1f38' },
+    'Planned':        { border: '#a78bfa', text: '#a78bfa', bg: '#1a1228' },
+    'Retiring':       { border: '#fb923c', text: '#fb923c', bg: '#2a1800' },
+    'Decommissioned': { border: '#f87171', text: '#f87171', bg: '#2a0d0d' },
+  };
+  const DEFAULT_STYLE = { border: '#3d59a1', text: '#7aa2f7', bg: '#131929' };
+
+  const style       = $derived(LIFECYCLE_STYLE[data.lifecycle] ?? DEFAULT_STYLE);
+  const isComponent = $derived(data.tier === 'component');
+  const borderStyle = $derived(
+    data.tier === 'service'   ? 'dashed' :
+    data.tier === 'interface' || data.tier === 'function' ? 'dotted' : 'solid'
+  );
+</script>
+
+<div
+  style="
+    background: {style.bg};
+    border: {isComponent ? '2.5px' : '1.5px'} {borderStyle} {style.border};
+    color: {style.text};
+    font-weight: {isComponent ? '700' : '400'};
+    font-size: {isComponent ? '12px' : '11px'};
+    min-width: {isComponent ? '140px' : '110px'};
+    max-width: {isComponent ? '180px' : '156px'};
+    padding: {isComponent ? '9px 13px' : '6px 10px'};
+    border-radius: 8px;
+    text-align: center;
+    line-height: 1.3;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+    cursor: default;
+    user-select: none;
+  "
+>
+  <Handle type="target" position={Position.Left}  style="background:{style.border}; width:8px; height:8px; border:none;" />
+  <div style="word-break:break-word;">{data.label}</div>
+  {#if data.badge && data.badge !== 'Component'}
+    <div style="font-size:9px; opacity:0.55; margin-top:2px; font-weight:400;">{data.badge}</div>
+  {/if}
+  <Handle type="source" position={Position.Right} style="background:{style.border}; width:8px; height:8px; border:none;" />
+</div>

--- a/cmd/archipulse/ui/src/routes/dependency/AppNode.svelte
+++ b/cmd/archipulse/ui/src/routes/dependency/AppNode.svelte
@@ -39,7 +39,7 @@
 ">
   <Handle type="target" position={Position.Left}  style="background:{style.border}; width:9px; height:9px; border:none; border-radius:50%;" />
   <div style="word-break:break-word;">{data.label}</div>
-  {#if data.badge && data.badge !== 'Component'}
+  {#if data.badge}
     <div style="font-size:9px; opacity:0.6; margin-top:3px; font-weight:400; letter-spacing:0.3px;">{data.badge}</div>
   {/if}
   <Handle type="source" position={Position.Right} style="background:{style.border}; width:9px; height:9px; border:none; border-radius:50%;" />

--- a/cmd/archipulse/ui/src/routes/dependency/DependencyGraphView.svelte
+++ b/cmd/archipulse/ui/src/routes/dependency/DependencyGraphView.svelte
@@ -251,7 +251,7 @@
     <div class="flex flex-1 min-h-0">
 
       <!-- Left panel -->
-      <div class="flex flex-col border-r border-border w-52 flex-shrink-0 bg-card/50 overflow-hidden">
+      <div class="flex flex-col border-r border-border w-52 flex-shrink-0 bg-card/50 overflow-hidden min-h-0 h-full">
 
         <div class="px-3 pt-3 pb-2 flex-shrink-0">
           <input type="search" bind:value={searchQ} placeholder="Find application…"

--- a/cmd/archipulse/ui/src/routes/dependency/DependencyGraphView.svelte
+++ b/cmd/archipulse/ui/src/routes/dependency/DependencyGraphView.svelte
@@ -32,8 +32,8 @@
   let error    = $state(null);
 
   // ── Panel ─────────────────────────────────────────────────────────────────
-  let searchQ    = $state('');
-  let selectedId = $state(null);
+  let searchQ      = $state('');
+  let selectedApps = $state(new Set()); // multi-select set of app IDs
 
   // ── Edge tooltip ──────────────────────────────────────────────────────────
   let tooltip = $state(null);
@@ -153,24 +153,30 @@
     setTimeout(fit, 80);
   }
 
-  // ── Focus / clear ─────────────────────────────────────────────────────────
-  function neighbourIds(id) {
-    const ids = new Set([id]);
+  // ── Multi-selection helpers ───────────────────────────────────────────────
+  function neighboursOfMany(ids) {
+    const result = new Set(ids);
     allEdges.forEach(e => {
-      if (e.source === id) ids.add(e.target);
-      if (e.target === id) ids.add(e.source);
+      if (ids.has(e.source)) result.add(e.target);
+      if (ids.has(e.target)) result.add(e.source);
     });
-    return ids;
+    return result;
   }
 
-  function focusNode(id) {
-    selectedId = id;
-    applyLayout(neighbourIds(id));
+  function currentVisibleIds() {
+    return selectedApps.size > 0 ? neighboursOfMany(selectedApps) : null;
+  }
+
+  function toggleApp(id) {
+    const next = new Set(selectedApps);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    selectedApps = next;
+    applyLayout(next.size > 0 ? neighboursOfMany(next) : null);
   }
 
   function clearFocus() {
-    selectedId = null;
-    applyLayout();
+    selectedApps = new Set();
+    applyLayout(null);
   }
 
   // ── Rel filter toggle ─────────────────────────────────────────────────────
@@ -179,7 +185,7 @@
     if (next.has(key)) { if (next.size === 1) return; next.delete(key); }
     else next.add(key);
     activeRels = next;
-    applyLayout(selectedId ? neighbourIds(selectedId) : null);
+    applyLayout(currentVisibleIds());
   }
 
   // ── Edge events (xyflow passes (event, edge) directly) ────────────────────
@@ -253,20 +259,37 @@
       <!-- Left panel -->
       <div class="flex flex-col border-r border-border w-52 flex-shrink-0 bg-card/50 overflow-hidden min-h-0 h-full">
 
+        <!-- Search -->
         <div class="px-3 pt-3 pb-2 flex-shrink-0">
           <input type="search" bind:value={searchQ} placeholder="Find application…"
             class="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-[12px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary" />
         </div>
 
-        <div class="overflow-y-auto flex-1 px-2 pb-2">
-          {#if selectedId}
-            <button class="w-full text-left px-2 py-1 rounded text-[11px] text-primary hover:bg-primary/10 mb-1.5" onclick={clearFocus}>← Show all</button>
-          {/if}
+        <!-- Selected chips -->
+        {#if selectedApps.size > 0}
+          <div class="px-2 pb-2 flex-shrink-0 flex flex-wrap gap-1 border-b border-border">
+            {#each [...selectedApps] as id}
+              {@const node = allNodes.find(n => n.id === id)}
+              {@const color = LIFECYCLE_COLORS[node?.lifecycle_status] ?? '#6b7280'}
+              <span class="inline-flex items-center gap-1 pl-1.5 pr-1 py-0.5 rounded-full text-[11px] font-medium"
+                    style="background:{color}22; border:1px solid {color}55; color:{color};">
+                <span class="max-w-[120px] truncate">{node?.name ?? id}</span>
+                <button class="flex-shrink-0 rounded-full hover:bg-white/20 p-0.5 leading-none"
+                        onclick={() => toggleApp(id)}>×</button>
+              </span>
+            {/each}
+            <button class="text-[10px] text-muted-foreground hover:text-foreground px-1" onclick={clearFocus}>clear</button>
+          </div>
+        {/if}
+
+        <!-- App list (scrollable) -->
+        <div class="overflow-y-auto flex-1 px-2 py-1">
           {#each filteredNodes as node}
             {@const color = LIFECYCLE_COLORS[node.lifecycle_status] ?? '#6b7280'}
+            {@const selected = selectedApps.has(node.id)}
             <button
-              class="w-full text-left flex items-center gap-1.5 px-2 py-1.5 rounded text-[12px] transition-colors {selectedId === node.id ? 'bg-primary/10 text-primary' : 'text-foreground hover:bg-muted/50'}"
-              onclick={() => selectedId === node.id ? clearFocus() : focusNode(node.id)}
+              class="w-full text-left flex items-center gap-1.5 px-2 py-1.5 rounded text-[12px] transition-colors {selected ? 'bg-primary/10 text-primary' : 'text-foreground hover:bg-muted/50'}"
+              onclick={() => toggleApp(node.id)}
             >
               <span class="size-2 rounded-full flex-shrink-0" style="background:{color}"></span>
               <span class="truncate">{node.name}</span>
@@ -274,7 +297,7 @@
           {/each}
         </div>
 
-        <!-- Relationship filters -->
+        <!-- Relationship filters — pinned at bottom -->
         <div class="border-t border-border px-3 py-2.5 flex-shrink-0">
           <div class="text-[10px] font-bold uppercase tracking-wide text-muted-foreground mb-1.5">Relationships</div>
           {#each REL_TYPES as rt}

--- a/cmd/archipulse/ui/src/routes/dependency/DependencyGraphView.svelte
+++ b/cmd/archipulse/ui/src/routes/dependency/DependencyGraphView.svelte
@@ -221,7 +221,7 @@
   </div>
 {/if}
 
-<div class="content" style="padding:0; display:flex; flex-direction:column; height:100%;">
+<div style="position:fixed; top:var(--nav-h); left:var(--sidebar-w); right:0; bottom:0; display:flex; flex-direction:column; overflow:hidden; background:var(--bg);">
 
   <!-- Header -->
   <div class="flex items-center justify-between gap-4 px-6 pt-5 pb-4 flex-shrink-0">

--- a/cmd/archipulse/ui/src/routes/dependency/DependencyGraphView.svelte
+++ b/cmd/archipulse/ui/src/routes/dependency/DependencyGraphView.svelte
@@ -1,0 +1,336 @@
+<script>
+  import { onMount } from 'svelte';
+  import {
+    SvelteFlow,
+    Controls,
+    MiniMap,
+    Background,
+    BackgroundVariant,
+  } from '@xyflow/svelte';
+  import '@xyflow/svelte/dist/style.css';
+  import dagre from '@dagrejs/dagre';
+  import { api } from '../../lib/api.js';
+  import AppNode from './AppNode.svelte';
+
+  let { params = {} } = $props();
+  $effect(() => { wsId = params.wsId; });
+  let wsId = $state('');
+
+  // ── XyFlow state ─────────────────────────────────────────────────────────
+  let nodes = $state([]);
+  let edges = $state([]);
+  const nodeTypes = { appNode: AppNode };
+
+  // fitView called via the flow instance obtained from oninit
+  let flowInstance = $state(null);
+  function fit() { flowInstance?.fitView({ padding: 0.12, duration: 300 }); }
+
+  // ── Data ──────────────────────────────────────────────────────────────────
+  let allNodes   = $state([]);
+  let allEdges   = $state([]);
+  let loading    = $state(true);
+  let error      = $state(null);
+
+  // ── Panel state ───────────────────────────────────────────────────────────
+  let searchQ    = $state('');
+  let selectedId = $state(null);
+
+  // ── Tooltip ───────────────────────────────────────────────────────────────
+  let tooltip = $state(null);
+
+  // ── Relationship filters ──────────────────────────────────────────────────
+  const REL_TYPES = [
+    { key: 'serving',     label: 'Serves',      color: '#7aa2f7' },
+    { key: 'flow',        label: 'Data Flow',    color: '#9ece6a' },
+    { key: 'access',      label: 'Accesses',     color: '#bb9af7' },
+    { key: 'triggering',  label: 'Triggers',     color: '#E85D3A' },
+    { key: 'association', label: 'Associated',   color: '#6b7280' },
+  ];
+  let activeRels = $state(new Set(REL_TYPES.map(r => r.key)));
+
+  const LIFECYCLE_COLORS = {
+    'Production':     '#4ade80',
+    'Pilot':          '#60a5fa',
+    'Planned':        '#a78bfa',
+    'Retiring':       '#fb923c',
+    'Decommissioned': '#f87171',
+  };
+
+  const REL_META = {
+    serving:     { label: 'Serves',         color: '#7aa2f7', animated: false },
+    flow:        { label: 'Data Flow',       color: '#9ece6a', animated: true  },
+    access:      { label: 'Accesses',        color: '#bb9af7', animated: true  },
+    triggering:  { label: 'Triggers',        color: '#E85D3A', animated: false },
+    association: { label: 'Associated with', color: '#6b7280', animated: false },
+  };
+
+  function relKey(rel) {
+    const r = (rel || '').toLowerCase();
+    if (r.includes('serving'))    return 'serving';
+    if (r.includes('flow'))       return 'flow';
+    if (r.includes('access'))     return 'access';
+    if (r.includes('triggering')) return 'triggering';
+    return 'association';
+  }
+
+  function nodeTier(type) {
+    if (type === 'ApplicationComponent') return 'component';
+    if (type === 'ApplicationService')   return 'service';
+    if (type === 'ApplicationInterface') return 'interface';
+    if (type === 'ApplicationFunction')  return 'function';
+    return 'other';
+  }
+
+  // ── Dagre layout ──────────────────────────────────────────────────────────
+  function layoutNodes(rawNodes, rawEdges, visibleIds = null) {
+    const g = new dagre.graphlib.Graph();
+    g.setDefaultEdgeLabel(() => ({}));
+    g.setGraph({ rankdir: 'LR', nodesep: 32, ranksep: 110, marginx: 48, marginy: 48 });
+
+    const nw = (tier) => tier === 'component' ? 180 : 150;
+    const nh = (tier) => tier === 'component' ? 48  : 38;
+    const nodeSet = visibleIds ? new Set(visibleIds) : null;
+
+    rawNodes.forEach(n => {
+      if (nodeSet && !nodeSet.has(n.id)) return;
+      const tier = nodeTier(n.type);
+      g.setNode(n.id, { width: nw(tier), height: nh(tier) });
+    });
+
+    rawEdges.forEach(e => {
+      if (!activeRels.has(relKey(e.relationship))) return;
+      if (nodeSet && (!nodeSet.has(e.source) || !nodeSet.has(e.target))) return;
+      if (e.source === e.target) return;
+      if (g.hasNode(e.source) && g.hasNode(e.target)) g.setEdge(e.source, e.target);
+    });
+
+    dagre.layout(g);
+
+    const nameById = Object.fromEntries(rawNodes.map(n => [n.id, n.name]));
+
+    const flowNodes = rawNodes
+      .filter(n => !nodeSet || nodeSet.has(n.id))
+      .map(n => {
+        const gn   = g.node(n.id);
+        const tier = nodeTier(n.type);
+        return {
+          id:       n.id,
+          type:     'appNode',
+          position: gn ? { x: gn.x - nw(tier) / 2, y: gn.y - nh(tier) / 2 } : { x: 0, y: 0 },
+          data:     { label: n.name, badge: n.type.replace('Application', ''), tier, lifecycle: n.lifecycle_status },
+        };
+      });
+
+    const flowEdges = rawEdges
+      .filter(e => {
+        if (!activeRels.has(relKey(e.relationship))) return false;
+        if (nodeSet && (!nodeSet.has(e.source) || !nodeSet.has(e.target))) return false;
+        return e.source !== e.target;
+      })
+      .map(e => {
+        const rk   = relKey(e.relationship);
+        const meta = REL_META[rk];
+        return {
+          id:        e.id,
+          source:    e.source,
+          target:    e.target,
+          animated:  meta.animated,
+          style:     `stroke:${meta.color}; stroke-width:1.5px;`,
+          markerEnd: { type: 'arrowclosed', color: meta.color, width: 16, height: 16 },
+          data:      { relLabel: meta.label, sourceName: nameById[e.source] ?? '', targetName: nameById[e.target] ?? '', rk },
+        };
+      });
+
+    return { flowNodes, flowEdges };
+  }
+
+  function applyLayout(visibleIds = null) {
+    const { flowNodes, flowEdges } = layoutNodes(allNodes, allEdges, visibleIds);
+    nodes = flowNodes;
+    edges = flowEdges;
+    setTimeout(fit, 60);
+  }
+
+  // ── Focus / clear ─────────────────────────────────────────────────────────
+  function neighbourIds(id) {
+    const ids = new Set([id]);
+    allEdges.forEach(e => {
+      if (e.source === id) ids.add(e.target);
+      if (e.target === id) ids.add(e.source);
+    });
+    return ids;
+  }
+
+  function focusNode(id) {
+    selectedId = id;
+    applyLayout(neighbourIds(id));
+  }
+
+  function clearFocus() {
+    selectedId = null;
+    applyLayout();
+  }
+
+  // ── Rel filter toggle ─────────────────────────────────────────────────────
+  function toggleRel(key) {
+    const next = new Set(activeRels);
+    if (next.has(key)) { if (next.size === 1) return; next.delete(key); }
+    else next.add(key);
+    activeRels = next;
+    applyLayout(selectedId ? neighbourIds(selectedId) : null);
+  }
+
+  // ── Edge events ────────────────────────────────────────────────────────────
+  function onEdgeMouseEnter(e) {
+    const d = e.detail?.edge?.data;
+    if (!d) return;
+    tooltip = { text: `${d.sourceName} → ${d.relLabel} → ${d.targetName}`, x: e.detail?.event?.clientX ?? 0, y: e.detail?.event?.clientY ?? 0 };
+  }
+  function onEdgeMouseMove(e) {
+    if (tooltip) tooltip = { ...tooltip, x: e.detail?.event?.clientX ?? tooltip.x, y: e.detail?.event?.clientY ?? tooltip.y };
+  }
+  function onEdgeMouseLeave() { tooltip = null; }
+
+  // ── Panel filter ──────────────────────────────────────────────────────────
+  const filteredNodes = $derived(
+    searchQ ? allNodes.filter(n => n.name.toLowerCase().includes(searchQ.toLowerCase())) : allNodes
+  );
+
+  // ── Load ──────────────────────────────────────────────────────────────────
+  onMount(async () => {
+    try {
+      const data = await api.get('/workspaces/' + params.wsId + '/views/application-dependency/graph');
+      allNodes = data.nodes ?? [];
+      allEdges = data.edges ?? [];
+      applyLayout();
+    } catch (e) {
+      error = e.message;
+    } finally {
+      loading = false;
+    }
+  });
+</script>
+
+{#if tooltip}
+  <div class="fixed z-50 pointer-events-none bg-popover border border-border rounded-lg shadow-lg px-3 py-2 text-[12px] text-foreground max-w-xs"
+       style="left:{Math.min(tooltip.x + 14, window.innerWidth - 280)}px; top:{tooltip.y - 36}px">
+    {tooltip.text}
+  </div>
+{/if}
+
+<div class="content" style="padding:0; display:flex; flex-direction:column; height:100%;">
+
+  <!-- Header -->
+  <div class="flex items-center justify-between gap-4 px-6 pt-5 pb-4 flex-shrink-0">
+    <div>
+      <h1 class="text-[18px] font-semibold">Dependency Graph</h1>
+      <div class="text-muted-foreground text-[13px] mt-0.5">Interactive application dependency map</div>
+    </div>
+    <button class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] hover:bg-muted transition-colors" onclick={fit}>⊡ Fit</button>
+  </div>
+
+  {#if loading}
+    <div class="flex items-center gap-2 text-muted-foreground py-6 px-6">
+      <div class="size-4 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
+      Loading…
+    </div>
+  {:else if error}
+    <div class="mx-6 text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2">{error}</div>
+  {:else if allNodes.length === 0}
+    <div class="text-center py-16 px-6 text-muted-foreground">
+      <div class="text-[40px] mb-3.5">📭</div>
+      <p class="text-[14px]">No application elements — import a model first.</p>
+    </div>
+  {:else}
+    <div class="flex flex-1 min-h-0">
+
+      <!-- Left panel -->
+      <div class="flex flex-col border-r border-border w-52 flex-shrink-0 bg-card/50 overflow-hidden">
+        <div class="px-3 pt-3 pb-2 flex-shrink-0">
+          <input type="search" bind:value={searchQ} placeholder="Find application…"
+            class="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-[12px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary" />
+        </div>
+
+        <div class="overflow-y-auto flex-1 px-2 pb-2">
+          {#if selectedId}
+            <button class="w-full text-left px-2 py-1 rounded text-[11px] text-primary hover:bg-primary/10 mb-1.5" onclick={clearFocus}>← Show all</button>
+          {/if}
+          {#each filteredNodes as node}
+            {@const color = LIFECYCLE_COLORS[node.lifecycle_status] ?? '#6b7280'}
+            <button
+              class="w-full text-left flex items-center gap-1.5 px-2 py-1.5 rounded text-[12px] transition-colors {selectedId === node.id ? 'bg-primary/10 text-primary' : 'text-foreground hover:bg-muted/50'}"
+              onclick={() => selectedId === node.id ? clearFocus() : focusNode(node.id)}
+            >
+              <span class="size-2 rounded-full flex-shrink-0" style="background:{color}"></span>
+              <span class="truncate">{node.name}</span>
+            </button>
+          {/each}
+        </div>
+
+        <!-- Rel filters -->
+        <div class="border-t border-border px-3 py-2.5 flex-shrink-0">
+          <div class="text-[10px] font-bold uppercase tracking-wide text-muted-foreground mb-1.5">Relationships</div>
+          {#each REL_TYPES as rt}
+            <label class="flex items-center gap-2 py-0.5 cursor-pointer select-none">
+              <span class="size-2.5 rounded-sm flex-shrink-0 transition-opacity {activeRels.has(rt.key) ? '' : 'opacity-20'}" style="background:{rt.color}"></span>
+              <input type="checkbox" class="sr-only" checked={activeRels.has(rt.key)} onchange={() => toggleRel(rt.key)} />
+              <span class="text-[11px] {activeRels.has(rt.key) ? 'text-foreground' : 'text-muted-foreground'}">{rt.label}</span>
+            </label>
+          {/each}
+        </div>
+      </div>
+
+      <!-- Flow canvas -->
+      <div class="flex-1 relative" style="background:#0d1117;">
+        <SvelteFlow
+          {nodes}
+          {edges}
+          {nodeTypes}
+          fitView
+          minZoom={0.1}
+          maxZoom={3}
+          proOptions={{ hideAttribution: true }}
+          oninit={(instance) => { flowInstance = instance; }}
+          onedgemouseenter={onEdgeMouseEnter}
+          onedgemousemove={onEdgeMouseMove}
+          onedgemouseleave={onEdgeMouseLeave}
+          style="background:#0d1117;"
+        >
+          <Controls position="bottom-right" style="background:#1a1f2e; border-color:#2a2d3e;" />
+          <MiniMap
+            position="bottom-right"
+            style="background:#1a1f2e; border:1px solid #2a2d3e; margin-bottom:44px;"
+            nodeColor={(n) => LIFECYCLE_COLORS[n.data?.lifecycle] ?? '#3d59a1'}
+            maskColor="rgba(0,0,0,0.6)"
+          />
+          <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="#1e2130" />
+        </SvelteFlow>
+
+        <!-- Legend: bottom-left corner over the canvas -->
+        <div class="absolute bottom-4 left-4 z-10 pointer-events-none rounded-lg px-3.5 py-3 text-[11px]"
+             style="background:rgba(13,17,23,0.88); border:1px solid #2a2d3e;">
+          <div class="text-[10px] font-bold uppercase tracking-wide text-muted-foreground mb-2">Node type</div>
+          {#each [
+            { label: 'Component', bStyle: 'solid',  color: '#7aa2f7', bold: true  },
+            { label: 'Service',   bStyle: 'dashed', color: '#60a5fa', bold: false },
+            { label: 'Interface', bStyle: 'dotted', color: '#38bdf8', bold: false },
+            { label: 'Function',  bStyle: 'dotted', color: '#818cf8', bold: false },
+          ] as t}
+            <div class="flex items-center gap-2 mb-1">
+              <div class="flex-shrink-0 rounded-sm" style="width:18px; height:11px; border:1.5px {t.bStyle} {t.color}; background:transparent;"></div>
+              <span style="color:{t.bold ? '#c9d1d9' : '#8b8fa8'}; font-weight:{t.bold ? 600 : 400};">{t.label}</span>
+            </div>
+          {/each}
+          <div class="text-[10px] font-bold uppercase tracking-wide text-muted-foreground mt-3 mb-2">Lifecycle</div>
+          {#each Object.entries(LIFECYCLE_COLORS) as [lc, color]}
+            <div class="flex items-center gap-2 mb-1">
+              <span class="size-2 rounded-full flex-shrink-0" style="background:{color}"></span>
+              <span class="text-muted-foreground">{lc}</span>
+            </div>
+          {/each}
+        </div>
+      </div>
+
+    </div>
+  {/if}
+</div>

--- a/cmd/archipulse/ui/src/routes/dependency/DependencyGraphView.svelte
+++ b/cmd/archipulse/ui/src/routes/dependency/DependencyGraphView.svelte
@@ -6,36 +6,36 @@
     MiniMap,
     Background,
     BackgroundVariant,
+    Panel,
   } from '@xyflow/svelte';
   import '@xyflow/svelte/dist/style.css';
   import dagre from '@dagrejs/dagre';
   import { api } from '../../lib/api.js';
   import AppNode from './AppNode.svelte';
+  import FlowControls from './FlowControls.svelte';
 
   let { params = {} } = $props();
-  $effect(() => { wsId = params.wsId; });
-  let wsId = $state('');
 
-  // ── XyFlow state ─────────────────────────────────────────────────────────
+  // ── XyFlow state ──────────────────────────────────────────────────────────
   let nodes = $state([]);
   let edges = $state([]);
   const nodeTypes = { appNode: AppNode };
 
-  // fitView called via the flow instance obtained from oninit
-  let flowInstance = $state(null);
-  function fit() { flowInstance?.fitView({ padding: 0.12, duration: 300 }); }
+  // fitView comes from useSvelteFlow() via child FlowControls
+  let fitView = $state(null);
+  function fit() { fitView?.({ padding: 0.12, duration: 300 }); }
 
   // ── Data ──────────────────────────────────────────────────────────────────
-  let allNodes   = $state([]);
-  let allEdges   = $state([]);
-  let loading    = $state(true);
-  let error      = $state(null);
+  let allNodes = $state([]);
+  let allEdges = $state([]);
+  let loading  = $state(true);
+  let error    = $state(null);
 
-  // ── Panel state ───────────────────────────────────────────────────────────
+  // ── Panel ─────────────────────────────────────────────────────────────────
   let searchQ    = $state('');
   let selectedId = $state(null);
 
-  // ── Tooltip ───────────────────────────────────────────────────────────────
+  // ── Edge tooltip ──────────────────────────────────────────────────────────
   let tooltip = $state(null);
 
   // ── Relationship filters ──────────────────────────────────────────────────
@@ -49,11 +49,11 @@
   let activeRels = $state(new Set(REL_TYPES.map(r => r.key)));
 
   const LIFECYCLE_COLORS = {
-    'Production':     '#4ade80',
-    'Pilot':          '#60a5fa',
-    'Planned':        '#a78bfa',
-    'Retiring':       '#fb923c',
-    'Decommissioned': '#f87171',
+    'Production':     '#22c55e',
+    'Pilot':          '#3b82f6',
+    'Planned':        '#8b5cf6',
+    'Retiring':       '#f97316',
+    'Decommissioned': '#ef4444',
   };
 
   const REL_META = {
@@ -85,10 +85,10 @@
   function layoutNodes(rawNodes, rawEdges, visibleIds = null) {
     const g = new dagre.graphlib.Graph();
     g.setDefaultEdgeLabel(() => ({}));
-    g.setGraph({ rankdir: 'LR', nodesep: 32, ranksep: 110, marginx: 48, marginy: 48 });
+    g.setGraph({ rankdir: 'LR', nodesep: 36, ranksep: 120, marginx: 60, marginy: 60 });
 
-    const nw = (tier) => tier === 'component' ? 180 : 150;
-    const nh = (tier) => tier === 'component' ? 48  : 38;
+    const nw = t => t === 'component' ? 190 : 158;
+    const nh = t => t === 'component' ? 52  : 42;
     const nodeSet = visibleIds ? new Set(visibleIds) : null;
 
     rawNodes.forEach(n => {
@@ -116,6 +116,7 @@
         return {
           id:       n.id,
           type:     'appNode',
+          draggable: false,
           position: gn ? { x: gn.x - nw(tier) / 2, y: gn.y - nh(tier) / 2 } : { x: 0, y: 0 },
           data:     { label: n.name, badge: n.type.replace('Application', ''), tier, lifecycle: n.lifecycle_status },
         };
@@ -135,8 +136,8 @@
           source:    e.source,
           target:    e.target,
           animated:  meta.animated,
-          style:     `stroke:${meta.color}; stroke-width:1.5px;`,
-          markerEnd: { type: 'arrowclosed', color: meta.color, width: 16, height: 16 },
+          style:     `stroke:${meta.color}; stroke-width:1.8px;`,
+          markerEnd: { type: 'arrowclosed', color: meta.color, width: 14, height: 14 },
           data:      { relLabel: meta.label, sourceName: nameById[e.source] ?? '', targetName: nameById[e.target] ?? '', rk },
         };
       });
@@ -148,7 +149,8 @@
     const { flowNodes, flowEdges } = layoutNodes(allNodes, allEdges, visibleIds);
     nodes = flowNodes;
     edges = flowEdges;
-    setTimeout(fit, 60);
+    // Fit after a short delay to ensure SvelteFlow has rendered new positions.
+    setTimeout(fit, 80);
   }
 
   // ── Focus / clear ─────────────────────────────────────────────────────────
@@ -180,18 +182,18 @@
     applyLayout(selectedId ? neighbourIds(selectedId) : null);
   }
 
-  // ── Edge events ────────────────────────────────────────────────────────────
-  function onEdgeMouseEnter(e) {
-    const d = e.detail?.edge?.data;
+  // ── Edge events (xyflow passes (event, edge) directly) ────────────────────
+  function onEdgeMouseEnter(event, edge) {
+    const d = edge?.data;
     if (!d) return;
-    tooltip = { text: `${d.sourceName} → ${d.relLabel} → ${d.targetName}`, x: e.detail?.event?.clientX ?? 0, y: e.detail?.event?.clientY ?? 0 };
+    tooltip = { text: `${d.sourceName}  →  ${d.relLabel}  →  ${d.targetName}`, x: event.clientX, y: event.clientY };
   }
-  function onEdgeMouseMove(e) {
-    if (tooltip) tooltip = { ...tooltip, x: e.detail?.event?.clientX ?? tooltip.x, y: e.detail?.event?.clientY ?? tooltip.y };
+  function onEdgeMouseMove(event) {
+    if (tooltip) tooltip = { ...tooltip, x: event.clientX, y: event.clientY };
   }
   function onEdgeMouseLeave() { tooltip = null; }
 
-  // ── Panel filter ──────────────────────────────────────────────────────────
+  // ── Panel list ────────────────────────────────────────────────────────────
   const filteredNodes = $derived(
     searchQ ? allNodes.filter(n => n.name.toLowerCase().includes(searchQ.toLowerCase())) : allNodes
   );
@@ -211,9 +213,10 @@
   });
 </script>
 
+<!-- Edge tooltip -->
 {#if tooltip}
-  <div class="fixed z-50 pointer-events-none bg-popover border border-border rounded-lg shadow-lg px-3 py-2 text-[12px] text-foreground max-w-xs"
-       style="left:{Math.min(tooltip.x + 14, window.innerWidth - 280)}px; top:{tooltip.y - 36}px">
+  <div class="fixed z-50 pointer-events-none rounded-lg shadow-xl px-3 py-2 text-[12px] text-foreground max-w-sm"
+       style="left:{Math.min(tooltip.x + 16, window.innerWidth - 320)}px; top:{tooltip.y - 40}px; background:rgba(22,27,34,0.95); border:1px solid #30363d;">
     {tooltip.text}
   </div>
 {/if}
@@ -226,7 +229,10 @@
       <h1 class="text-[18px] font-semibold">Dependency Graph</h1>
       <div class="text-muted-foreground text-[13px] mt-0.5">Interactive application dependency map</div>
     </div>
-    <button class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] hover:bg-muted transition-colors" onclick={fit}>⊡ Fit</button>
+    <button
+      class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] hover:bg-muted transition-colors"
+      onclick={fit}
+    >⊡ Fit</button>
   </div>
 
   {#if loading}
@@ -246,6 +252,7 @@
 
       <!-- Left panel -->
       <div class="flex flex-col border-r border-border w-52 flex-shrink-0 bg-card/50 overflow-hidden">
+
         <div class="px-3 pt-3 pb-2 flex-shrink-0">
           <input type="search" bind:value={searchQ} placeholder="Find application…"
             class="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-[12px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary" />
@@ -267,7 +274,7 @@
           {/each}
         </div>
 
-        <!-- Rel filters -->
+        <!-- Relationship filters -->
         <div class="border-t border-border px-3 py-2.5 flex-shrink-0">
           <div class="text-[10px] font-bold uppercase tracking-wide text-muted-foreground mb-1.5">Relationships</div>
           {#each REL_TYPES as rt}
@@ -281,54 +288,61 @@
       </div>
 
       <!-- Flow canvas -->
-      <div class="flex-1 relative" style="background:#0d1117;">
+      <div class="flex-1 min-w-0" style="background:#161b22;">
         <SvelteFlow
           {nodes}
           {edges}
           {nodeTypes}
+          nodesDraggable={false}
           fitView
-          minZoom={0.1}
+          minZoom={0.08}
           maxZoom={3}
           proOptions={{ hideAttribution: true }}
-          oninit={(instance) => { flowInstance = instance; }}
           onedgemouseenter={onEdgeMouseEnter}
           onedgemousemove={onEdgeMouseMove}
           onedgemouseleave={onEdgeMouseLeave}
-          style="background:#0d1117;"
+          style="background:#161b22; width:100%; height:100%;"
         >
-          <Controls position="bottom-right" style="background:#1a1f2e; border-color:#2a2d3e;" />
+          <!-- Registers fitView from inside the SvelteFlow context -->
+          <FlowControls onReady={(fn) => { fitView = fn; }} />
+
+          <Controls showInteractive={false} style="background:#1c2128; border:1px solid #30363d; border-radius:8px;" />
+
           <MiniMap
             position="bottom-right"
-            style="background:#1a1f2e; border:1px solid #2a2d3e; margin-bottom:44px;"
-            nodeColor={(n) => LIFECYCLE_COLORS[n.data?.lifecycle] ?? '#3d59a1'}
-            maskColor="rgba(0,0,0,0.6)"
+            style="background:#1c2128; border:1px solid #30363d; border-radius:8px; margin-bottom:48px;"
+            nodeColor={(n) => LIFECYCLE_COLORS[n.data?.lifecycle] ?? '#4a6fa5'}
+            maskColor="rgba(0,0,0,0.55)"
           />
-          <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="#1e2130" />
-        </SvelteFlow>
 
-        <!-- Legend: bottom-left corner over the canvas -->
-        <div class="absolute bottom-4 left-4 z-10 pointer-events-none rounded-lg px-3.5 py-3 text-[11px]"
-             style="background:rgba(13,17,23,0.88); border:1px solid #2a2d3e;">
-          <div class="text-[10px] font-bold uppercase tracking-wide text-muted-foreground mb-2">Node type</div>
-          {#each [
-            { label: 'Component', bStyle: 'solid',  color: '#7aa2f7', bold: true  },
-            { label: 'Service',   bStyle: 'dashed', color: '#60a5fa', bold: false },
-            { label: 'Interface', bStyle: 'dotted', color: '#38bdf8', bold: false },
-            { label: 'Function',  bStyle: 'dotted', color: '#818cf8', bold: false },
-          ] as t}
-            <div class="flex items-center gap-2 mb-1">
-              <div class="flex-shrink-0 rounded-sm" style="width:18px; height:11px; border:1.5px {t.bStyle} {t.color}; background:transparent;"></div>
-              <span style="color:{t.bold ? '#c9d1d9' : '#8b8fa8'}; font-weight:{t.bold ? 600 : 400};">{t.label}</span>
+          <Background variant={BackgroundVariant.Dots} gap={22} size={1} color="#21262d" />
+
+          <!-- Legend panel — rendered inside SvelteFlow as an overlay -->
+          <Panel position="bottom-left">
+            <div class="rounded-lg px-3.5 py-3 text-[11px]" style="background:rgba(22,27,34,0.92); border:1px solid #30363d; min-width:140px;">
+              <div class="text-[10px] font-bold uppercase tracking-wide mb-2" style="color:#6b7280;">Node type</div>
+              {#each [
+                { label: 'Component', bs: 'solid',  color: '#93b4f0', bold: true  },
+                { label: 'Service',   bs: 'dashed', color: '#7aabf7', bold: false },
+                { label: 'Interface', bs: 'dotted', color: '#5ebbe8', bold: false },
+                { label: 'Function',  bs: 'dotted', color: '#a89cf7', bold: false },
+              ] as t}
+                <div class="flex items-center gap-2 mb-1.5">
+                  <div style="width:20px; height:12px; border-radius:3px; border:1.5px {t.bs} {t.color}; background:transparent; flex-shrink:0;"></div>
+                  <span style="color:{t.bold ? '#cdd9e5' : '#8b949e'}; font-weight:{t.bold ? 600 : 400};">{t.label}</span>
+                </div>
+              {/each}
+
+              <div class="text-[10px] font-bold uppercase tracking-wide mt-3 mb-2" style="color:#6b7280;">Lifecycle</div>
+              {#each Object.entries(LIFECYCLE_COLORS) as [lc, color]}
+                <div class="flex items-center gap-2 mb-1.5">
+                  <span style="width:8px; height:8px; border-radius:50%; background:{color}; flex-shrink:0; display:inline-block;"></span>
+                  <span style="color:#8b949e;">{lc}</span>
+                </div>
+              {/each}
             </div>
-          {/each}
-          <div class="text-[10px] font-bold uppercase tracking-wide text-muted-foreground mt-3 mb-2">Lifecycle</div>
-          {#each Object.entries(LIFECYCLE_COLORS) as [lc, color]}
-            <div class="flex items-center gap-2 mb-1">
-              <span class="size-2 rounded-full flex-shrink-0" style="background:{color}"></span>
-              <span class="text-muted-foreground">{lc}</span>
-            </div>
-          {/each}
-        </div>
+          </Panel>
+        </SvelteFlow>
       </div>
 
     </div>

--- a/cmd/archipulse/ui/src/routes/dependency/FlowControls.svelte
+++ b/cmd/archipulse/ui/src/routes/dependency/FlowControls.svelte
@@ -1,0 +1,11 @@
+<script>
+  import { useSvelteFlow, Panel } from '@xyflow/svelte';
+
+  let { onReady } = $props();
+
+  const { fitView } = useSvelteFlow();
+
+  $effect(() => {
+    onReady(fitView);
+  });
+</script>

--- a/internal/viewer/views/application_dependency.go
+++ b/internal/viewer/views/application_dependency.go
@@ -9,9 +9,10 @@ import (
 
 // ApplicationDependencyNode is a node in the dependency graph.
 type ApplicationDependencyNode struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	Type string `json:"type"`
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	Type            string `json:"type"`
+	LifecycleStatus string `json:"lifecycle_status"`
 }
 
 // ApplicationDependencyEdge is an edge in the dependency graph.
@@ -30,14 +31,30 @@ type ApplicationDependencyGraph struct {
 
 // ApplicationDependency returns the application dependency graph
 // (nodes + edges) for use with Cytoscape.js.
-// Equivalent to Essential EAM "Application Dependency Viewer".
+// Only ApplicationComponent nodes are included as primary nodes;
+// services/interfaces/functions appear as secondary nodes.
+// lifecycle_status is resolved from element_properties.
 func ApplicationDependency(db *sql.DB, workspaceID uuid.UUID) (*ApplicationDependencyGraph, error) {
-	// Nodes: all application-layer elements.
-	nodeRows, err := db.Query(`
-		SELECT source_id, name, type
-		FROM elements
-		WHERE workspace_id = $1 AND layer = 'Application'
-		ORDER BY name`, workspaceID)
+	// Nodes: all application-layer elements with lifecycle_status property.
+	nodeRows, err := db.Query(fmt.Sprintf(`
+		SELECT
+			e.source_id,
+			e.name,
+			e.type,
+			COALESCE(
+				(SELECT ep.value
+				 FROM element_properties ep
+				 WHERE ep.element_id = e.id
+				   AND ep.key = 'lifecycle_status'
+				   AND ep.source = 'model'
+				 LIMIT 1),
+				''
+			) AS lifecycle_status
+		FROM elements e
+		WHERE e.workspace_id = $1
+		  AND e.layer = 'Application'
+		  AND e.type IN (%s)
+		ORDER BY e.name`, appTypesSQL), workspaceID)
 	if err != nil {
 		return nil, fmt.Errorf("application dependency nodes: %w", err)
 	}
@@ -49,7 +66,7 @@ func ApplicationDependency(db *sql.DB, workspaceID uuid.UUID) (*ApplicationDepen
 	}
 	for nodeRows.Next() {
 		var n ApplicationDependencyNode
-		if err := nodeRows.Scan(&n.ID, &n.Name, &n.Type); err != nil {
+		if err := nodeRows.Scan(&n.ID, &n.Name, &n.Type, &n.LifecycleStatus); err != nil {
 			return nil, err
 		}
 		graph.Nodes = append(graph.Nodes, n)
@@ -58,7 +75,7 @@ func ApplicationDependency(db *sql.DB, workspaceID uuid.UUID) (*ApplicationDepen
 		return nil, err
 	}
 
-	// Edges: relationships between application-layer elements.
+	// Edges: Serving, Flow, Association and Access relationships between app elements.
 	edgeRows, err := db.Query(`
 		SELECT r.source_id, r.source_element, r.target_element, r.type
 		FROM relationships r
@@ -67,6 +84,13 @@ func ApplicationDependency(db *sql.DB, workspaceID uuid.UUID) (*ApplicationDepen
 		JOIN elements tgt ON tgt.workspace_id = r.workspace_id
 			AND tgt.source_id = r.target_element AND tgt.layer = 'Application'
 		WHERE r.workspace_id = $1
+		  AND r.type IN (
+		  	'Serving', 'ServingRelationship',
+		  	'Flow', 'FlowRelationship',
+		  	'Access', 'AccessRelationship',
+		  	'Association', 'AssociationRelationship',
+		  	'Triggering', 'TriggeringRelationship'
+		  )
 		ORDER BY r.source_element, r.target_element`, workspaceID)
 	if err != nil {
 		return nil, fmt.Errorf("application dependency edges: %w", err)


### PR DESCRIPTION
## Summary
- Replaces the chaotic force-directed layout with hierarchical **dagre LR** — apps flow left to right by dependency order
- **Left panel**: searchable app list with click-to-focus, relationship type toggles, node type legend
- **Edge hover tooltip**: shows `Source → Serves → Target` inline without any click/modal
- **Node colours** driven by `lifecycle_status` (Production=green, Pilot=blue, Retiring=orange, etc.)
- Backend now returns `lifecycle_status` per node and includes Flow/Access/Triggering edges

## Test plan
- [ ] Graph renders in dagre LR order (no tangled layout)
- [ ] Click an app in the left panel → graph focuses and fits that app's neighbourhood
- [ ] "← Show all" / second click resets to full view
- [ ] Hover over an edge → tooltip appears with both app names and relationship label
- [ ] Toggling a relationship type hides/shows those edges immediately
- [ ] Node border colour matches lifecycle status; solid/dashed/dotted encodes type
- [ ] Integration Map (other graph view) is unaffected
- [ ] CI passes