### PR TITLE
refactor(ui): move ViewRouter-rendered views to components/views/

### DIFF
--- a/cmd/archipulse/ui/src/components/views/ApplicationCatalogueView.svelte
+++ b/cmd/archipulse/ui/src/components/views/ApplicationCatalogueView.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from 'svelte';
-  import { api } from '../lib/api.js';
+  import { api } from '../../lib/api.js';
 
   export let params = {};
   $: wsId = params.wsId;

--- a/cmd/archipulse/ui/src/components/views/ApplicationDashboard.svelte
+++ b/cmd/archipulse/ui/src/components/views/ApplicationDashboard.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from 'svelte';
-  import { api } from '../lib/api.js';
+  import { api } from '../../lib/api.js';
   import { ArcChart } from 'layerchart';
 
   export let params = {};

--- a/cmd/archipulse/ui/src/components/views/ElementCatalogueView.svelte
+++ b/cmd/archipulse/ui/src/components/views/ElementCatalogueView.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from 'svelte';
-  import { api } from '../lib/api.js';
+  import { api } from '../../lib/api.js';
 
   export let params = {};
   $: wsId = params.wsId;

--- a/cmd/archipulse/ui/src/components/views/TableView.svelte
+++ b/cmd/archipulse/ui/src/components/views/TableView.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount } from 'svelte';
-  import { api } from '../lib/api.js';
-  import { VIEWS } from '../lib/views.js';
+  import { api } from '../../lib/api.js';
+  import { VIEWS } from '../../lib/views.js';
   import * as Table from '$lib/components/ui/table';
   import { Button } from '$lib/components/ui/button';
   import { Badge } from '$lib/components/ui/badge';

--- a/cmd/archipulse/ui/src/components/views/TechnologyCatalogueView.svelte
+++ b/cmd/archipulse/ui/src/components/views/TechnologyCatalogueView.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from 'svelte';
-  import { api } from '../lib/api.js';
+  import { api } from '../../lib/api.js';
 
   export let params = {};
   $: wsId = params.wsId;

--- a/cmd/archipulse/ui/src/routes/ViewRouter.svelte
+++ b/cmd/archipulse/ui/src/routes/ViewRouter.svelte
@@ -1,12 +1,12 @@
 <script>
   import { push } from 'svelte-spa-router';
   import { VIEWS } from '../lib/views.js';
-  import TableView from './TableView.svelte';
-  import ApplicationDashboard from './ApplicationDashboard.svelte';
+  import TableView from '../components/views/TableView.svelte';
+  import ApplicationDashboard from '../components/views/ApplicationDashboard.svelte';
   import ApplicationLandscapeMap from './ApplicationLandscapeMap.svelte';
-  import ApplicationCatalogueView from './ApplicationCatalogueView.svelte';
-  import TechnologyCatalogueView from './TechnologyCatalogueView.svelte';
-  import ElementCatalogueView from './ElementCatalogueView.svelte';
+  import ApplicationCatalogueView from '../components/views/ApplicationCatalogueView.svelte';
+  import TechnologyCatalogueView from '../components/views/TechnologyCatalogueView.svelte';
+  import ElementCatalogueView from '../components/views/ElementCatalogueView.svelte';
 
   export let params = {};
 

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,0 +1,6 @@
+# ArchiPulse Memory
+
+- [ArchiPulse project status](project_status.md) — v0.5 in progress; current stack and completed work
+- [ArchiPulse technical decisions](project_tech.md) — stack, gotchas, conventions, local DB config
+- [No Claude attribution](feedback_no_attribution.md) — never add Co-Authored-By or Generated with Claude Code
+- [Git workflow](feedback_git_workflow.md) — always branch + PR, never push directly to main

--- a/memory/feedback_git_workflow.md
+++ b/memory/feedback_git_workflow.md
@@ -1,0 +1,15 @@
+---
+name: Git workflow — always use branches and PRs
+description: Never push directly to main; always create a feature branch and open a PR
+type: feedback
+---
+
+Always work on a feature branch and open a PR. Never commit or push directly to main.
+
+**Why:** User explicitly requested this after direct pushes to main happened repeatedly.
+
+**How to apply:**
+- Before starting any work, create a branch: `git checkout -b feat/...` or `fix/...`
+- Commit to the branch, push with `-u origin <branch>`
+- Open a PR with `gh pr create`
+- Never run `git push` targeting main directly

