### PR TITLE
feat(ui): mobile responsive layout

### DIFF
--- a/cmd/archipulse/ui/src/App.svelte
+++ b/cmd/archipulse/ui/src/App.svelte
@@ -87,15 +87,31 @@
   function routeEvent(e) {
     currentParams = extractParams($location);
   }
+
+  let sidebarOpen = false;
+
+  function toggleSidebar() {
+    sidebarOpen = !sidebarOpen;
+  }
+
+  function closeSidebar() {
+    sidebarOpen = false;
+  }
+
+  // Close sidebar on navigation
+  $: if ($location) sidebarOpen = false;
 </script>
 
-<Nav wsId={wsId} wsName={ws ? ws.name : null} {viewLabel} />
+<Nav wsId={wsId} wsName={ws ? ws.name : null} {viewLabel} on:toggleSidebar={toggleSidebar} />
 
 <div class="app-shell">
   {#if wsId}
+    <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+    <div class="sidebar-overlay {sidebarOpen ? 'open' : ''}" onclick={closeSidebar}></div>
     <Sidebar
       {wsId}
       {ws}
+      open={sidebarOpen}
       on:imported={handleImported}
     />
     <div style="flex:1;display:flex;flex-direction:column;min-width:0">

--- a/cmd/archipulse/ui/src/app.css
+++ b/cmd/archipulse/ui/src/app.css
@@ -214,6 +214,13 @@
 .breadcrumb .sep { color: var(--border); }
 .breadcrumb .current { color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
+/* ── Full-screen flow views (Dependency Graph, Capability Tree) ──────────── */
+@media (max-width: 768px) {
+  .flow-fullscreen {
+    left: 0 !important;
+  }
+}
+
 /* ── Graph ───────────────────────────────────────────────────────────────── */
 .cy-container {
   width: 100%;

--- a/cmd/archipulse/ui/src/app.css
+++ b/cmd/archipulse/ui/src/app.css
@@ -113,6 +113,7 @@
     left: 0;
     overflow-y: auto;
     z-index: 90;
+    transition: transform 0.25s ease;
   }
 
   /* ── Content areas ────────────────────────────────────────────────────── */
@@ -128,6 +129,34 @@
     max-width: 1080px;
     margin: 0 auto;
     width: 100%;
+  }
+
+  /* ── Sidebar overlay (mobile) ─────────────────────────────────────────── */
+  .sidebar-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(15,23,42,0.4);
+    z-index: 89;
+  }
+
+  @media (max-width: 768px) {
+    .sidebar {
+      transform: translateX(-100%);
+    }
+    .sidebar.open {
+      transform: translateX(0);
+    }
+    .sidebar-overlay.open {
+      display: block;
+    }
+    .content {
+      margin-left: 0;
+      padding: 16px;
+    }
+    .content-full {
+      padding: 16px;
+    }
   }
 }
 
@@ -152,6 +181,25 @@
 .w-pulse  { font-weight: 700; color: var(--brand); }
 .nav-sep  { width: 1px; height: 20px; background: var(--border); margin: 0 4px; }
 .nav-spacer { flex: 1; }
