### PR TITLE
feat(ui): Corporate Light theme across all views

### DIFF
--- a/cmd/archipulse/ui/src/app.css
+++ b/cmd/archipulse/ui/src/app.css
@@ -30,16 +30,16 @@
 }
 
 :root {
-  /* ── ArchiPulse design tokens — Corporate Navy Dark ────────────────────── */
-  --bg:         #0d1526;
-  --surface:    #122040;
-  --surface2:   #0f1a35;
+  /* ── ArchiPulse design tokens — Corporate Light ────────────────────────── */
+  --bg:         #f8fafc;
+  --surface:    #ffffff;
+  --surface2:   #f1f5f9;
   --brand:      #2563eb;
-  --brand-light:#60a5fa;
-  --text:       #e2e8f0;
-  --text-muted: #94a3b8;
-  --danger:     #f87171;
-  --success:    #4ade80;
+  --brand-light:#3b82f6;
+  --text:       #0f172a;
+  --text-muted: #64748b;
+  --danger:     #dc2626;
+  --success:    #16a34a;
   --sidebar-w:  240px;
   --nav-h:      52px;
   --font:       'Inter', system-ui, sans-serif;
@@ -61,8 +61,8 @@
   --accent-foreground:      var(--brand);
   --destructive:            var(--danger);
   --destructive-foreground: #ffffff;
-  --border:                 #1e3a5f;
-  --input:                  #1e3a5f;
+  --border:                 #cbd5e1;
+  --input:                  #cbd5e1;
   --ring:                   var(--brand);
   --radius:                 0.375rem;
 }

--- a/cmd/archipulse/ui/src/components/Sidebar.svelte
+++ b/cmd/archipulse/ui/src/components/Sidebar.svelte
@@ -16,11 +16,11 @@
   $: loc = $location;
 
   const dotColors = {
-    'dot-biz':   '#e0af68',
-    'dot-app':   '#7aa2f7',
-    'dot-tech':  '#9ece6a',
-    'dot-cross': '#8b8fa8',
-    'dot-mot':   '#bb9af7',
+    'dot-biz':   '#d97706',
+    'dot-app':   '#2563eb',
+    'dot-tech':  '#16a34a',
+    'dot-cross': '#64748b',
+    'dot-mot':   '#7c3aed',
   };
 
   let importResult = null;
@@ -81,7 +81,7 @@
   {/if}
 
   <div
