### PR TITLE
feat(demo): DEMO_MODE with one-click login banner

### DIFF
--- a/cmd/archipulse/ui/src/routes/Login.svelte
+++ b/cmd/archipulse/ui/src/routes/Login.svelte
@@ -8,13 +8,18 @@
   let error = null;
   let loading = false;
   let oidcEnabled = false;
+  let demoMode = false;
+  let demoEmail = '';
+  let demoPassword = '';
 
   onMount(async () => {
-    // If already logged in, go straight to home.
     const u = $user;
     if (u) { push('/'); return; }
     const cfg = await fetchAuthConfig();
     oidcEnabled = cfg.oidc_enabled;
+    demoMode = cfg.demo_mode ?? false;
+    demoEmail = cfg.demo_email ?? '';
+    demoPassword = cfg.demo_password ?? '';
   });
 
   async function handleSubmit(e) {
@@ -23,6 +28,24 @@
     loading = true;
     try {
       await login(email, password);
+      push('/');
+    } catch (err) {
+      error = err.message;
+    } finally {
+      loading = false;
+    }
+  }
+
+  function fillDemo() {
+    email = demoEmail;
+    password = demoPassword;
+  }
+
+  async function loginAsDemo() {
+    error = null;
+    loading = true;
+    try {
+      await login(demoEmail, demoPassword);
       push('/');
     } catch (err) {
       error = err.message;
@@ -45,6 +68,27 @@
         <span style="color:var(--text-muted)">Archi</span><span style="color:var(--foreground)">Pulse</span>
       </span>
     </div>
+
+    <!-- Demo banner -->
+    {#if demoMode}
+      <div class="mb-4 rounded-xl border border-primary/30 bg-primary/5 px-4 py-3">
+        <div class="flex items-center gap-2 mb-2">
+          <span class="text-[12px] font-semibold text-primary uppercase tracking-wide">Demo pública</span>
+        </div>
+        <div class="text-[12px] text-muted-foreground mb-1">Entra con las credenciales de prueba:</div>
+        <div class="font-mono text-[12px] text-foreground mb-3 space-y-0.5">
+          <div>{demoEmail}</div>
+          <div>{demoPassword}</div>
+        </div>
+        <button
+          onclick={loginAsDemo}
+          disabled={loading}
+          class="w-full text-center text-[12px] font-medium bg-primary/10 hover:bg-primary/20 text-primary border border-primary/30 rounded-md py-1.5 transition-colors disabled:opacity-60"
+        >
+          Entrar como demo →
+        </button>
+      </div>
+    {/if}
 
     <div class="bg-card border border-border rounded-xl p-6 shadow-sm">
       <h1 class="text-[16px] font-semibold text-foreground mb-1">Sign in</h1>

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -24,6 +24,11 @@ type Config struct {
 	BootstrapEmail    string
 	BootstrapPassword string
 
+	// Demo mode — shows pre-filled credentials on the login page.
+	DemoMode     bool
+	DemoEmail    string
+	DemoPassword string
+
 	// OIDC (all three must be set to enable)
 	OIDCIssuerURL    string
 	OIDCClientID     string
@@ -51,6 +56,9 @@ func ConfigFromEnv() (*Config, error) {
 		}
 	}
 
+	demoEmail := os.Getenv("DEMO_EMAIL")
+	demoPassword := os.Getenv("DEMO_PASSWORD")
+
 	return &Config{
 		JWTSecret:         secret,
 		TokenTTL:          ttl,
@@ -58,6 +66,9 @@ func ConfigFromEnv() (*Config, error) {
 		CookieSecure:      os.Getenv("COOKIE_SECURE") != "false",
 		BootstrapEmail:    os.Getenv("ARCHIPULSE_BOOTSTRAP_EMAIL"),
 		BootstrapPassword: os.Getenv("ARCHIPULSE_BOOTSTRAP_PASSWORD"),
+		DemoMode:          os.Getenv("DEMO_MODE") == "true" && demoEmail != "" && demoPassword != "",
+		DemoEmail:         demoEmail,
+		DemoPassword:      demoPassword,
 		OIDCIssuerURL:     os.Getenv("OIDC_ISSUER_URL"),
 		OIDCClientID:      os.Getenv("OIDC_CLIENT_ID"),
 		OIDCClientSecret:  os.Getenv("OIDC_CLIENT_SECRET"),

--- a/internal/auth/bootstrap.go
+++ b/internal/auth/bootstrap.go
@@ -5,9 +5,16 @@ import (
 	"fmt"
 )
 
-// Bootstrap ensures the first admin user exists when the DB is empty.
-// It is a no-op when users already exist or when the env vars are not set.
+// Bootstrap ensures the first admin user exists when the DB is empty,
+// and upserts the demo viewer account when demo mode is enabled.
 func Bootstrap(svc *Service) error {
+	if err := bootstrapAdmin(svc); err != nil {
+		return err
+	}
+	return bootstrapDemo(svc)
+}
+
+func bootstrapAdmin(svc *Service) error {
 	if svc.Cfg.BootstrapEmail == "" || svc.Cfg.BootstrapPassword == "" {
 		return nil
 	}
@@ -31,6 +38,38 @@ func Bootstrap(svc *Service) error {
 	}
 
 	fmt.Printf("auth: bootstrapped admin user %q\n", svc.Cfg.BootstrapEmail)
+	return nil
+}
+
+// bootstrapDemo creates or resets the demo viewer account on every startup
+// when DEMO_MODE=true, so the password is always in sync with DEMO_PASSWORD.
+func bootstrapDemo(svc *Service) error {
+	if !svc.Cfg.DemoMode {
+		return nil
+	}
+
+	hash, err := HashPassword(svc.Cfg.DemoPassword)
+	if err != nil {
+		return fmt.Errorf("demo bootstrap hash: %w", err)
+	}
+
+	existing, err := svc.Users.GetByEmail(svc.Cfg.DemoEmail)
+	if err == ErrNotFound {
+		_, err = svc.Users.Create(svc.Cfg.DemoEmail, hash, "viewer")
+		if err != nil {
+			return fmt.Errorf("demo bootstrap create: %w", err)
+		}
+		fmt.Printf("auth: created demo user %q\n", svc.Cfg.DemoEmail)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("demo bootstrap lookup: %w", err)
+	}
+
+	// Update hash in case DEMO_PASSWORD changed.
+	if err := svc.Users.UpdatePasswordHash(existing.ID.String(), hash); err != nil {
+		return fmt.Errorf("demo bootstrap update: %w", err)
+	}
 	return nil
 }
 

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -114,9 +114,15 @@ func (svc *Service) handleMe(w http.ResponseWriter, r *http.Request) {
 
 func (svc *Service) handleConfig(oidc *OIDCProvider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusOK, map[string]any{
+		resp := map[string]any{
 			"oidc_enabled": oidc != nil,
-		})
+			"demo_mode":    svc.Cfg.DemoMode,
+		}
+		if svc.Cfg.DemoMode {
+			resp["demo_email"] = svc.Cfg.DemoEmail
+			resp["demo_password"] = svc.Cfg.DemoPassword
+		}
+		writeJSON(w, http.StatusOK, resp)
 	}
 }
 

--- a/internal/auth/user_store.go
+++ b/internal/auth/user_store.go
@@ -90,6 +90,15 @@ func (s *UserStore) Exists() (bool, error) {
 	return n > 0, nil
 }
 
+// UpdatePasswordHash replaces a user's bcrypt password hash.
+func (s *UserStore) UpdatePasswordHash(id, hash string) error {
+	_, err := s.db.Exec(
+		"UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2",
+		hash, id,
+	)
+	return err
+}
+
 // UpdateRole changes a user's role.
 func (s *UserStore) UpdateRole(id, role string) error {
 	_, err := s.db.Exec(


### PR DESCRIPTION
## Summary

- New env vars: `DEMO_MODE=true`, `DEMO_EMAIL`, `DEMO_PASSWORD`
- On startup with demo mode enabled, bootstrap creates/resets a `viewer` account with `DEMO_EMAIL` + `DEMO_PASSWORD` (idempotent — runs every boot to keep password in sync)
- `/api/v1/auth/config` now returns `demo_mode`, `demo_email`, `demo_password` when enabled
- Login page shows a banner with the credentials and an **"Entrar como demo →"** button for one-click access
- When `DEMO_MODE` is not set the login page is identical to before

## Railway setup (demo service)

Add these three variables in the Railway dashboard:

| Variable | Value |
|---|---|
| `DEMO_MODE` | `true` |
| `DEMO_EMAIL` | `demo@archipulse.org` |
| `DEMO_PASSWORD` | something simple like `demo1234` |

## Test plan

- [ ] Set env vars locally in `.env`, run `go run ./cmd/archipulse serve`
- [ ] Visit `/login` — banner appears with credentials
- [ ] Click "Entrar como demo" — logs in as viewer, lands on home
- [ ] Verify viewer cannot access admin-only routes (403)
- [ ] Without `DEMO_MODE=true` — login page shows no banner