+
+.nav-hamburger {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: none;
+  color: var(--text);
+  cursor: pointer;
+  border-radius: 6px;
+  flex-shrink: 0;
+}
+.nav-hamburger:hover { background: var(--border); }
+
+@media (max-width: 768px) {
+  .nav-hamburger { display: flex; }
+}
 
 .breadcrumb {
   display: flex;

--- a/cmd/archipulse/ui/src/components/Nav.svelte
+++ b/cmd/archipulse/ui/src/components/Nav.svelte
@@ -1,18 +1,33 @@
 <script>
   import { push } from 'svelte-spa-router';
   import { Button } from '$lib/components/ui/button';
+  import { createEventDispatcher } from 'svelte';
 
   export let wsId = null;
   export let wsName = null;
   export let viewLabel = null;
 
+  const dispatch = createEventDispatcher();
+
   function showCreateWs() {
-    // Dispatch event to App.svelte to open modal
     window.dispatchEvent(new CustomEvent('archipulse:create-ws'));
+  }
+
+  function toggleSidebar() {
+    dispatch('toggleSidebar');
   }
 </script>
 
 <nav>
+  {#if wsId}
+    <button class="nav-hamburger" onclick={toggleSidebar} aria-label="Toggle menu">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6"/>
+        <line x1="3" y1="12" x2="21" y2="12"/>
+        <line x1="3" y1="18" x2="21" y2="18"/>
+      </svg>
+    </button>
+  {/if}
   <a class="nav-logo" href="#/" use:push={'/'}>
     <svg width="22" height="22" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
       <polygon points="16,2 27,8 27,22 16,28 5,22 5,8" fill="#E85D3A"/>

--- a/cmd/archipulse/ui/src/components/Sidebar.svelte
+++ b/cmd/archipulse/ui/src/components/Sidebar.svelte
@@ -8,6 +8,7 @@
 
   export let wsId;
   export let ws = null;
+  export let open = false;
 
   const dispatch = createEventDispatcher();
 
@@ -72,7 +73,7 @@
   }
 </script>
 
-<aside class="sidebar">
+<aside class="sidebar {open ? 'open' : ''}">
   {#if ws}
     <div class="px-4 pt-4 pb-3 border-b border-border">
       <div class="text-[13px] font-semibold text-foreground whitespace-nowrap overflow-hidden text-ellipsis mb-1">{ws.name}</div>

--- a/cmd/archipulse/ui/src/components/views/ApplicationDashboard.svelte
+++ b/cmd/archipulse/ui/src/components/views/ApplicationDashboard.svelte
@@ -185,8 +185,8 @@
       <!-- Two-column layout: app list | donuts -->
       <div class="flex gap-5 items-start">
 
-        <!-- App list panel -->
-        <div class="flex-shrink-0 w-48 bg-card border border-border rounded-xl overflow-hidden shadow-sm">
+        <!-- App list panel — hidden on mobile -->
+        <div class="hidden sm:flex flex-shrink-0 w-48 bg-card border border-border rounded-xl overflow-hidden shadow-sm flex-col">
           <div class="text-[10px] font-bold tracking-[0.6px] uppercase text-muted-foreground px-3 py-2.5 border-b border-border">
             Applications ({data.apps.length})
           </div>
@@ -205,7 +205,7 @@
         </div>
 
         <!-- Donuts grid -->
-        <div class="flex-1 grid grid-cols-1 xl:grid-cols-2 gap-4">
+        <div class="flex-1 grid grid-cols-1 md:grid-cols-2 gap-4">
           {#each sortedPropKeys(data.properties) as key}
             {@const buckets = data.properties[key]}
             {@const slices = arcData(buckets)}

--- a/cmd/archipulse/ui/src/routes/CapabilityTree.svelte
+++ b/cmd/archipulse/ui/src/routes/CapabilityTree.svelte
@@ -201,7 +201,7 @@
 </script>
 
 <!-- full-viewport container, same pattern as DependencyGraphView -->
-<div style="position:fixed; top:var(--nav-h); left:var(--sidebar-w); right:0; bottom:0; display:flex; flex-direction:column; overflow:hidden; background:var(--bg);">
+<div class="flow-fullscreen" style="position:fixed; top:var(--nav-h); left:var(--sidebar-w); right:0; bottom:0; display:flex; flex-direction:column; overflow:hidden; background:var(--bg);">
 
   <!-- Header -->
   <div class="flex items-center justify-between gap-4 px-6 pt-5 pb-4 flex-shrink-0">
@@ -230,8 +230,8 @@
   {:else}
     <div class="flex flex-1 min-h-0">
 
-      <!-- Left panel -->
-      <div class="flex flex-col border-r border-border w-52 flex-shrink-0 bg-card/50 overflow-hidden min-h-0 h-full">
+      <!-- Left panel — hidden on mobile -->
+      <div class="hidden sm:flex flex-col border-r border-border w-52 flex-shrink-0 bg-card/50 overflow-hidden min-h-0 h-full">
 
         <!-- Search -->
         <div class="px-3 pt-3 pb-2 flex-shrink-0">

--- a/cmd/archipulse/ui/src/routes/CapabilityTree.svelte
+++ b/cmd/archipulse/ui/src/routes/CapabilityTree.svelte
@@ -228,7 +228,7 @@
       <p class="text-[14px]">No Capability elements found — import or create Capability elements first.</p>
     </div>
   {:else}
-    <div class="flex flex-1 min-h-0">
+    <div class="flex flex-1 min-h-0 relative">
 
       <!-- Left panel — hidden on mobile -->
       <div class="hidden sm:flex flex-col border-r border-border w-52 flex-shrink-0 bg-card/50 overflow-hidden min-h-0 h-full">
@@ -279,8 +279,24 @@
         </div>
       </div>
 
+      <!-- Mobile capability selector -->
+      <div class="sm:hidden absolute top-0 left-0 right-0 z-10 px-3 py-2 bg-card/95 border-b border-border flex items-center gap-2">
+        <select
+          class="flex-1 bg-background border border-border rounded-md px-2.5 py-1.5 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+          onchange={e => e.target.value === '' ? clearSelection() : selectCap(e.target.value)}
+        >
+          <option value="">All capabilities</option>
+          {#each allCaps as cap}
+            <option value={cap.id} selected={cap.id === selectedId}>{cap.name}</option>
+          {/each}
+        </select>
+        {#if selectedId}
+          <button class="text-[12px] text-muted-foreground hover:text-foreground px-2 py-1.5 border border-border rounded-md bg-background" onclick={clearSelection}>✕</button>
+        {/if}
+      </div>
+
       <!-- Flow canvas -->
-      <div class="flex-1 min-w-0" style="background:#f8fafc;">
+      <div class="flex-1 min-w-0 relative" style="background:#f8fafc;">
         <SvelteFlow
           {nodes}
           {edges}

--- a/cmd/archipulse/ui/src/routes/DependencyGraphView.svelte
+++ b/cmd/archipulse/ui/src/routes/DependencyGraphView.svelte
@@ -252,7 +252,7 @@
       <p class="text-[14px]">No application elements — import a model first.</p>
     </div>
   {:else}
-    <div class="flex flex-1 min-h-0">
+    <div class="flex flex-1 min-h-0 relative">
 
       <!-- Left panel — hidden on mobile -->
       <div class="hidden sm:flex flex-col border-r border-border w-52 flex-shrink-0 bg-card/50 overflow-hidden min-h-0 h-full">
@@ -308,8 +308,41 @@
         </div>
       </div>
 
+      <!-- Mobile search + chips bar -->
+      <div class="sm:hidden absolute top-0 left-0 right-0 z-10 bg-card/95 border-b border-border px-3 py-2 flex flex-col gap-1.5">
+        <input type="search" bind:value={searchQ} placeholder="Find application…"
+          class="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary" />
+        {#if selectedApps.size > 0}
+          <div class="flex flex-wrap gap-1 items-center">
+            {#each [...selectedApps] as id}
+              {@const node = allNodes.find(n => n.id === id)}
+              {@const color = LIFECYCLE_COLORS[node?.lifecycle_status] ?? '#6b7280'}
+              <span class="inline-flex items-center gap-1 pl-1.5 pr-1 py-0.5 rounded-full text-[11px] font-medium"
+                    style="background:{color}22; border:1px solid {color}55; color:{color};">
+                <span class="max-w-[100px] truncate">{node?.name ?? id}</span>
+                <button class="flex-shrink-0 rounded-full p-0.5 leading-none" onclick={() => toggleApp(id)}>×</button>
+              </span>
+            {/each}
+            <button class="text-[10px] text-muted-foreground hover:text-foreground px-1" onclick={clearFocus}>clear</button>
+          </div>
+        {:else if searchQ}
+          <div class="flex flex-col gap-0.5 max-h-36 overflow-y-auto">
+            {#each filteredNodes as node}
+              {@const color = LIFECYCLE_COLORS[node.lifecycle_status] ?? '#6b7280'}
+              <button
+                class="w-full text-left flex items-center gap-1.5 px-2 py-1 rounded text-[12px] text-foreground hover:bg-muted/50 transition-colors"
+                onclick={() => { toggleApp(node.id); searchQ = ''; }}
+              >
+                <span class="size-2 rounded-full flex-shrink-0" style="background:{color}"></span>
+                <span class="truncate">{node.name}</span>
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+
       <!-- Flow canvas -->
-      <div class="flex-1 min-w-0" style="background:#f8fafc;">
+      <div class="flex-1 min-w-0 relative" style="background:#f8fafc;">
         <SvelteFlow
           {nodes}
           {edges}

--- a/cmd/archipulse/ui/src/routes/DependencyGraphView.svelte
+++ b/cmd/archipulse/ui/src/routes/DependencyGraphView.svelte
@@ -225,7 +225,7 @@
   </div>
 {/if}
 
-<div style="position:fixed; top:var(--nav-h); left:var(--sidebar-w); right:0; bottom:0; display:flex; flex-direction:column; overflow:hidden; background:var(--bg);">
+<div class="flow-fullscreen" style="position:fixed; top:var(--nav-h); left:var(--sidebar-w); right:0; bottom:0; display:flex; flex-direction:column; overflow:hidden; background:var(--bg);">
 
   <!-- Header -->
   <div class="flex items-center justify-between gap-4 px-6 pt-5 pb-4 flex-shrink-0">
@@ -254,8 +254,8 @@
   {:else}
     <div class="flex flex-1 min-h-0">
 
-      <!-- Left panel -->
-      <div class="flex flex-col border-r border-border w-52 flex-shrink-0 bg-card/50 overflow-hidden min-h-0 h-full">
+      <!-- Left panel — hidden on mobile -->
+      <div class="hidden sm:flex flex-col border-r border-border w-52 flex-shrink-0 bg-card/50 overflow-hidden min-h-0 h-full">
 
         <!-- Search -->
         <div class="px-3 pt-3 pb-2 flex-shrink-0">


### PR DESCRIPTION
## Summary

- Sidebar collapses to a slide-in drawer on mobile with hamburger toggle in nav
- Overlay closes sidebar on tap outside; navigation auto-closes it
- Dependency Graph and Capability Tree: `left:0` on mobile, left panel hidden
- Application Dashboard: app list panel hidden on mobile, donut grid goes single-column
- Capability Tree mobile: select dropdown to filter/focus a capability
- Dependency Graph mobile: search input + chip multi-select bar above the canvas

## Test plan
- [ ] Sidebar opens/closes via hamburger on mobile
- [ ] Tapping overlay closes sidebar
- [ ] Navigating between views closes sidebar
- [ ] Dependency Graph fills full width on mobile, search+chips work
- [ ] Capability Tree fills full width on mobile, select dropdown works
- [ ] Dashboard shows donuts only (no app list) on mobile
- [ ] Desktop layout unchanged