-    class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm cursor-pointer transition-colors mx-2 mt-2 {loc === '/ws/' + wsId ? 'bg-primary/10 text-primary font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
+    class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm cursor-pointer transition-colors mx-2 mt-2 {loc === '/ws/' + wsId ? 'bg-white text-foreground font-medium shadow-sm' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
     on:click={() => push('/ws/' + wsId)}
     on:keydown={e => e.key === 'Enter' && push('/ws/' + wsId)}
     role="button"
@@ -102,7 +102,7 @@
           {@const base = '/ws/' + wsId + '/view/' + key}
           {@const active = loc === base || loc.startsWith(base + '/')}
           <div
-            class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm cursor-pointer transition-colors {active ? 'bg-primary/10 text-primary font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
+            class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm cursor-pointer transition-colors {active ? 'bg-white text-foreground font-medium shadow-sm' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
             on:click={() => push('/ws/' + wsId + '/view/' + navTarget(key, v))}
             on:keydown={e => e.key === 'Enter' && push('/ws/' + wsId + '/view/' + navTarget(key, v))}
             role="button"

--- a/cmd/archipulse/ui/src/components/flow/AppNode.svelte
+++ b/cmd/archipulse/ui/src/components/flow/AppNode.svelte
@@ -4,13 +4,13 @@
   let { data = {} } = $props();
 
   const LIFECYCLE_STYLE = {
-    'Production':     { border: '#22c55e', text: '#86efac', bg: '#14352a' },
-    'Pilot':          { border: '#3b82f6', text: '#93c5fd', bg: '#172444' },
-    'Planned':        { border: '#8b5cf6', text: '#c4b5fd', bg: '#22173a' },
-    'Retiring':       { border: '#f97316', text: '#fdba74', bg: '#3a2010' },
-    'Decommissioned': { border: '#ef4444', text: '#fca5a5', bg: '#3a1414' },
+    'Production':     { border: '#16a34a', text: '#166534', bg: '#f0fdf4' },
+    'Pilot':          { border: '#2563eb', text: '#1d4ed8', bg: '#eff6ff' },
+    'Planned':        { border: '#7c3aed', text: '#6d28d9', bg: '#f5f3ff' },
+    'Retiring':       { border: '#ea580c', text: '#c2410c', bg: '#fff7ed' },
+    'Decommissioned': { border: '#dc2626', text: '#b91c1c', bg: '#fef2f2' },
   };
-  const DEFAULT_STYLE = { border: '#4a6fa5', text: '#93b4f0', bg: '#1e2d45' };
+  const DEFAULT_STYLE = { border: '#2563eb', text: '#1e3a8a', bg: '#eff6ff' };
 
   const style       = $derived(LIFECYCLE_STYLE[data.lifecycle] ?? DEFAULT_STYLE);
   const isComponent = $derived(data.tier === 'component');
@@ -33,7 +33,7 @@
   border-radius:8px;
   text-align:center;
   line-height:1.35;
-  box-shadow:0 2px 12px rgba(0,0,0,0.5);
+  box-shadow:0 1px 4px rgba(0,0,0,0.10), 0 0 0 1px rgba(0,0,0,0.04);
   cursor:default;
   user-select:none;
 ">

--- a/cmd/archipulse/ui/src/components/flow/CapabilityNode.svelte
+++ b/cmd/archipulse/ui/src/components/flow/CapabilityNode.svelte
@@ -5,9 +5,9 @@
 </script>
 
 <div style="
-  background:#201808;
-  border:2px solid #e0af68;
-  color:#fcd990;
+  background:#fffbeb;
+  border:2px solid #d97706;
+  color:#78350f;
   font-weight:600;
   font-size:12px;
   min-width:160px;
@@ -16,14 +16,14 @@
   border-radius:8px;
   text-align:center;
   line-height:1.35;
-  box-shadow:0 2px 14px rgba(0,0,0,0.55);
+  box-shadow:0 1px 4px rgba(0,0,0,0.10), 0 0 0 1px rgba(0,0,0,0.04);
   cursor:default;
   user-select:none;
 ">
-  <Handle type="target" position={Position.Left}  style="background:#e0af68; width:9px; height:9px; border:none; border-radius:50%;" />
+  <Handle type="target" position={Position.Left}  style="background:#d97706; width:9px; height:9px; border:none; border-radius:50%;" />
   <div style="word-break:break-word;">{data.label}</div>
   {#if data.appCount > 0}
-    <div style="font-size:9px; opacity:0.5; margin-top:3px; font-weight:400; letter-spacing:0.3px;">{data.appCount} app{data.appCount > 1 ? 's' : ''}</div>
+    <div style="font-size:9px; opacity:0.55; margin-top:3px; font-weight:400; letter-spacing:0.3px;">{data.appCount} app{data.appCount > 1 ? 's' : ''}</div>
   {/if}
-  <Handle type="source" position={Position.Right} style="background:#e0af68; width:9px; height:9px; border:none; border-radius:50%;" />
+  <Handle type="source" position={Position.Right} style="background:#d97706; width:9px; height:9px; border:none; border-radius:50%;" />
 </div>

--- a/cmd/archipulse/ui/src/components/views/ApplicationCatalogueView.svelte
+++ b/cmd/archipulse/ui/src/components/views/ApplicationCatalogueView.svelte
@@ -37,23 +37,23 @@
   }
 
   const LIFECYCLE_COLORS = {
-    'Production':    'bg-[#14301e] text-[#4ade80]',
-    'Pilot':         'bg-[#1e2f55] text-[#60a5fa]',
-    'Planned':       'bg-[#2a1f4a] text-[#a78bfa]',
-    'Retiring':      'bg-[#3a2010] text-[#fb923c]',
-    'Decommissioned':'bg-[#3a1010] text-[#f87171]',
+    'Production':    'bg-[#dcfce7] text-[#166534]',
+    'Pilot':         'bg-[#dbeafe] text-[#1e40af]',
+    'Planned':       'bg-[#ede9fe] text-[#5b21b6]',
+    'Retiring':      'bg-[#ffedd5] text-[#9a3412]',
+    'Decommissioned':'bg-[#fee2e2] text-[#991b1b]',
   };
   const CRIT_COLORS = {
-    'Critical': 'bg-[#3a1010] text-[#f87171]',
-    'High':     'bg-[#3a2010] text-[#fb923c]',
-    'Medium':   'bg-[#3a3010] text-[#facc15]',
-    'Low':      'bg-[#14301e] text-[#4ade80]',
+    'Critical': 'bg-[#fee2e2] text-[#991b1b]',
+    'High':     'bg-[#ffedd5] text-[#9a3412]',
+    'Medium':   'bg-[#fef9c3] text-[#713f12]',
+    'Low':      'bg-[#dcfce7] text-[#166534]',
   };
   const DEPLOY_COLORS = {
-    'On-Premise':   'bg-[#1a2a1a] text-[#4ade80]',
-    'Public Cloud': 'bg-[#1e2f55] text-[#60a5fa]',
-    'SaaS':         'bg-[#14302a] text-[#34d399]',
-    'Hybrid':       'bg-[#2a1f4a] text-[#a78bfa]',
+    'On-Premise':   'bg-[#dcfce7] text-[#166534]',
+    'Public Cloud': 'bg-[#dbeafe] text-[#1e40af]',
+    'SaaS':         'bg-[#ccfbf1] text-[#134e4a]',
+    'Hybrid':       'bg-[#ede9fe] text-[#5b21b6]',
   };
 
   function badgeClass(key, val) {

--- a/cmd/archipulse/ui/src/components/views/ApplicationDashboard.svelte
+++ b/cmd/archipulse/ui/src/components/views/ApplicationDashboard.svelte
@@ -35,10 +35,10 @@
   ];
 
   const PALETTE = [
-    '#4ade80','#60a5fa','#a78bfa','#fb923c','#f87171',
-    '#34d399','#f472b6','#facc15','#38bdf8','#c084fc',
+    '#16a34a','#2563eb','#7c3aed','#ea580c','#dc2626',
+    '#0891b2','#db2777','#ca8a04','#0284c7','#9333ea',
   ];
-  const UNSET_COLOR = '#4b5563';
+  const UNSET_COLOR = '#94a3b8';
 
   function colorFor(value, index) {
     return value === '(unset)' ? UNSET_COLOR : PALETTE[index % PALETTE.length];
@@ -186,7 +186,7 @@
       <div class="flex gap-5 items-start">
 
         <!-- App list panel -->
-        <div class="flex-shrink-0 w-48 bg-card border border-border rounded-xl overflow-hidden">
+        <div class="flex-shrink-0 w-48 bg-card border border-border rounded-xl overflow-hidden shadow-sm">
           <div class="text-[10px] font-bold tracking-[0.6px] uppercase text-muted-foreground px-3 py-2.5 border-b border-border">
             Applications ({data.apps.length})
           </div>
@@ -209,7 +209,7 @@
           {#each sortedPropKeys(data.properties) as key}
             {@const buckets = data.properties[key]}
             {@const slices = arcData(buckets)}
-            <div class="bg-card border border-border rounded-xl p-4">
+            <div class="bg-card border border-border rounded-xl p-4 shadow-sm">
               <div class="text-[11px] font-bold tracking-[0.6px] uppercase text-muted-foreground mb-3">{propLabel(key)}</div>
               <div class="flex gap-4 items-center">
                 <!-- Donut -->

--- a/cmd/archipulse/ui/src/components/views/ElementCatalogueView.svelte
+++ b/cmd/archipulse/ui/src/components/views/ElementCatalogueView.svelte
@@ -19,14 +19,14 @@
 
   // ── Layer meta ────────────────────────────────────────────────────────────
   const LAYER_META = {
-    'Application':           { bg: '#0d1b38', text: '#7aa2f7', border: '#2a4080' },
-    'Business':              { bg: '#211800', text: '#e0af68', border: '#5a4010' },
-    'Technology':            { bg: '#0d1f0d', text: '#9ece6a', border: '#2a4a1a' },
-    'Motivation':            { bg: '#1e1030', text: '#bb9af7', border: '#4a2a80' },
-    'Strategy':              { bg: '#0d2020', text: '#4fd1c5', border: '#1a5555' },
-    'Physical':              { bg: '#201408', text: '#d4956a', border: '#5a3a18' },
-    'ImplementationMigration': { bg: '#10181e', text: '#7dcfff', border: '#1e4060' },
-    'Composite':             { bg: '#161b22', text: '#8b949e', border: '#30363d' },
+    'Application':           { bg: '#eff6ff', text: '#1d4ed8', border: '#bfdbfe' },
+    'Business':              { bg: '#fffbeb', text: '#92400e', border: '#fde68a' },
+    'Technology':            { bg: '#f0fdf4', text: '#166534', border: '#bbf7d0' },
+    'Motivation':            { bg: '#f5f3ff', text: '#6d28d9', border: '#ddd6fe' },
+    'Strategy':              { bg: '#f0fdfa', text: '#0f766e', border: '#99f6e4' },
+    'Physical':              { bg: '#fff7ed', text: '#9a3412', border: '#fed7aa' },
+    'ImplementationMigration': { bg: '#f0f9ff', text: '#075985', border: '#bae6fd' },
+    'Composite':             { bg: '#f8fafc', text: '#475569', border: '#cbd5e1' },
   };
 
   const LAYER_LABELS = {
@@ -135,20 +135,26 @@
       <div class="flex flex-wrap gap-1.5">
         {#each layers as l}
           {@const m = LAYER_META[l] ?? LAYER_META['Composite']}
-          {@const active = activeLayers.size === 0 || activeLayers.has(l)}
-          <button
+          <span
+            role="button"
+            tabindex="0"
             onclick={() => toggleLayer(l)}
-            class="px-2.5 py-0.5 rounded-full text-[11px] font-medium border transition-opacity {activeLayers.size > 0 && !activeLayers.has(l) ? 'opacity-30' : ''}"
-            style="background:{m.bg}; color:{m.text}; border-color:{m.border};"
+            onkeydown={e => e.key === 'Enter' && toggleLayer(l)}
+            class="px-2.5 py-0.5 text-[11px] font-medium cursor-pointer transition-opacity select-none {activeLayers.size > 0 && !activeLayers.has(l) ? 'opacity-30' : ''}"
+            style="background:{m.bg}; color:{m.text}; border-radius:3px;"
           >
             {layerLabel(l)}
-          </button>
+          </span>
         {/each}
         {#if activeLayers.size > 0}
-          <button
+          <span
+            role="button"
+            tabindex="0"
             onclick={() => { activeLayers = new Set(); }}
-            class="px-2 py-0.5 rounded-full text-[11px] text-muted-foreground hover:text-foreground border border-border transition-colors"
-          >✕ clear</button>
+            onkeydown={e => e.key === 'Enter' && (activeLayers = new Set())}
+            class="px-2 py-0.5 text-[11px] text-muted-foreground hover:text-foreground cursor-pointer select-none"
+            style="border-radius:3px;"
+          >✕ clear</span>
         {/if}
       </div>
     </div>
@@ -186,8 +192,8 @@
               {@const m = LAYER_META[row.layer] ?? LAYER_META['Composite']}
               <tr class="border-b border-border hover:bg-muted/40 transition-colors">
                 <td class="px-3 py-2 whitespace-nowrap">
-                  <span class="inline-block px-2 py-0.5 rounded-full text-[11px] font-medium border"
-                        style="background:{m.bg}; color:{m.text}; border-color:{m.border};">
+                  <span class="inline-block px-2 py-0.5 text-[11px] font-medium"
+                        style="background:{m.bg}; color:{m.text}; border-radius:3px; border:none;">
                     {layerLabel(row.layer)}
                   </span>
                 </td>

--- a/cmd/archipulse/ui/src/components/views/TableView.svelte
+++ b/cmd/archipulse/ui/src/components/views/TableView.svelte
@@ -20,10 +20,10 @@
   const layerCols = new Set(['Layer', 'layer']);
 
   function layerTagClass(val) {
-    if (val === 'Application') return 'bg-[#1e2f55] text-[#7aa2f7] border-0 text-[11px]';
-    if (val === 'Business')    return 'bg-[#2a2414] text-[#e0af68] border-0 text-[11px]';
-    if (val === 'Technology')  return 'bg-[#1a2a1a] text-[#9ece6a] border-0 text-[11px]';
-    if (val === 'Motivation')  return 'bg-[#2a1a2a] text-[#bb9af7] border-0 text-[11px]';
+    if (val === 'Application') return 'bg-[#eff6ff] text-[#1d4ed8] border-0 text-[11px]';
+    if (val === 'Business')    return 'bg-[#fffbeb] text-[#92400e] border-0 text-[11px]';
+    if (val === 'Technology')  return 'bg-[#f0fdf4] text-[#166534] border-0 text-[11px]';
+    if (val === 'Motivation')  return 'bg-[#f5f3ff] text-[#6d28d9] border-0 text-[11px]';
     return null;
   }
 

--- a/cmd/archipulse/ui/src/components/views/TechnologyCatalogueView.svelte
+++ b/cmd/archipulse/ui/src/components/views/TechnologyCatalogueView.svelte
@@ -29,14 +29,17 @@
   }
 
   const CATEGORY_BADGE = {
-    'Node':              'bg-[#1e2f55] text-[#7aa2f7]',
-    'Device':            'bg-[#1e2f55] text-[#7aa2f7]',
-    'SystemSoftware':    'bg-[#14302a] text-[#34d399]',
-    'TechnologyService': 'bg-[#2a2414] text-[#e0af68]',
-    'Artifact':          'bg-[#2a1f4a] text-[#a78bfa]',
+    'Node':              { bg: '#dbeafe', text: '#1e40af' },
+    'Device':            { bg: '#dbeafe', text: '#1e40af' },
+    'SystemSoftware':    { bg: '#dcfce7', text: '#166534' },
+    'TechnologyService': { bg: '#ffedd5', text: '#9a3412' },
+    'Artifact':          { bg: '#ede9fe', text: '#5b21b6' },
+    'CommunicationNetwork': { bg: '#f1f5f9', text: '#475569' },
+    'Path':              { bg: '#f1f5f9', text: '#475569' },
   };
-  function categoryBadgeClass(t) {
-    return CATEGORY_BADGE[t] ?? 'bg-muted text-muted-foreground';
+  function categoryBadgeStyle(t) {
+    const b = CATEGORY_BADGE[t] ?? { bg: '#f1f5f9', text: '#475569' };
+    return `background:${b.bg}; color:${b.text};`;
   }
 
   // ── Filtering & sorting ────────────────────────────────────────────────────
@@ -166,7 +169,7 @@
               <tr class="hover:bg-muted/30 transition-colors">
                 <td class="px-3 py-2.5 font-medium text-foreground whitespace-nowrap">{entry.name}</td>
                 <td class="px-3 py-2.5 whitespace-nowrap">
-                  <span class="inline-block px-2 py-0.5 rounded text-[11px] font-medium {categoryBadgeClass(entry.type)}">
+                  <span class="inline-block px-2 py-0.5 rounded text-[11px] font-medium" style="{categoryBadgeStyle(entry.type)}">
                     {categoryLabel(entry.type)}
                   </span>
                 </td>
@@ -179,7 +182,7 @@
                   {:else}
                     <div class="flex flex-wrap gap-1">
                       {#each entry.used_by_apps as app}
-                        <span class="inline-block px-1.5 py-0.5 rounded text-[11px] bg-[#1e2f55] text-[#7aa2f7]">{app}</span>
+                        <span class="inline-block px-1.5 py-0.5 rounded text-[11px]" style="background:#dbeafe; color:#1e40af;">{app}</span>
                       {/each}
                     </div>
                   {/if}

--- a/cmd/archipulse/ui/src/routes/ApplicationLandscapeMap.svelte
+++ b/cmd/archipulse/ui/src/routes/ApplicationLandscapeMap.svelte
@@ -18,31 +18,31 @@
   // Well-known value → colour for common property keys
   const KNOWN_COLORS = {
     lifecycle_status: {
-      'Production':    '#4ade80',
-      'Pilot':         '#60a5fa',
-      'Planned':       '#a78bfa',
-      'Retiring':      '#fb923c',
-      'Decommissioned':'#f87171',
+      'Production':    '#16a34a',
+      'Pilot':         '#2563eb',
+      'Planned':       '#7c3aed',
+      'Retiring':      '#ea580c',
+      'Decommissioned':'#dc2626',
     },
     criticality: {
-      'Critical': '#f87171',
-      'High':     '#fb923c',
-      'Medium':   '#facc15',
-      'Low':      '#4ade80',
+      'Critical': '#dc2626',
+      'High':     '#ea580c',
+      'Medium':   '#ca8a04',
+      'Low':      '#16a34a',
     },
     deployment_model: {
-      'On-Premise':  '#4ade80',
-      'Public Cloud':'#60a5fa',
-      'SaaS':        '#34d399',
-      'Hybrid':      '#a78bfa',
+      'On-Premise':  '#16a34a',
+      'Public Cloud':'#2563eb',
+      'SaaS':        '#0891b2',
+      'Hybrid':      '#7c3aed',
     },
   };
 
   const PALETTE = [
-    '#4ade80','#60a5fa','#a78bfa','#fb923c','#f87171',
-    '#34d399','#f472b6','#facc15','#38bdf8','#c084fc',
+    '#16a34a','#2563eb','#7c3aed','#ea580c','#dc2626',
+    '#0891b2','#db2777','#ca8a04','#0284c7','#9333ea',
   ];
-  const UNSET_COLOR = '#374151';
+  const UNSET_COLOR = '#94a3b8';
 
   // Per-overlay, assign consistent colours to each distinct value
   function buildColorMap(overlay, l1List) {
@@ -69,11 +69,12 @@
 
   $: colorMap = data ? buildColorMap(overlay, data.l1) : {};
 
-  // overlay is passed explicitly so Svelte tracks it as a template dependency
-  // and re-evaluates the expression when the overlay selector changes.
-  function chipColor(app, ov) {
+  // Chip uses a colored left border (same saturated color as legend dot)
+  // with a neutral background — directly connects chip to legend visually.
+  function chipStyle(app, ov) {
     const v = app.properties?.[ov] ?? '';
-    return v ? (colorMap[v] ?? '#6b7280') : UNSET_COLOR;
+    const color = v ? (colorMap[v] ?? '#94a3b8') : UNSET_COLOR;
+    return `border-left: 3px solid ${color}; background:${color}18; color:#1e293b; padding-left:7px;`;
   }
 
   // ── Legend entries (distinct values present) ──────────────────────────────
@@ -208,15 +209,15 @@
       <div class="space-y-4">
         {#each data.l1 as l1}
           {@const totalApps = l1.l2.reduce((s, l2) => s + l2.apps.length, 0)}
-          <div class="border border-border rounded-xl overflow-hidden">
+          <div class="border border-slate-300 rounded-xl overflow-hidden" style="box-shadow: 0 1px 3px rgba(0,0,0,0.08), 0 0 0 1px rgba(0,0,0,0.04);">
             <!-- L1 header -->
-            <div class="bg-[#1a1f2e] border-b border-border px-4 py-2.5 flex items-center gap-3">
-              <span class="text-[13px] font-bold text-foreground tracking-wide uppercase">{l1.name}</span>
-              <span class="text-[11px] text-muted-foreground ml-auto">{totalApps} app{totalApps !== 1 ? 's' : ''}</span>
+            <div class="bg-slate-100 border-b border-slate-200 px-4 py-2.5 flex items-center gap-3">
+              <span class="text-[12px] font-bold text-slate-600 tracking-[0.8px] uppercase">{l1.name}</span>
+              <span class="text-[11px] text-slate-400 ml-auto">{totalApps} app{totalApps !== 1 ? 's' : ''}</span>
             </div>
 
             <!-- L2 rows -->
-            <div class="divide-y divide-border/50">
+            <div class="divide-y divide-slate-200">
               {#each l1.l2 as l2}
                 <div class="flex items-start gap-3 px-4 py-2.5 hover:bg-muted/20 transition-colors">
                   <!-- L2 name + count -->
@@ -232,8 +233,8 @@
                     {:else}
                       {#each l2.apps as app}
                         <button
-                          class="inline-flex items-center px-2.5 py-0.5 rounded text-[11px] font-medium text-[#0f1117] transition-opacity hover:opacity-80 cursor-default"
-                          style="background:{chipColor(app, overlay)}"
+                          class="inline-flex items-center px-2.5 py-1 rounded text-[11px] font-medium transition-opacity hover:opacity-80 cursor-default"
+                          style="{chipStyle(app, overlay)}"
                           onmouseenter={(e) => showTooltip(e, app)}
                           onmouseleave={hideTooltip}
                           onfocus={(e) => showTooltip(e, app)}

--- a/cmd/archipulse/ui/src/routes/CapabilityTree.svelte
+++ b/cmd/archipulse/ui/src/routes/CapabilityTree.svelte
@@ -155,8 +155,8 @@
         id:        `comp_${cap.parent_id}_${cap.id}`,
         source:    cap.parent_id,
         target:    cap.id,
-        style:     'stroke:#c09040; stroke-width:1.8px;',
-        markerEnd: { type: 'arrowclosed', color: '#c09040', width: 12, height: 12 },
+        style:     'stroke:#d97706; stroke-width:1.8px;',
+        markerEnd: { type: 'arrowclosed', color: '#d97706', width: 12, height: 12 },
       });
     });
 
@@ -166,8 +166,8 @@
         id:        `srv_${nodeId}`,
         source:    capId,
         target:    nodeId,
-        style:     'stroke:#4a6fa555; stroke-width:1.4px; stroke-dasharray:5,4;',
-        markerEnd: { type: 'arrowclosed', color: '#4a6fa5', width: 11, height: 11 },
+        style:     'stroke:#2563eb55; stroke-width:1.4px; stroke-dasharray:5,4;',
+        markerEnd: { type: 'arrowclosed', color: '#2563eb', width: 11, height: 11 },
       });
     });
 
@@ -280,7 +280,7 @@
       </div>
 
       <!-- Flow canvas -->
-      <div class="flex-1 min-w-0" style="background:#0d1526;">
+      <div class="flex-1 min-w-0" style="background:#f8fafc;">
         <SvelteFlow
           {nodes}
           {edges}
@@ -290,28 +290,28 @@
           minZoom={0.05}
           maxZoom={3}
           proOptions={{ hideAttribution: true }}
-          style="background:#0d1526; width:100%; height:100%;"
+          style="background:#f8fafc; width:100%; height:100%;"
         >
           <FlowControls onReady={(fn) => { fitView = fn; }} />
 
-          <Controls showInteractive={false} style="background:#122040; border:1px solid #1e3a5f; border-radius:8px;" />
+          <Controls showInteractive={false} style="background:#ffffff; border:1px solid #e2e8f0; border-radius:8px;" />
 
           <MiniMap
             position="bottom-right"
-            style="background:#122040; border:1px solid #1e3a5f; border-radius:8px; margin-bottom:48px;"
-            nodeColor={(n) => n.type === 'capNode' ? '#c09040' : (LIFECYCLE_COLORS[n.data?.lifecycle] ?? '#4a6fa5')}
+            style="background:#ffffff; border:1px solid #e2e8f0; border-radius:8px; margin-bottom:48px;"
+            nodeColor={(n) => n.type === 'capNode' ? '#d97706' : (LIFECYCLE_COLORS[n.data?.lifecycle] ?? '#2563eb')}
             maskColor="rgba(0,0,0,0.55)"
           />
 
-          <Background variant={BackgroundVariant.Dots} gap={22} size={1} color="#112050" />
+          <Background variant={BackgroundVariant.Dots} gap={22} size={1} color="#cbd5e1" />
 
           <!-- Legend -->
           <Panel position="bottom-left">
-            <div class="rounded-lg px-3.5 py-3 text-[11px]" style="background:rgba(13,21,38,0.94); border:1px solid #1e3a5f; min-width:140px;">
-              <div class="text-[10px] font-bold uppercase tracking-wide mb-2" style="color:#6b7280;">Node type</div>
+            <div class="rounded-lg px-3.5 py-3 text-[11px]" style="background:rgba(255,255,255,0.97); border:1px solid #e2e8f0; min-width:140px;">
+              <div class="text-[10px] font-bold uppercase tracking-wide mb-2" style="color:#64748b;">Node type</div>
               <div class="flex items-center gap-2 mb-1.5">
-                <div style="width:20px; height:12px; border-radius:3px; border:2px solid #e0af68; background:#201808; flex-shrink:0;"></div>
-                <span style="color:#fcd990; font-weight:600;">Capability</span>
+                <div style="width:20px; height:12px; border-radius:3px; border:2px solid #d97706; background:#fffbeb; flex-shrink:0;"></div>
+                <span style="color:#78350f; font-weight:600;">Capability</span>
               </div>
               {#each [
                 { label: 'Component', bs: 'solid',  color: '#93b4f0', bold: true  },
@@ -325,14 +325,14 @@
                 </div>
               {/each}
 
-              <div class="text-[10px] font-bold uppercase tracking-wide mt-3 mb-1.5" style="color:#6b7280;">Edges</div>
+              <div class="text-[10px] font-bold uppercase tracking-wide mt-3 mb-1.5" style="color:#64748b;">Edges</div>
               <div class="flex items-center gap-2 mb-1.5">
-                <div style="width:20px; height:2px; background:#c09040; flex-shrink:0;"></div>
-                <span style="color:#8b949e;">Composition</span>
+                <div style="width:20px; height:2px; background:#d97706; flex-shrink:0;"></div>
+                <span style="color:#475569;">Composition</span>
               </div>
               <div class="flex items-center gap-2">
-                <div style="width:20px; height:1px; border-top:1.5px dashed #4a6fa5; flex-shrink:0;"></div>
-                <span style="color:#8b949e;">Supports</span>
+                <div style="width:20px; height:1px; border-top:1.5px dashed #2563eb; flex-shrink:0;"></div>
+                <span style="color:#475569;">Supports</span>
               </div>
             </div>
           </Panel>

--- a/cmd/archipulse/ui/src/routes/DependencyGraphView.svelte
+++ b/cmd/archipulse/ui/src/routes/DependencyGraphView.svelte
@@ -49,11 +49,11 @@
   let activeRels = $state(new Set(REL_TYPES.map(r => r.key)));
 
   const LIFECYCLE_COLORS = {
-    'Production':     '#22c55e',
-    'Pilot':          '#3b82f6',
-    'Planned':        '#8b5cf6',
-    'Retiring':       '#f97316',
-    'Decommissioned': '#ef4444',
+    'Production':     '#16a34a',
+    'Pilot':          '#2563eb',
+    'Planned':        '#7c3aed',
+    'Retiring':       '#ea580c',
+    'Decommissioned': '#dc2626',
   };
 
   const REL_META = {
@@ -220,7 +220,7 @@
 <!-- Edge tooltip -->
 {#if tooltip}
   <div class="fixed z-50 pointer-events-none rounded-lg shadow-xl px-3 py-2 text-[12px] text-foreground max-w-sm"
-       style="left:{Math.min(tooltip.x + 16, window.innerWidth - 320)}px; top:{tooltip.y - 40}px; background:rgba(13,21,38,0.96); border:1px solid #1e3a5f;">
+       style="left:{Math.min(tooltip.x + 16, window.innerWidth - 320)}px; top:{tooltip.y - 40}px; background:rgba(255,255,255,0.97); border:1px solid #e2e8f0;">
     {tooltip.text}
   </div>
 {/if}
@@ -309,7 +309,7 @@
       </div>
 
       <!-- Flow canvas -->
-      <div class="flex-1 min-w-0" style="background:#0d1526;">
+      <div class="flex-1 min-w-0" style="background:#f8fafc;">
         <SvelteFlow
           {nodes}
           {edges}
@@ -321,26 +321,26 @@
           proOptions={{ hideAttribution: true }}
           onedgepointerenter={onEdgePointerEnter}
           onedgepointerleave={onEdgePointerLeave}
-          style="background:#0d1526; width:100%; height:100%;"
+          style="background:#f8fafc; width:100%; height:100%;"
         >
           <!-- Registers fitView from inside the SvelteFlow context -->
           <FlowControls onReady={(fn) => { fitView = fn; }} />
 
-          <Controls showInteractive={false} style="background:#122040; border:1px solid #1e3a5f; border-radius:8px;" />
+          <Controls showInteractive={false} style="background:#ffffff; border:1px solid #e2e8f0; border-radius:8px;" />
 
           <MiniMap
             position="bottom-right"
-            style="background:#122040; border:1px solid #1e3a5f; border-radius:8px; margin-bottom:48px;"
+            style="background:#ffffff; border:1px solid #e2e8f0; border-radius:8px; margin-bottom:48px;"
             nodeColor={(n) => LIFECYCLE_COLORS[n.data?.lifecycle] ?? '#4a6fa5'}
             maskColor="rgba(0,0,0,0.55)"
           />
 
-          <Background variant={BackgroundVariant.Dots} gap={22} size={1} color="#112050" />
+          <Background variant={BackgroundVariant.Dots} gap={22} size={1} color="#cbd5e1" />
 
           <!-- Legend panel — rendered inside SvelteFlow as an overlay -->
           <Panel position="bottom-left">
-            <div class="rounded-lg px-3.5 py-3 text-[11px]" style="background:rgba(13,21,38,0.94); border:1px solid #1e3a5f; min-width:140px;">
-              <div class="text-[10px] font-bold uppercase tracking-wide mb-2" style="color:#6b7280;">Node type</div>
+            <div class="rounded-lg px-3.5 py-3 text-[11px]" style="background:rgba(255,255,255,0.97); border:1px solid #e2e8f0; min-width:140px;">
+              <div class="text-[10px] font-bold uppercase tracking-wide mb-2" style="color:#64748b;">Node type</div>
               {#each [
                 { label: 'Component', bs: 'solid',  color: '#93b4f0', bold: true  },
                 { label: 'Service',   bs: 'dashed', color: '#7aabf7', bold: false },
@@ -353,11 +353,11 @@
                 </div>
               {/each}
 
-              <div class="text-[10px] font-bold uppercase tracking-wide mt-3 mb-2" style="color:#6b7280;">Lifecycle</div>
+              <div class="text-[10px] font-bold uppercase tracking-wide mt-3 mb-2" style="color:#64748b;">Lifecycle</div>
               {#each Object.entries(LIFECYCLE_COLORS) as [lc, color]}
                 <div class="flex items-center gap-2 mb-1.5">
                   <span style="width:8px; height:8px; border-radius:50%; background:{color}; flex-shrink:0; display:inline-block;"></span>
-                  <span style="color:#8b949e;">{lc}</span>
+                  <span style="color:#475569;">{lc}</span>
                 </div>
               {/each}
             </div>


### PR DESCRIPTION
## Summary

- Replaces the dark navy theme with a Corporate Light design suited for enterprise EA tooling
- Design tokens: `#f8fafc` background, `#ffffff` surfaces, `#2563eb` brand blue, `#cbd5e1` borders
- Light-mode nodes (AppNode/CapabilityNode) with pastel backgrounds and dark same-hue text
- Dependency Graph and Capability Tree: light canvas, controls, minimap, and legend
- Application Landscape: light L1 headers; chip colors derived from legend via `color18` tint trick
- All catalogue views: badge colors use inline `style=` (avoids Tailwind v4 build-time purge of dynamic classes)
- Sidebar active state: clean white card on slate sidebar instead of blue tint
- Application Dashboard: saturated palette on white with `shadow-sm` card separation

## Test plan

- [ ] Application Dashboard — donut charts render with correct colors, legend tooltips work
- [ ] Application Catalogue — lifecycle/criticality/deployment badges are readable
- [ ] Technology Catalogue — category badges display correctly
- [ ] Element Catalogue — layer filter pills and table badges render
- [ ] Application Landscape Map — chips match legend color, L1 headers are light
- [ ] Dependency Graph — light canvas, node colors, edge tooltips
- [ ] Capability Tree — light canvas, amber capability nodes
- [ ] Sidebar — active item shows white card highlight