### PR TITLE
feat(view): redesign Capability Tree with @xyflow/svelte

### DIFF
--- a/cmd/archipulse/ui/src/routes/CapabilityTree.svelte
+++ b/cmd/archipulse/ui/src/routes/CapabilityTree.svelte
@@ -1,140 +1,344 @@
 <script>
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount } from 'svelte';
+  import {
+    SvelteFlow,
+    Controls,
+    MiniMap,
+    Background,
+    BackgroundVariant,
+    Panel,
+  } from '@xyflow/svelte';
+  import '@xyflow/svelte/dist/style.css';
+  import dagre from '@dagrejs/dagre';
   import { api } from '../lib/api.js';
-  import { VIEWS } from '../lib/views.js';
-  import { makeCapabilityTree } from '../lib/cytoscape.js';
-  import { Button } from '$lib/components/ui/button';
+  import CapabilityNode from './capability/CapabilityNode.svelte';
+  import AppNode       from './dependency/AppNode.svelte';
+  import FlowControls  from './dependency/FlowControls.svelte';
 
-  export let params = {};
+  let { params = {} } = $props();
 
-  let container;
-  let tooltipEl;
-  let cy = null;
-  let loading = true;
-  let error = null;
-  let empty = false;
+  // ── XyFlow state ──────────────────────────────────────────────────────────
+  let nodes     = $state([]);
+  let edges     = $state([]);
+  const nodeTypes = { capNode: CapabilityNode, appNode: AppNode };
 
-  $: wsId = params.wsId;
-  $: meta = VIEWS['capability-tree'] || { label: 'Capability Tree', desc: '' };
+  let fitView = $state(null);
+  function fit() { fitView?.({ padding: 0.12, duration: 300 }); }
 
