### PR TITLE
feat(theme): Corporate Navy Dark

### DIFF
--- a/cmd/archipulse/ui/src/app.css
+++ b/cmd/archipulse/ui/src/app.css
@@ -30,14 +30,14 @@
 }
 
 :root {
-  /* ── ArchiPulse design tokens ──────────────────────────────────────────── */
-  --bg:         #0f1117;
-  --surface:    #1a1d27;
-  --surface2:   #13151f;
-  --brand:      #E85D3A;
-  --brand-light:#ff8c6b;
-  --text:       #e2e4f0;
-  --text-muted: #8b8fa8;
+  /* ── ArchiPulse design tokens — Corporate Navy Dark ────────────────────── */
+  --bg:         #0d1526;
+  --surface:    #122040;
+  --surface2:   #0f1a35;
+  --brand:      #2563eb;
+  --brand-light:#60a5fa;
+  --text:       #e2e8f0;
+  --text-muted: #94a3b8;
   --danger:     #f87171;
   --success:    #4ade80;
   --sidebar-w:  240px;
@@ -61,8 +61,8 @@
   --accent-foreground:      var(--brand);
   --destructive:            var(--danger);
   --destructive-foreground: #ffffff;
-  --border:                 #2a2d3e;
-  --input:                  #2a2d3e;
+  --border:                 #1e3a5f;
+  --input:                  #1e3a5f;
   --ring:                   var(--brand);
   --radius:                 0.375rem;
 }

--- a/cmd/archipulse/ui/src/routes/CapabilityTree.svelte
+++ b/cmd/archipulse/ui/src/routes/CapabilityTree.svelte
@@ -280,7 +280,7 @@
       </div>
 
       <!-- Flow canvas -->
-      <div class="flex-1 min-w-0" style="background:#161b22;">
+      <div class="flex-1 min-w-0" style="background:#0d1526;">
         <SvelteFlow
           {nodes}
           {edges}
@@ -290,24 +290,24 @@
           minZoom={0.05}
           maxZoom={3}
           proOptions={{ hideAttribution: true }}
-          style="background:#161b22; width:100%; height:100%;"
+          style="background:#0d1526; width:100%; height:100%;"
         >
           <FlowControls onReady={(fn) => { fitView = fn; }} />
 
-          <Controls showInteractive={false} style="background:#1c2128; border:1px solid #30363d; border-radius:8px;" />
+          <Controls showInteractive={false} style="background:#122040; border:1px solid #1e3a5f; border-radius:8px;" />
 
           <MiniMap
             position="bottom-right"
-            style="background:#1c2128; border:1px solid #30363d; border-radius:8px; margin-bottom:48px;"
+            style="background:#122040; border:1px solid #1e3a5f; border-radius:8px; margin-bottom:48px;"
             nodeColor={(n) => n.type === 'capNode' ? '#c09040' : (LIFECYCLE_COLORS[n.data?.lifecycle] ?? '#4a6fa5')}
             maskColor="rgba(0,0,0,0.55)"
           />
 
-          <Background variant={BackgroundVariant.Dots} gap={22} size={1} color="#21262d" />
+          <Background variant={BackgroundVariant.Dots} gap={22} size={1} color="#112050" />
 
           <!-- Legend -->
           <Panel position="bottom-left">
-            <div class="rounded-lg px-3.5 py-3 text-[11px]" style="background:rgba(22,27,34,0.92); border:1px solid #30363d; min-width:140px;">
+            <div class="rounded-lg px-3.5 py-3 text-[11px]" style="background:rgba(13,21,38,0.94); border:1px solid #1e3a5f; min-width:140px;">
               <div class="text-[10px] font-bold uppercase tracking-wide mb-2" style="color:#6b7280;">Node type</div>
               <div class="flex items-center gap-2 mb-1.5">
                 <div style="width:20px; height:12px; border-radius:3px; border:2px solid #e0af68; background:#201808; flex-shrink:0;"></div>

--- a/cmd/archipulse/ui/src/routes/DependencyGraphView.svelte
+++ b/cmd/archipulse/ui/src/routes/DependencyGraphView.svelte
@@ -43,7 +43,7 @@
     { key: 'serving',     label: 'Serves',      color: '#7aa2f7' },
     { key: 'flow',        label: 'Data Flow',    color: '#9ece6a' },
     { key: 'access',      label: 'Accesses',     color: '#bb9af7' },
-    { key: 'triggering',  label: 'Triggers',     color: '#E85D3A' },
+    { key: 'triggering',  label: 'Triggers',     color: '#e53e3e' },
     { key: 'association', label: 'Associated',   color: '#6b7280' },
   ];
   let activeRels = $state(new Set(REL_TYPES.map(r => r.key)));