--- a/memory/feedback_no_attribution.md
+++ b/memory/feedback_no_attribution.md
@@ -1,0 +1,11 @@
+---
+name: No Claude attribution in commits
+description: Never add Co-Authored-By Claude or Generated with Claude Code to commits or PRs
+type: feedback
+---
+
+Never add `Co-Authored-By: Claude` or "Generated with Claude Code" footers to commit messages or PR descriptions.
+
+**Why:** User preference — these are their commits and PRs.
+
+**How to apply:** Omit any Claude attribution from all git commits and PR bodies, always.

--- a/memory/project_status.md
+++ b/memory/project_status.md
@@ -1,0 +1,53 @@
+---
+name: ArchiPulse project status
+description: Current version, completed milestones, and next up on the roadmap
+type: project
+---
+
+As of 2026-04-02, main includes full Application Dashboard (merged via PR #10).
+
+## Completed (merged to main)
+
+- v0.1: AOEF/AJX parser, PostgreSQL schema, CRUD API, optimistic locking, export, CI
+- v0.2: Embedded SPA, EAM views, Cytoscape dependency graph, Docker Compose
+- v0.3: Integration Map view, Capability Tree (Cytoscape dagre LR), app sub-type differentiation
+- v0.4: Svelte 5 + Vite 6 frontend (replaced vanilla JS SPA)
+- `element_properties` table (migration 006): source-tracked key/value properties per element, AOEF parser updated, GET /elements/:id returns properties grouped by source
+- Tailwind CSS v4 + shadcn-svelte: full component migration (Button, Badge, Dialog, Input, Label, Separator, Table), Node 24, postgres:17 in CI
+- `examples/archisurance-extended.xml`: full ArchiSurance AOEF model (40 apps, 5L1/20L2 capabilities, technology + motivation layers, intentional coverage gaps)
+- Application Dashboard: all-property donut grid + capability filter (layerchart@next ArcChart); backend at `GET /views/application-dashboard/stats?capability=<name>`
+
+## Application Dashboard — shipped (main, 2026-04-02)
+- All-properties donut grid (lifecycle_status, deployment_model, criticality, vendor, business_owner, user_count)
+- Capability filter dropdown (fixes: AOEF uses xsi:type="Realization" not "RealizationRelationship")
+- Left app list panel (w-48 card, scrollable, filtered by capability)
+- Hover tooltip per legend row showing app list for that slice value
+- App highlight: clicking an app in left panel rings its slice across all donuts
+- Sidebar active state fix: uses `$: loc = $location` directly in template (not prop from parent)
+
+## Rich Catalogue Views — shipped (main, 2026-04-02)
+- Application Catalogue: sortable table with property columns (vendor, lifecycle, criticality, deployment, owner, user_count), colour badges, column visibility toggle, global search, CSV export (PR #12)
+- Technology Catalogue: sortable table with category badges (Node/SystemSoftware/TechnologyService), Hosted Applications chips via Assignment relationships, search, CSV export
+- Both catalogues moved to dedicated "Catalogues" sidebar section (layer: 'catalogue' in views.js)
+- Backend: `GET /views/application-catalogue/entries` and `GET /views/technology-catalogue/entries`
+
+## Application Landscape Map — shipped (main, 2026-04-02)
+- Replaces plain table with L1/L2 capability grid + coloured app chips (PR #11)
+- Overlay selector (lifecycle_status, criticality, deployment_model, vendor…) re-colours chips; legend bar shows distinct values
+- Hover tooltip per chip shows name, type, all properties; L2 rows with no apps show gap-analysis "No applications"
+- Backend: `GET /views/application-landscape/map` → `ApplicationLandscapeMap()` in `internal/viewer/views/application_landscape_map.go`
+- Routing: `views.js` `map: true` flag → `ViewRouter` uses `$:` reactive redirect (not `onMount`) so it works from any prior view
+- Reactivity fix: `chipColor(app, overlay)` passes overlay explicitly so Svelte re-evaluates on overlay change
+
+## Current stack
+
+- **Backend**: Go 1.24, chi v5, lib/pq, PostgreSQL 17
+- **Frontend**: Svelte 5, Vite 6, Tailwind CSS v4 (@tailwindcss/vite), shadcn-svelte, layerchart@next, Cytoscape.js + dagre
+- **UI components**: shadcn-svelte copy-paste in `cmd/archipulse/ui/src/lib/components/ui/`
+- **CSS tokens**: `--brand` (orange), `--bg`, `--surface`, `--surface2`, `--text`, `--text-muted` mapped to shadcn vars
+- **Infra**: Docker Compose (postgres:17-alpine + multi-stage build node:24-alpine + golang:1.24-alpine)
+- **Local dev**: `docker compose up db -d` → `go run ./cmd/archipulse serve` → `cd cmd/archipulse/ui && npm run dev` (Vite proxy to :8080)
+
+## Key CSS gotcha (fixed in #8)
+
+In Tailwind v4, unlayered CSS beats `@layer utilities`. All layout/reset styles must be in `@layer base`, otherwise they strip Tailwind utility classes (padding, margin, etc.) from shadcn components.

--- a/memory/project_tech.md
+++ b/memory/project_tech.md
@@ -1,0 +1,41 @@
+---
+name: ArchiPulse technical decisions
+description: Stack details, conventions, local dev config, and architectural decisions
+type: project
+---
+
+## Local dev
+
+- Runs via `docker compose up --build` — postgres + app in containers
+- Migrations run automatically via `entrypoint.sh` on startup
+- Frontend at http://localhost:8080
+
+## Conventions
+
+- Conventional Commits: `feat(scope):`, `fix(scope):`, `docs(scope):` etc.
+- Branch naming: `feat/`, `fix/`, `docs/`, `extractor/`, `view/`
+- One PR per concern; squash merge to main
+- `go fmt` + `golangci-lint` enforced in CI
+
+## Architecture decisions
+
+- AOEF mapped directly to PostgreSQL tables — no custom metamodel
+- `element_properties`: no UNIQUE constraint — same key can exist from multiple sources (model + extractors)
+- `source` field on properties = extractor name or 'model'; `collected_at` nullable (null for model source)
+- GET /elements/:id returns `{ element, properties: { "model": [...], "aws-lambda": [...] } }` — grouped by source (Option C: separate lanes, no forced reconciliation)
+- EAM views are SQL queries in `internal/viewer/views/`, exposed via `/api/v1/workspaces/:id/views/:name`
+- Frontend is an embedded SPA (`//go:embed all:ui/dist`) — single binary, no runtime deps
+
+## Svelte 5 reactivity gotchas
+
+- Functions called in templates (`{fn(arg)}`) don't create reactive dependencies on variables read inside the function body — only on args visible in the template expression. Fix: pass reactive variables explicitly as args.
+- `onMount` does NOT re-fire when the same component receives new props (same route pattern, different params). Use `$: if (dep) { ... }` reactive blocks for side effects that must re-run on prop changes.
+
+## shadcn-svelte setup
+
+- Tailwind v4, CSS-first config (no tailwind.config.js)
+- `@tailwindcss/vite` plugin in vite.config.js
+- `components.json` in `cmd/archipulse/ui/`
+- Add components: `npx shadcn-svelte@latest add <component>` from `cmd/archipulse/ui/`
+- CSS token names: `--brand` (not `--accent`), `--text-muted` (not `--muted`) to avoid conflict with shadcn reserved names
+- All layout/reset CSS must be inside `@layer base` — otherwise beats Tailwind utilities


### PR DESCRIPTION
## Summary
Completes the frontend structure refactor started in #17.

`routes/` now contains **only** components registered directly as routes in `App.svelte`. Components that are rendered conditionally by `ViewRouter` (not registered as routes) move to `components/views/`.

### Before
```
routes/
  TableView.svelte             ← not a route
  ApplicationDashboard.svelte  ← not a route
  ApplicationCatalogueView     ← not a route
  TechnologyCatalogueView      ← not a route
  ElementCatalogueView         ← not a route
  ViewRouter.svelte            ← route ✓
  ...
```

### After
```
components/
  Nav.svelte  Sidebar.svelte
  flow/   AppNode  CapabilityNode  FlowControls
  views/  TableView  ApplicationDashboard  ApplicationCatalogue
          TechnologyCatalogue  ElementCatalogue

routes/                        ← only App.svelte-registered routes
  Home  WorkspaceOverview  ViewRouter
  DependencyGraphView  CapabilityTree  ApplicationLandscapeMap
```