### PR TITLE
fix(views): make all views model-agnostic for any ArchiMate file

### DIFF
--- a/cmd/archipulse/ui/src/components/views/ApplicationCatalogueView.svelte
+++ b/cmd/archipulse/ui/src/components/views/ApplicationCatalogueView.svelte
@@ -36,31 +36,61 @@
     return PROP_LABELS[k] ?? k.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
   }
 
-  const LIFECYCLE_COLORS = {
-    'Production':    'bg-[#dcfce7] text-[#166534]',
-    'Pilot':         'bg-[#dbeafe] text-[#1e40af]',
-    'Planned':       'bg-[#ede9fe] text-[#5b21b6]',
-    'Retiring':      'bg-[#ffedd5] text-[#9a3412]',
-    'Decommissioned':'bg-[#fee2e2] text-[#991b1b]',
-  };
-  const CRIT_COLORS = {
-    'Critical': 'bg-[#fee2e2] text-[#991b1b]',
-    'High':     'bg-[#ffedd5] text-[#9a3412]',
-    'Medium':   'bg-[#fef9c3] text-[#713f12]',
-    'Low':      'bg-[#dcfce7] text-[#166534]',
-  };
-  const DEPLOY_COLORS = {
-    'On-Premise':   'bg-[#dcfce7] text-[#166534]',
-    'Public Cloud': 'bg-[#dbeafe] text-[#1e40af]',
-    'SaaS':         'bg-[#ccfbf1] text-[#134e4a]',
-    'Hybrid':       'bg-[#ede9fe] text-[#5b21b6]',
+  // Known-value badge classes for common ArchiMate property values.
+  const KNOWN_BADGES = {
+    lifecycle_status: {
+      'Production':    'bg-[#dcfce7] text-[#166534]',
+      'Pilot':         'bg-[#dbeafe] text-[#1e40af]',
+      'Planned':       'bg-[#ede9fe] text-[#5b21b6]',
+      'Retiring':      'bg-[#ffedd5] text-[#9a3412]',
+      'Decommissioned':'bg-[#fee2e2] text-[#991b1b]',
+    },
+    criticality: {
+      'Critical': 'bg-[#fee2e2] text-[#991b1b]',
+      'High':     'bg-[#ffedd5] text-[#9a3412]',
+      'Medium':   'bg-[#fef9c3] text-[#713f12]',
+      'Low':      'bg-[#dcfce7] text-[#166534]',
+    },
+    deployment_model: {
+      'On-Premise':   'bg-[#dcfce7] text-[#166534]',
+      'Public Cloud': 'bg-[#dbeafe] text-[#1e40af]',
+      'SaaS':         'bg-[#ccfbf1] text-[#134e4a]',
+      'Hybrid':       'bg-[#ede9fe] text-[#5b21b6]',
+    },
   };
 
+  // Palette for dynamically assigning colors to unknown property values.
+  const DYNAMIC_PALETTE = [
+    { bg: '#dbeafe', text: '#1e40af' },
+    { bg: '#dcfce7', text: '#166534' },
+    { bg: '#ede9fe', text: '#5b21b6' },
+    { bg: '#ffedd5', text: '#9a3412' },
+    { bg: '#ccfbf1', text: '#134e4a' },
+    { bg: '#fef9c3', text: '#713f12' },
+    { bg: '#fce7f3', text: '#9d174d' },
+    { bg: '#e0f2fe', text: '#0369a1' },
+  ];
+  // Cache: key → (value → style string)
+  const dynamicBadgeCache = {};
+  function dynamicBadgeStyle(key, val) {
+    if (!dynamicBadgeCache[key]) dynamicBadgeCache[key] = {};
+    if (!dynamicBadgeCache[key][val]) {
+      const idx = Object.keys(dynamicBadgeCache[key]).length % DYNAMIC_PALETTE.length;
+      dynamicBadgeCache[key][val] = idx;
+    }
+    const p = DYNAMIC_PALETTE[dynamicBadgeCache[key][val]];
+    return `background:${p.bg}; color:${p.text};`;
+  }
+
+  // Returns a Tailwind class string for known values, null to fall through to inline style.
   function badgeClass(key, val) {
-    if (key === 'lifecycle_status') return LIFECYCLE_COLORS[val] ?? 'bg-muted text-muted-foreground';
-    if (key === 'criticality')      return CRIT_COLORS[val]      ?? 'bg-muted text-muted-foreground';
-    if (key === 'deployment_model') return DEPLOY_COLORS[val]    ?? 'bg-muted text-muted-foreground';
-    return null;
+    return KNOWN_BADGES[key]?.[val] ?? null;
+  }
+
+  // Returns an inline style string for dynamic (unknown) values.
+  function badgeStyle(key, val) {
+    if (KNOWN_BADGES[key]?.[val]) return null; // handled by badgeClass
+    return dynamicBadgeStyle(key, val);
   }
 
   // ── Type display ───────────────────────────────────────────────────────────
@@ -248,9 +278,12 @@
                 {#each activePropCols as k}
                   {@const val = entry.properties[k] ?? ''}
                   {@const bc = val ? badgeClass(k, val) : null}
+                  {@const bs = val && !bc ? badgeStyle(k, val) : null}
                   <td class="px-3 py-2.5 whitespace-nowrap">
                     {#if bc}
                       <span class="inline-block px-2 py-0.5 rounded text-[11px] font-medium {bc}">{val}</span>
+                    {:else if bs}
+                      <span class="inline-block px-2 py-0.5 rounded text-[11px] font-medium" style={bs}>{val}</span>
                     {:else if val}
                       <span class="text-foreground">{val}</span>
                     {:else}

--- a/cmd/archipulse/ui/src/components/views/ApplicationDashboard.svelte
+++ b/cmd/archipulse/ui/src/components/views/ApplicationDashboard.svelte
@@ -182,6 +182,7 @@
         <p class="text-[14px] leading-relaxed">No applications found for this scope.</p>
       </div>
     {:else}
+      {@const propKeys = sortedPropKeys(data.properties)}
       <!-- Two-column layout: app list | donuts -->
       <div class="flex gap-5 items-start">
 
@@ -204,52 +205,61 @@
           </div>
         </div>
 
-        <!-- Donuts grid -->
-        <div class="flex-1 grid grid-cols-1 md:grid-cols-2 gap-4">
-          {#each sortedPropKeys(data.properties) as key}
-            {@const buckets = data.properties[key]}
-            {@const slices = arcData(buckets)}
-            <div class="bg-card border border-border rounded-xl p-4 shadow-sm">
-              <div class="text-[11px] font-bold tracking-[0.6px] uppercase text-muted-foreground mb-3">{propLabel(key)}</div>
-              <div class="flex gap-4 items-center">
-                <!-- Donut -->
-                <div class="size-[150px] flex-shrink-0">
-                  <ArcChart
-                    data={slices}
-                    key="key"
-                    label="label"
-                    value="value"
-                    c="color"
-                    innerRadius={0.60}
-                    padAngle={0.02}
-                    cornerRadius={2}
-                  />
-                </div>
-                <!-- Legend with hover tooltip -->
-                <div class="flex flex-col gap-0.5 min-w-0 flex-1">
-                  {#each slices as slice}
-                    {@const isHighlighted = selectedApp != null
-                      && (data.apps.find(a => a.id === selectedApp)?.properties?.[key] ?? '') === (slice.key === '(unset)' ? '' : slice.key)}
-                    <div
-                      role="button"
-                      tabindex="0"
-                      class="flex items-center gap-2 text-[12px] rounded px-1.5 py-1 cursor-default transition-colors hover:bg-muted/60
-                        {isHighlighted ? 'bg-primary/8 ring-1 ring-inset ring-primary/30' : ''}"
-                      onmouseenter={(e) => showTooltip(e, key, slice)}
-                      onmouseleave={hideTooltip}
-                      onfocus={(e) => showTooltip(e, key, slice)}
-                      onblur={hideTooltip}
-                    >
-                      <span class="size-2.5 rounded-full flex-shrink-0" style="background:{slice.color}"></span>
-                      <span class="text-muted-foreground truncate flex-1" title={slice.label}>{slice.label}</span>
-                      <span class="font-semibold tabular-nums text-foreground">{slice.value}</span>
-                    </div>
-                  {/each}
+        <!-- Right side: donuts or empty-property notice -->
+        {#if propKeys.length === 0}
+          <div class="flex-1 flex flex-col items-center justify-center py-16 text-muted-foreground text-center">
+            <div class="text-[32px] mb-3">📊</div>
+            <p class="text-[14px] font-medium text-foreground mb-1">No property data available</p>
+            <p class="text-[13px] max-w-xs">This model doesn't include application properties (lifecycle, criticality, etc.). Charts will appear once properties are defined.</p>
+          </div>
+        {:else}
+          <!-- Donuts grid -->
+          <div class="flex-1 grid grid-cols-1 md:grid-cols-2 gap-4">
+            {#each propKeys as key}
+              {@const buckets = data.properties[key]}
+              {@const slices = arcData(buckets)}
+              <div class="bg-card border border-border rounded-xl p-4 shadow-sm">
+                <div class="text-[11px] font-bold tracking-[0.6px] uppercase text-muted-foreground mb-3">{propLabel(key)}</div>
+                <div class="flex gap-4 items-center">
+                  <!-- Donut -->
+                  <div class="size-[150px] flex-shrink-0">
+                    <ArcChart
+                      data={slices}
+                      key="key"
+                      label="label"
+                      value="value"
+                      c="color"
+                      innerRadius={0.60}
+                      padAngle={0.02}
+                      cornerRadius={2}
+                    />
+                  </div>
+                  <!-- Legend with hover tooltip -->
+                  <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+                    {#each slices as slice}
+                      {@const isHighlighted = selectedApp != null
+                        && (data.apps.find(a => a.id === selectedApp)?.properties?.[key] ?? '') === (slice.key === '(unset)' ? '' : slice.key)}
+                      <div
+                        role="button"
+                        tabindex="0"
+                        class="flex items-center gap-2 text-[12px] rounded px-1.5 py-1 cursor-default transition-colors hover:bg-muted/60
+                          {isHighlighted ? 'bg-primary/8 ring-1 ring-inset ring-primary/30' : ''}"
+                        onmouseenter={(e) => showTooltip(e, key, slice)}
+                        onmouseleave={hideTooltip}
+                        onfocus={(e) => showTooltip(e, key, slice)}
+                        onblur={hideTooltip}
+                      >
+                        <span class="size-2.5 rounded-full flex-shrink-0" style="background:{slice.color}"></span>
+                        <span class="text-muted-foreground truncate flex-1" title={slice.label}>{slice.label}</span>
+                        <span class="font-semibold tabular-nums text-foreground">{slice.value}</span>
+                      </div>
+                    {/each}
+                  </div>
                 </div>
               </div>
-            </div>
-          {/each}
-        </div>
+            {/each}
+          </div>
+        {/if}
 
       </div>
     {/if}

--- a/cmd/archipulse/ui/src/components/views/TechnologyCatalogueView.svelte
+++ b/cmd/archipulse/ui/src/components/views/TechnologyCatalogueView.svelte
@@ -16,30 +16,53 @@
 
   // ── Type → category label ──────────────────────────────────────────────────
   const TYPE_CATEGORY = {
-    'Node':              'Infrastructure Node',
-    'Device':            'Device',
-    'SystemSoftware':    'System Software',
-    'TechnologyService': 'Technology Service',
-    'Artifact':          'Artifact',
-    'Path':              'Network Path',
-    'CommunicationNetwork': 'Network',
+    'Node':                   'Infrastructure Node',
+    'Device':                 'Device',
+    'SystemSoftware':         'System Software',
+    'TechnologyService':      'Technology Service',
+    'TechnologyProcess':      'Technology Process',
+    'TechnologyFunction':     'Technology Function',
+    'TechnologyInteraction':  'Technology Interaction',
+    'TechnologyInterface':    'Technology Interface',
+    'TechnologyCollaboration':'Technology Collaboration',
+    'Artifact':               'Artifact',
+    'Path':                   'Network Path',
+    'CommunicationNetwork':   'Network',
   };
   function categoryLabel(t) {
     return TYPE_CATEGORY[t] ?? t.replace(/([A-Z])/g, ' $1').trim();
   }
 
   const CATEGORY_BADGE = {
-    'Node':              { bg: '#dbeafe', text: '#1e40af' },
-    'Device':            { bg: '#dbeafe', text: '#1e40af' },
-    'SystemSoftware':    { bg: '#dcfce7', text: '#166534' },
-    'TechnologyService': { bg: '#ffedd5', text: '#9a3412' },
-    'Artifact':          { bg: '#ede9fe', text: '#5b21b6' },
-    'CommunicationNetwork': { bg: '#f1f5f9', text: '#475569' },
-    'Path':              { bg: '#f1f5f9', text: '#475569' },
+    'Node':                   { bg: '#dbeafe', text: '#1e40af' },
+    'Device':                 { bg: '#dbeafe', text: '#1e40af' },
+    'SystemSoftware':         { bg: '#dcfce7', text: '#166534' },
+    'TechnologyService':      { bg: '#ffedd5', text: '#9a3412' },
+    'TechnologyProcess':      { bg: '#fef9c3', text: '#713f12' },
+    'TechnologyFunction':     { bg: '#ccfbf1', text: '#134e4a' },
+    'TechnologyInteraction':  { bg: '#e0f2fe', text: '#0369a1' },
+    'TechnologyInterface':    { bg: '#e0f2fe', text: '#0369a1' },
+    'TechnologyCollaboration':{ bg: '#fce7f3', text: '#9d174d' },
+    'Artifact':               { bg: '#ede9fe', text: '#5b21b6' },
+    'CommunicationNetwork':   { bg: '#f1f5f9', text: '#475569' },
+    'Path':                   { bg: '#f1f5f9', text: '#475569' },
   };
+  const _EXTRA_PALETTE = [
+    { bg: '#dbeafe', text: '#1e40af' }, { bg: '#dcfce7', text: '#166534' },
+    { bg: '#ede9fe', text: '#5b21b6' }, { bg: '#ffedd5', text: '#9a3412' },
+    { bg: '#ccfbf1', text: '#134e4a' }, { bg: '#fef9c3', text: '#713f12' },
+    { bg: '#fce7f3', text: '#9d174d' }, { bg: '#e0f2fe', text: '#0369a1' },
+  ];
+  const _extraCache = {};
   function categoryBadgeStyle(t) {
-    const b = CATEGORY_BADGE[t] ?? { bg: '#f1f5f9', text: '#475569' };
-    return `background:${b.bg}; color:${b.text};`;
+    const b = CATEGORY_BADGE[t];
+    if (b) return `background:${b.bg}; color:${b.text};`;
+    if (!_extraCache[t]) {
+      const idx = Object.keys(_extraCache).length % _EXTRA_PALETTE.length;
+      _extraCache[t] = _EXTRA_PALETTE[idx];
+    }
+    const p = _extraCache[t];
+    return `background:${p.bg}; color:${p.text};`;
   }
 
   // ── Filtering & sorting ────────────────────────────────────────────────────

--- a/cmd/archipulse/ui/src/routes/DependencyGraphView.svelte
+++ b/cmd/archipulse/ui/src/routes/DependencyGraphView.svelte
@@ -48,13 +48,27 @@
   ];
   let activeRels = $state(new Set(REL_TYPES.map(r => r.key)));
 
-  const LIFECYCLE_COLORS = {
+  // Fixed palette for known lifecycle values; unknown values get a deterministic hash color.
+  const LIFECYCLE_FIXED = {
     'Production':     '#16a34a',
     'Pilot':          '#2563eb',
     'Planned':        '#7c3aed',
     'Retiring':       '#ea580c',
     'Decommissioned': '#dc2626',
   };
+  const EXTRA_PALETTE = ['#0891b2','#db2777','#ca8a04','#9333ea','#059669','#d97706','#6366f1'];
+
+  // Built dynamically from data so any lifecycle value gets a consistent color.
+  let LIFECYCLE_COLORS = {};
+  function buildLifecycleColors(nodes) {
+    const vals = [...new Set(nodes.map(n => n.lifecycle_status).filter(Boolean))];
+    const result = {};
+    let extraIdx = 0;
+    for (const v of vals) {
+      result[v] = LIFECYCLE_FIXED[v] ?? EXTRA_PALETTE[extraIdx++ % EXTRA_PALETTE.length];
+    }
+    return result;
+  }
 
   const REL_META = {
     serving:     { label: 'Serves',         color: '#7aa2f7', animated: false },
@@ -81,6 +95,25 @@
     return 'other';
   }
 
+  // ── Bidirectional edge deduplication ─────────────────────────────────────
+  // If A→B and B→A exist with the same rel type, collapse into one bidirectional edge.
+  function deduplicateEdges(edges) {
+    const seen = new Map(); // key → edge index in result
+    const result = [];
+    for (const e of edges) {
+      const fwd = `${e.source}|${e.target}|${relKey(e.relationship)}`;
+      const rev = `${e.target}|${e.source}|${relKey(e.relationship)}`;
+      if (seen.has(rev)) {
+        // Mark the existing edge as bidirectional
+        result[seen.get(rev)]._bidirectional = true;
+      } else if (!seen.has(fwd)) {
+        seen.set(fwd, result.length);
+        result.push({ ...e, _bidirectional: false });
+      }
+    }
+    return result;
+  }
+
   // ── Dagre layout ──────────────────────────────────────────────────────────
   function layoutNodes(rawNodes, rawEdges, visibleIds = null) {
     const g = new dagre.graphlib.Graph();
@@ -97,14 +130,27 @@
       g.setNode(n.id, { width: nw(tier), height: nh(tier) });
     });
 
-    rawEdges.forEach(e => {
-      if (!activeRels.has(relKey(e.relationship))) return;
-      if (nodeSet && (!nodeSet.has(e.source) || !nodeSet.has(e.target))) return;
-      if (e.source === e.target) return;
+    // Use pre-deduplicated edges for layout (bidirectional shown as one edge)
+    const layoutEdges = deduplicateEdges(
+      rawEdges.filter(e => {
+        if (!activeRels.has(relKey(e.relationship))) return false;
+        if (nodeSet && (!nodeSet.has(e.source) || !nodeSet.has(e.target))) return false;
+        return e.source !== e.target;
+      })
+    );
+    layoutEdges.forEach(e => {
       if (g.hasNode(e.source) && g.hasNode(e.target)) g.setEdge(e.source, e.target);
     });
 
     dagre.layout(g);
+
+    const dedupedEdges = deduplicateEdges(
+      rawEdges.filter(e => {
+        if (!activeRels.has(relKey(e.relationship))) return false;
+        if (nodeSet && (!nodeSet.has(e.source) || !nodeSet.has(e.target))) return false;
+        return e.source !== e.target;
+      })
+    );
 
     const nameById = Object.fromEntries(rawNodes.map(n => [n.id, n.name]));
 
@@ -122,25 +168,23 @@
         };
       });
 
-    const flowEdges = rawEdges
-      .filter(e => {
-        if (!activeRels.has(relKey(e.relationship))) return false;
-        if (nodeSet && (!nodeSet.has(e.source) || !nodeSet.has(e.target))) return false;
-        return e.source !== e.target;
-      })
-      .map(e => {
-        const rk   = relKey(e.relationship);
-        const meta = REL_META[rk];
-        return {
-          id:        e.id,
-          source:    e.source,
-          target:    e.target,
-          animated:  meta.animated,
-          style:     `stroke:${meta.color}; stroke-width:1.8px;`,
-          markerEnd: { type: 'arrowclosed', color: meta.color, width: 14, height: 14 },
-          data:      { relLabel: meta.label, sourceName: nameById[e.source] ?? '', targetName: nameById[e.target] ?? '', rk },
-        };
-      });
+    const flowEdges = dedupedEdges.map(e => {
+      const rk   = relKey(e.relationship);
+      const meta = REL_META[rk];
+      const edge = {
+        id:        e.id,
+        source:    e.source,
+        target:    e.target,
+        animated:  meta.animated,
+        style:     `stroke:${meta.color}; stroke-width:1.8px;`,
+        markerEnd: { type: 'arrowclosed', color: meta.color, width: 14, height: 14 },
+        data:      { relLabel: meta.label, sourceName: nameById[e.source] ?? '', targetName: nameById[e.target] ?? '', rk, bidirectional: e._bidirectional },
+      };
+      if (e._bidirectional) {
+        edge.markerStart = { type: 'arrowclosed', color: meta.color, width: 14, height: 14 };
+      }
+      return edge;
+    });
 
     return { flowNodes, flowEdges };
   }
@@ -208,6 +252,7 @@
       const data = await api.get('/workspaces/' + params.wsId + '/views/application-dependency/graph');
       allNodes = data.nodes ?? [];
       allEdges = data.edges ?? [];
+      LIFECYCLE_COLORS = buildLifecycleColors(allNodes);
       applyLayout();
     } catch (e) {
       error = e.message;
@@ -386,6 +431,7 @@
                 </div>
               {/each}
 
+              {#if Object.keys(LIFECYCLE_COLORS).length > 0}
               <div class="text-[10px] font-bold uppercase tracking-wide mt-3 mb-2" style="color:#64748b;">Lifecycle</div>
               {#each Object.entries(LIFECYCLE_COLORS) as [lc, color]}
                 <div class="flex items-center gap-2 mb-1.5">
@@ -393,6 +439,7 @@
                   <span style="color:#475569;">{lc}</span>
                 </div>
               {/each}
+              {/if}
             </div>
           </Panel>
         </SvelteFlow>


### PR DESCRIPTION
## Summary

Discovered when loading ArchiMetal.xml — views were broken or colorless because they assumed ArchiSurance-specific property values and types.

- **Application Dashboard**: shows a clean empty-state (list + explanation) when the model has no model properties, instead of rendering a blank layout that looked broken
- **Dependency Graph**: lifecycle palette is now built from the actual node data (any value gets a color); bidirectional edges (A→B _and_ B→A with same relationship type) are collapsed into a single double-headed arrow, eliminating the visual mess of overlapping/redundant arrows
- **Application Catalogue**: badge colors now fall back to a rotating dynamic palette for any value not in the known map (Production/Pilot/etc.) — no more colorless grey badges for unknown lifecycle or deployment values
- **Technology Catalogue**: added all missing ArchiMate technology layer types (`TechnologyProcess`, `TechnologyFunction`, `TechnologyInteraction`, `TechnologyInterface`, `TechnologyCollaboration`) to the label and badge maps; added a generic rotating palette fallback for any future unknown type

## Test plan

- [ ] Load ArchiMetal.xml into a workspace
- [ ] Application Dashboard → shows app list + "No property data" notice instead of blank grid
- [ ] Dependency Graph → all nodes colored by their actual lifecycle value; bidirectional connections show as a single double-headed arrow
- [ ] Application Catalogue → all property values show colored badges (not grey)
- [ ] Technology Catalogue → TechnologyProcess, TechnologyFunction etc. show correct labels and colored badges
- [ ] ArchiSurance still works identically (regression check)