-  onMount(async () => {
-    loading = true;
-    error = null;
-    empty = false;
-    try {
-      const data = await api.get('/workspaces/' + wsId + '/views/capability-tree/tree');
-      const nodes = data.nodes || [];
-      if (nodes.length === 0) {
-        empty = true;
-        loading = false;
-        return;
-      }
-      loading = false;
-      await tick();
-      cy = makeCapabilityTree(container, nodes);
+  // ── Data ──────────────────────────────────────────────────────────────────
+  let allCaps  = $state([]);   // CapabilityNode[] from API
+  let loading  = $state(true);
+  let error    = $state(null);
 
-      // Tooltip
-      cy.on('mouseover', 'node', e => {
-        const d = e.target.data();
-        const apps = d.apps || [];
-        const displayName = d.kind === 'app' ? d.label.split('\n')[0] : d.label;
-        const typeColor = d.kind === 'capability' ? '#e0af68'
-          : d.appSub === 'component' ? '#7aa2f7'
-          : d.appSub === 'service'   ? '#4a9eff'
-          : d.appSub === 'function'  ? '#5a80a8'
-          : '#6b7280';
-        tooltipEl.querySelector('.tt-name').textContent = displayName;
-        const ttType = tooltipEl.querySelector('.tt-type');
-        ttType.textContent = d.kind === 'app' ? (d.appType || 'Application') : 'Capability';
-        ttType.style.color = typeColor;
-        // Apps list
-        let appsHtml = '';
-        if (apps.length) {
-          appsHtml = '<div class="tt-apps-label">Supported by</div>' +
-            apps.map(a => `<div class="tt-app">· ${a.name}</div>`).join('');
+  // ── Selection ─────────────────────────────────────────────────────────────
+  let selectedId = $state(null);  // focused root/mid capability
+  let searchQ    = $state('');
+
+  // ── Derived lists ─────────────────────────────────────────────────────────
+  const rootCaps = $derived(allCaps.filter(c => !c.parent_id));
+
+  const filteredCaps = $derived(
+    searchQ
+      ? allCaps.filter(c => c.name.toLowerCase().includes(searchQ.toLowerCase()))
+      : rootCaps
+  );
+
+  // ── Lifecycle colours (shared with AppNode) ───────────────────────────────
+  const LIFECYCLE_COLORS = {
+    'Production':     '#22c55e',
+    'Pilot':          '#3b82f6',
+    'Planned':        '#8b5cf6',
+    'Retiring':       '#f97316',
+    'Decommissioned': '#ef4444',
+  };
+
+  // ── Tree helpers ──────────────────────────────────────────────────────────
+  function getSubtreeIds(rootId) {
+    const ids = new Set([rootId]);
+    let changed = true;
+    while (changed) {
+      changed = false;
+      allCaps.forEach(c => {
+        if (c.parent_id && ids.has(c.parent_id) && !ids.has(c.id)) {
+          ids.add(c.id);
+          changed = true;
         }
-        const appsContainer = tooltipEl.querySelector('.tt-apps');
-        if (appsContainer) appsContainer.innerHTML = appsHtml;
-        tooltipEl.style.display = 'block';
       });
-      cy.on('mousemove', e => {
-        if (tooltipEl.style.display === 'none') return;
-        tooltipEl.style.left = (e.originalEvent.clientX + 14) + 'px';
-        tooltipEl.style.top  = (e.originalEvent.clientY - 10) + 'px';
-      });
-      cy.on('mouseout', 'node', () => { tooltipEl.style.display = 'none'; });
+    }
+    return ids;
+  }
 
-      cy.on('tap', 'node', e => {
-        cy.elements().addClass('faded');
-        e.target.removeClass('faded');
-        e.target.neighborhood().removeClass('faded');
+  function appTier(type) {
+    if (type === 'ApplicationComponent') return 'component';
+    if (type === 'ApplicationService')   return 'service';
+    if (type === 'ApplicationInterface') return 'interface';
+    if (type === 'ApplicationFunction')  return 'function';
+    return 'other';
+  }
+
+  // ── Dagre layout ──────────────────────────────────────────────────────────
+  const CAP_W = 195, CAP_H = 54;
+  const APP_W = 172, APP_H = 46;
+
+  function applyLayout(focusId = null) {
+    const capSet = focusId ? getSubtreeIds(focusId) : null;
+
+    const g = new dagre.graphlib.Graph();
+    g.setDefaultEdgeLabel(() => ({}));
+    g.setGraph({ rankdir: 'LR', nodesep: 32, ranksep: 110, marginx: 60, marginy: 60 });
+
+    // Capability nodes
+    allCaps.forEach(cap => {
+      if (capSet && !capSet.has(cap.id)) return;
+      g.setNode(cap.id, { width: CAP_W, height: CAP_H });
+    });
+
+    // Composition edges (parent → child capability)
+    allCaps.forEach(cap => {
+      if (!cap.parent_id) return;
+      if (capSet && (!capSet.has(cap.parent_id) || !capSet.has(cap.id))) return;
+      if (g.hasNode(cap.parent_id) && g.hasNode(cap.id)) {
+        g.setEdge(cap.parent_id, cap.id);
+      }
+    });
+
+    // App nodes + serving edges (capability → app)
+    const appEntries = [];
+    allCaps.forEach(cap => {
+      if (capSet && !capSet.has(cap.id)) return;
+      (cap.supporting_apps ?? []).forEach(app => {
+        const nodeId = `app_${cap.id}_${app.id}`;
+        g.setNode(nodeId, { width: APP_W, height: APP_H });
+        g.setEdge(cap.id, nodeId);
+        appEntries.push({ nodeId, app, capId: cap.id });
       });
-      cy.on('tap', e => {
-        if (e.target === cy) cy.elements().removeClass('faded');
+    });
+
+    dagre.layout(g);
+
+    // Build flow nodes
+    const flowNodes = [];
+
+    allCaps.forEach(cap => {
+      if (capSet && !capSet.has(cap.id)) return;
+      const gn  = g.node(cap.id);
+      const appCount = (cap.supporting_apps ?? []).length;
+      flowNodes.push({
+        id:        cap.id,
+        type:      'capNode',
+        draggable: false,
+        position:  gn ? { x: gn.x - CAP_W / 2, y: gn.y - CAP_H / 2 } : { x: 0, y: 0 },
+        data:      { label: cap.name, appCount },
       });
+    });
+
+    appEntries.forEach(({ nodeId, app }) => {
+      const gn   = g.node(nodeId);
+      const tier = appTier(app.type);
+      flowNodes.push({
+        id:        nodeId,
+        type:      'appNode',
+        draggable: false,
+        position:  gn ? { x: gn.x - APP_W / 2, y: gn.y - APP_H / 2 } : { x: 0, y: 0 },
+        data:      { label: app.name, badge: app.type.replace('Application', ''), tier, lifecycle: app.lifecycle_status },
+      });
+    });
+
+    // Build flow edges
+    const flowEdges = [];
+
+    // Composition edges
+    allCaps.forEach(cap => {
+      if (!cap.parent_id) return;
+      if (capSet && (!capSet.has(cap.parent_id) || !capSet.has(cap.id))) return;
+      flowEdges.push({
+        id:        `comp_${cap.parent_id}_${cap.id}`,
+        source:    cap.parent_id,
+        target:    cap.id,
+        style:     'stroke:#c09040; stroke-width:1.8px;',
+        markerEnd: { type: 'arrowclosed', color: '#c09040', width: 12, height: 12 },
+      });
+    });
+
+    // Serving edges (cap → app)
+    appEntries.forEach(({ nodeId, capId }) => {
+      flowEdges.push({
+        id:        `srv_${nodeId}`,
+        source:    capId,
+        target:    nodeId,
+        style:     'stroke:#4a6fa555; stroke-width:1.4px; stroke-dasharray:5,4;',
+        markerEnd: { type: 'arrowclosed', color: '#4a6fa5', width: 11, height: 11 },
+      });
+    });
+
+    nodes = flowNodes;
+    edges = flowEdges;
+    setTimeout(fit, 80);
+  }
+
+  function selectCap(id) {
+    selectedId = id === selectedId ? null : id;
+    applyLayout(selectedId);
+  }
+
+  function clearSelection() {
+    selectedId = null;
+    applyLayout(null);
+  }
+
+  // ── Load ──────────────────────────────────────────────────────────────────
+  onMount(async () => {
+    try {
+      const data = await api.get('/workspaces/' + params.wsId + '/views/capability-tree/tree');
+      allCaps = data.nodes ?? [];
+      applyLayout(null);
     } catch (e) {
       error = e.message;
+    } finally {
       loading = false;
     }
   });
-
-  onDestroy(() => {
-    if (cy) cy.destroy();
-  });
-
-  function fit() { if (cy) cy.fit(undefined, 40); }
-  function zoomIn() {
-    if (cy) cy.zoom({ level: cy.zoom() * 1.2, renderedPosition: { x: cy.width() / 2, y: cy.height() / 2 } });
-  }
-  function zoomOut() {
-    if (cy) cy.zoom({ level: cy.zoom() / 1.2, renderedPosition: { x: cy.width() / 2, y: cy.height() / 2 } });
-  }
-
-  async function tick() {
-    return new Promise(resolve => requestAnimationFrame(resolve));
-  }
 </script>
 
-<div class="content">
-  <div class="flex items-start justify-between mb-6 gap-4">
+<!-- full-viewport container, same pattern as DependencyGraphView -->
+<div style="position:fixed; top:var(--nav-h); left:var(--sidebar-w); right:0; bottom:0; display:flex; flex-direction:column; overflow:hidden; background:var(--bg);">
+
+  <!-- Header -->
+  <div class="flex items-center justify-between gap-4 px-6 pt-5 pb-4 flex-shrink-0">
     <div>
-      <h1 class="text-[18px] font-semibold">{meta.label}</h1>
-      <div class="text-muted-foreground text-[13px] mt-0.5">{meta.desc}</div>
+      <h1 class="text-[18px] font-semibold">Capability Tree</h1>
+      <div class="text-muted-foreground text-[13px] mt-0.5">Business capabilities and supporting applications</div>
     </div>
+    <button
+      class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] hover:bg-muted transition-colors"
+      onclick={fit}
+    >⊡ Fit</button>
   </div>
 
   {#if loading}
-    <div class="flex items-center gap-2 text-muted-foreground py-6">
+    <div class="flex items-center gap-2 text-muted-foreground py-6 px-6">
       <div class="size-4 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
       Loading…
     </div>
   {:else if error}
-    <div class="text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2">Error: {error}</div>
-  {:else if empty}
+    <div class="mx-6 text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2">{error}</div>
+  {:else if allCaps.length === 0}
     <div class="text-center py-16 px-6 text-muted-foreground">
       <div class="text-[40px] mb-3.5">◈</div>
-      <p class="text-[14px] leading-relaxed">No Capability elements found.<br>Import or create elements with type <strong>Capability</strong>.</p>
+      <p class="text-[14px]">No Capability elements found — import or create Capability elements first.</p>
     </div>
   {:else}
-    <div class="cap-cy-wrap">
-      <div id="cap-cy" bind:this={container}></div>
-      <div class="cap-cy-controls">
-        <Button variant="outline" size="icon" class="size-8" title="Fit" onclick={fit}>⊡</Button>
-        <Button variant="outline" size="icon" class="size-8" title="Zoom in" onclick={zoomIn}>+</Button>
-        <Button variant="outline" size="icon" class="size-8" title="Zoom out" onclick={zoomOut}>−</Button>
+    <div class="flex flex-1 min-h-0">
+
+      <!-- Left panel -->
+      <div class="flex flex-col border-r border-border w-52 flex-shrink-0 bg-card/50 overflow-hidden min-h-0 h-full">
+
+        <!-- Search -->
+        <div class="px-3 pt-3 pb-2 flex-shrink-0">
+          <input type="search" bind:value={searchQ} placeholder="Find capability…"
+            class="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-[12px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary" />
+        </div>
+
+        <!-- "All" reset button when something is selected -->
+        {#if selectedId}
+          <div class="px-3 pb-2 flex-shrink-0">
+            <button
+              class="w-full text-left px-2 py-1 rounded text-[11px] text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+              onclick={clearSelection}
+            >← Show all</button>
+          </div>
+        {/if}
+
+        <!-- Section label -->
+        <div class="px-3 pb-1 flex-shrink-0">
+          <span class="text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+            {searchQ ? 'Results' : 'Capabilities'}
+          </span>
+        </div>
+
+        <!-- Capability list (scrollable) -->
+        <div class="overflow-y-auto flex-1 px-2 pb-2">
+          {#each filteredCaps as cap}
+            {@const isRoot = !cap.parent_id}
+            {@const selected = cap.id === selectedId}
+            <button
+              class="w-full text-left flex items-center gap-1.5 px-2 py-1.5 rounded text-[12px] transition-colors {selected ? 'bg-amber-500/10 text-amber-300' : 'text-foreground hover:bg-muted/50'}"
+              onclick={() => selectCap(cap.id)}
+            >
+              <span class="size-2 rounded-sm flex-shrink-0 {isRoot ? 'bg-amber-500/70' : 'bg-amber-500/30'}"></span>
+              <span class="truncate {isRoot ? 'font-medium' : ''}">{cap.name}</span>
+            </button>
+          {/each}
+        </div>
+
+        <!-- Stats -->
+        <div class="border-t border-border px-3 py-2.5 flex-shrink-0">
+          <div class="text-[10px] text-muted-foreground">
+            {rootCaps.length} root · {allCaps.length} total
+          </div>
+        </div>
       </div>
-      <div class="cap-cy-legend">
-        <span><i style="background:#2a2010;border:2px solid #e0af68"></i> Capability</span>
-        <span><i style="background:#0d1f2e;border:2px solid #7aa2f7"></i> Component</span>
-        <span><i style="background:#0d1a28;border:2px solid #4a9eff;border-style:dashed"></i> Service</span>
-        <span><i style="background:#0d1520;border:1px solid #3a5a80"></i> Function</span>
+
+      <!-- Flow canvas -->
+      <div class="flex-1 min-w-0" style="background:#161b22;">
+        <SvelteFlow
+          {nodes}
+          {edges}
+          {nodeTypes}
+          nodesDraggable={false}
+          fitView
+          minZoom={0.05}
+          maxZoom={3}
+          proOptions={{ hideAttribution: true }}
+          style="background:#161b22; width:100%; height:100%;"
+        >
+          <FlowControls onReady={(fn) => { fitView = fn; }} />
+
+          <Controls showInteractive={false} style="background:#1c2128; border:1px solid #30363d; border-radius:8px;" />
+
+          <MiniMap
+            position="bottom-right"
+            style="background:#1c2128; border:1px solid #30363d; border-radius:8px; margin-bottom:48px;"
+            nodeColor={(n) => n.type === 'capNode' ? '#c09040' : (LIFECYCLE_COLORS[n.data?.lifecycle] ?? '#4a6fa5')}
+            maskColor="rgba(0,0,0,0.55)"
+          />
+
+          <Background variant={BackgroundVariant.Dots} gap={22} size={1} color="#21262d" />
+
+          <!-- Legend -->
+          <Panel position="bottom-left">
+            <div class="rounded-lg px-3.5 py-3 text-[11px]" style="background:rgba(22,27,34,0.92); border:1px solid #30363d; min-width:140px;">
+              <div class="text-[10px] font-bold uppercase tracking-wide mb-2" style="color:#6b7280;">Node type</div>
+              <div class="flex items-center gap-2 mb-1.5">
+                <div style="width:20px; height:12px; border-radius:3px; border:2px solid #e0af68; background:#201808; flex-shrink:0;"></div>
+                <span style="color:#fcd990; font-weight:600;">Capability</span>
+              </div>
+              {#each [
+                { label: 'Component', bs: 'solid',  color: '#93b4f0', bold: true  },
+                { label: 'Service',   bs: 'dashed', color: '#7aabf7', bold: false },
+                { label: 'Interface', bs: 'dotted', color: '#5ebbe8', bold: false },
+                { label: 'Function',  bs: 'dotted', color: '#a89cf7', bold: false },
+              ] as t}
+                <div class="flex items-center gap-2 mb-1.5">
+                  <div style="width:20px; height:12px; border-radius:3px; border:1.5px {t.bs} {t.color}; background:transparent; flex-shrink:0;"></div>
+                  <span style="color:{t.bold ? '#cdd9e5' : '#8b949e'}; font-weight:{t.bold ? 600 : 400};">{t.label}</span>
+                </div>
+              {/each}
+
+              <div class="text-[10px] font-bold uppercase tracking-wide mt-3 mb-1.5" style="color:#6b7280;">Edges</div>
+              <div class="flex items-center gap-2 mb-1.5">
+                <div style="width:20px; height:2px; background:#c09040; flex-shrink:0;"></div>
+                <span style="color:#8b949e;">Composition</span>
+              </div>
+              <div class="flex items-center gap-2">
+                <div style="width:20px; height:1px; border-top:1.5px dashed #4a6fa5; flex-shrink:0;"></div>
+                <span style="color:#8b949e;">Supports</span>
+              </div>
+            </div>
+          </Panel>
+        </SvelteFlow>
       </div>
+
     </div>
   {/if}
-</div>
-
-<div class="cap-tooltip" bind:this={tooltipEl}>
-  <div class="tt-name"></div>
-  <div class="tt-type"></div>
-  <div class="tt-apps"></div>
 </div>

--- a/cmd/archipulse/ui/src/routes/capability/CapabilityNode.svelte
+++ b/cmd/archipulse/ui/src/routes/capability/CapabilityNode.svelte
@@ -1,0 +1,29 @@
+<script>
+  import { Handle, Position } from '@xyflow/svelte';
+
+  let { data = {} } = $props();
+</script>
+
+<div style="
+  background:#201808;
+  border:2px solid #e0af68;
+  color:#fcd990;
+  font-weight:600;
+  font-size:12px;
+  min-width:160px;
+  max-width:210px;
+  padding:10px 14px;
+  border-radius:8px;
+  text-align:center;
+  line-height:1.35;
+  box-shadow:0 2px 14px rgba(0,0,0,0.55);
+  cursor:default;
+  user-select:none;
+">
+  <Handle type="target" position={Position.Left}  style="background:#e0af68; width:9px; height:9px; border:none; border-radius:50%;" />
+  <div style="word-break:break-word;">{data.label}</div>
+  {#if data.appCount > 0}
+    <div style="font-size:9px; opacity:0.5; margin-top:3px; font-weight:400; letter-spacing:0.3px;">{data.appCount} app{data.appCount > 1 ? 's' : ''}</div>
+  {/if}
+  <Handle type="source" position={Position.Right} style="background:#e0af68; width:9px; height:9px; border:none; border-radius:50%;" />
+</div>

--- a/internal/viewer/views/capability_tree_data.go
+++ b/internal/viewer/views/capability_tree_data.go
@@ -18,9 +18,10 @@ type CapabilityNode struct {
 
 // CapabilitySuppApp is an application element that serves a capability or process.
 type CapabilitySuppApp struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	Type string `json:"type"`
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	Type            string `json:"type"`
+	LifecycleStatus string `json:"lifecycle_status"`
 }
 
 // CapabilityTreeData returns all capability/process nodes with parent references
@@ -72,7 +73,16 @@ func CapabilityTreeData(db *sql.DB, workspaceID uuid.UUID) ([]CapabilityNode, er
 			r.target_element AS cap_id,
 			a.source_id,
 			a.name,
-			a.type
+			a.type,
+			COALESCE(
+				(SELECT ep.value
+				 FROM element_properties ep
+				 WHERE ep.element_id = a.id
+				   AND ep.key = 'lifecycle_status'
+				   AND ep.source = 'model'
+				 LIMIT 1),
+				''
+			) AS lifecycle_status
 		FROM relationships r
 		JOIN elements a
 			ON  a.workspace_id = r.workspace_id
@@ -93,7 +103,7 @@ func CapabilityTreeData(db *sql.DB, workspaceID uuid.UUID) ([]CapabilityNode, er
 	for appRows.Next() {
 		var capID string
 		var app CapabilitySuppApp
-		if err := appRows.Scan(&capID, &app.ID, &app.Name, &app.Type); err != nil {
+		if err := appRows.Scan(&capID, &app.ID, &app.Name, &app.Type, &app.LifecycleStatus); err != nil {
 			return nil, err
 		}
 		if idx, ok := nodeIndex[capID]; ok {


### PR DESCRIPTION
## Summary
- Replace Cytoscape with `@xyflow/svelte` — same approach as the Dependency Graph redesign
- Combo/dropdown replaced by a scrollable left panel list; supports search and click-to-focus on any subtree
- Dagre LR layout: capability hierarchy expands left-to-right, supporting apps appear to the right of each capability
- New `CapabilityNode.svelte` (amber/gold) visually distinct from app nodes
- Backend adds `lifecycle_status` to supporting apps so they use the same lifecycle colour scheme as the Dependency Graph
- Legend panel rendered inside the canvas as a `<Panel>` overlay

## Test plan
- [ ] Capability Tree loads and fits to viewport on open
- [ ] Left panel shows all root capabilities; search filters across all levels
- [ ] Clicking a capability focuses on its subtree and all supporting apps
- [ ] "Show all" resets to full graph
- [ ] Fit button and minimap work
- [ ] App nodes show lifecycle colour if available