### PR TITLE
fix(dependency): correct edge hover tooltip event API

### DIFF
--- a/cmd/archipulse/ui/src/routes/dependency/DependencyGraphView.svelte
+++ b/cmd/archipulse/ui/src/routes/dependency/DependencyGraphView.svelte
@@ -188,16 +188,14 @@
     applyLayout(currentVisibleIds());
   }
 
-  // ── Edge events (xyflow passes (event, edge) directly) ────────────────────
-  function onEdgeMouseEnter(event, edge) {
+  // ── Edge events ───────────────────────────────────────────────────────────
+  // @xyflow/svelte uses onedgepointerenter/leave; callback receives { event, edge }
+  function onEdgePointerEnter({ event, edge }) {
     const d = edge?.data;
     if (!d) return;
     tooltip = { text: `${d.sourceName}  →  ${d.relLabel}  →  ${d.targetName}`, x: event.clientX, y: event.clientY };
   }
-  function onEdgeMouseMove(event) {
-    if (tooltip) tooltip = { ...tooltip, x: event.clientX, y: event.clientY };
-  }
-  function onEdgeMouseLeave() { tooltip = null; }
+  function onEdgePointerLeave() { tooltip = null; }
 
   // ── Panel list ────────────────────────────────────────────────────────────
   const filteredNodes = $derived(
@@ -321,9 +319,8 @@
           minZoom={0.08}
           maxZoom={3}
           proOptions={{ hideAttribution: true }}
-          onedgemouseenter={onEdgeMouseEnter}
-          onedgemousemove={onEdgeMouseMove}
-          onedgemouseleave={onEdgeMouseLeave}
+          onedgepointerenter={onEdgePointerEnter}
+          onedgepointerleave={onEdgePointerLeave}
           style="background:#161b22; width:100%; height:100%;"
         >
           <!-- Registers fitView from inside the SvelteFlow context -->


### PR DESCRIPTION
## Summary
- `onedgemouseenter`/`onedgemouseleave` don't exist in `@xyflow/svelte` — caused silent no-op, tooltip never fired
- Correct props are `onedgepointerenter` / `onedgepointerleave`
- Callback signature is `{ event, edge }` (object), not `(event, edge)` (two args)
- Removed the non-existent `onedgemousemove` handler

## Test plan
- [ ] Hover over any edge in the Dependency Graph — tooltip should appear showing `Source → RelType → Target`
- [ ] Moving away from the edge should dismiss the tooltip