@@ -60,7 +60,7 @@
     serving:     { label: 'Serves',         color: '#7aa2f7', animated: false },
     flow:        { label: 'Data Flow',       color: '#9ece6a', animated: true  },
     access:      { label: 'Accesses',        color: '#bb9af7', animated: true  },
-    triggering:  { label: 'Triggers',        color: '#E85D3A', animated: false },
+    triggering:  { label: 'Triggers',        color: '#e53e3e', animated: false },
     association: { label: 'Associated with', color: '#6b7280', animated: false },
   };
 
@@ -220,7 +220,7 @@
 <!-- Edge tooltip -->
 {#if tooltip}
   <div class="fixed z-50 pointer-events-none rounded-lg shadow-xl px-3 py-2 text-[12px] text-foreground max-w-sm"
-       style="left:{Math.min(tooltip.x + 16, window.innerWidth - 320)}px; top:{tooltip.y - 40}px; background:rgba(22,27,34,0.95); border:1px solid #30363d;">
+       style="left:{Math.min(tooltip.x + 16, window.innerWidth - 320)}px; top:{tooltip.y - 40}px; background:rgba(13,21,38,0.96); border:1px solid #1e3a5f;">
     {tooltip.text}
   </div>
 {/if}
@@ -309,7 +309,7 @@
       </div>
 
       <!-- Flow canvas -->
-      <div class="flex-1 min-w-0" style="background:#161b22;">
+      <div class="flex-1 min-w-0" style="background:#0d1526;">
         <SvelteFlow
           {nodes}
           {edges}
@@ -321,25 +321,25 @@
           proOptions={{ hideAttribution: true }}
           onedgepointerenter={onEdgePointerEnter}
           onedgepointerleave={onEdgePointerLeave}
-          style="background:#161b22; width:100%; height:100%;"
+          style="background:#0d1526; width:100%; height:100%;"
         >
           <!-- Registers fitView from inside the SvelteFlow context -->
           <FlowControls onReady={(fn) => { fitView = fn; }} />
 
-          <Controls showInteractive={false} style="background:#1c2128; border:1px solid #30363d; border-radius:8px;" />
+          <Controls showInteractive={false} style="background:#122040; border:1px solid #1e3a5f; border-radius:8px;" />
 
           <MiniMap
             position="bottom-right"
-            style="background:#1c2128; border:1px solid #30363d; border-radius:8px; margin-bottom:48px;"
+            style="background:#122040; border:1px solid #1e3a5f; border-radius:8px; margin-bottom:48px;"
             nodeColor={(n) => LIFECYCLE_COLORS[n.data?.lifecycle] ?? '#4a6fa5'}
             maskColor="rgba(0,0,0,0.55)"
           />
 
-          <Background variant={BackgroundVariant.Dots} gap={22} size={1} color="#21262d" />
+          <Background variant={BackgroundVariant.Dots} gap={22} size={1} color="#112050" />
 
           <!-- Legend panel — rendered inside SvelteFlow as an overlay -->
           <Panel position="bottom-left">
-            <div class="rounded-lg px-3.5 py-3 text-[11px]" style="background:rgba(22,27,34,0.92); border:1px solid #30363d; min-width:140px;">
+            <div class="rounded-lg px-3.5 py-3 text-[11px]" style="background:rgba(13,21,38,0.94); border:1px solid #1e3a5f; min-width:140px;">
               <div class="text-[10px] font-bold uppercase tracking-wide mb-2" style="color:#6b7280;">Node type</div>
               {#each [
                 { label: 'Component', bs: 'solid',  color: '#93b4f0', bold: true  },


### PR DESCRIPTION
## Summary
Replaces the GitHub-black hacker palette with a Corporate Navy Dark theme aimed at Enterprise Architects.

| Token | Before | After |
|---|---|---|
| `--bg` | `#0f1117` black | `#0d1526` navy deep |
| `--surface` | `#1a1d27` grey-dark | `#122040` navy structured |
| `--brand` | `#E85D3A` orange-red | `#2563eb` corporate blue |
| `--border` | `#2a2d3e` generic grey | `#1e3a5f` navy structured |
| `--text-muted` | `#8b8fa8` | `#94a3b8` cold slate |

- Graph canvas backgrounds, controls, minimap and legend panels updated to match
- Triggering edge colour changed orange → red (stays distinct from new blue brand)
- Lifecycle node colours untouched (intentional data colours)