### PR TITLE
refactor: project structure cleanup

### DIFF
--- a/cmd/archipulse/ui/src/App.svelte
+++ b/cmd/archipulse/ui/src/App.svelte
@@ -5,10 +5,10 @@
   import Sidebar from './components/Sidebar.svelte';
   import Home from './routes/Home.svelte';
   import WorkspaceOverview from './routes/WorkspaceOverview.svelte';
-  import ViewRouter from './routes/ViewRouter.svelte';
-  import DependencyGraphView from './routes/DependencyGraphView.svelte';
-  import CapabilityTree from './routes/CapabilityTree.svelte';
-  import ApplicationLandscapeMap from './routes/ApplicationLandscapeMap.svelte';
+  import ViewRouter from './components/views/ViewRouter.svelte';
+  import DependencyGraphView from './components/views/DependencyGraphView.svelte';
+  import CapabilityTree from './components/views/CapabilityTree.svelte';
+  import ApplicationLandscapeMap from './components/views/ApplicationLandscapeMap.svelte';
   import Login from './routes/Login.svelte';
 
   import { api } from './lib/api.js';

--- a/cmd/archipulse/ui/src/components/views/ApplicationLandscapeMap.svelte
+++ b/cmd/archipulse/ui/src/components/views/ApplicationLandscapeMap.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from 'svelte';
-  import { api } from '../lib/api.js';
+  import { api } from '../../lib/api.js';
 
   export let params = {};
   $: wsId = params.wsId;

--- a/cmd/archipulse/ui/src/components/views/CapabilityTree.svelte
+++ b/cmd/archipulse/ui/src/components/views/CapabilityTree.svelte
@@ -10,10 +10,10 @@
   } from '@xyflow/svelte';
   import '@xyflow/svelte/dist/style.css';
   import dagre from '@dagrejs/dagre';
-  import { api } from '../lib/api.js';
-  import CapabilityNode from '../components/flow/CapabilityNode.svelte';
-  import AppNode       from '../components/flow/AppNode.svelte';
-  import FlowControls  from '../components/flow/FlowControls.svelte';
+  import { api } from '../../lib/api.js';
+  import CapabilityNode from '../flow/CapabilityNode.svelte';
+  import AppNode       from '../flow/AppNode.svelte';
+  import FlowControls  from '../flow/FlowControls.svelte';
 
   let { params = {} } = $props();
 

--- a/cmd/archipulse/ui/src/components/views/DependencyGraphView.svelte
+++ b/cmd/archipulse/ui/src/components/views/DependencyGraphView.svelte
@@ -10,9 +10,9 @@
   } from '@xyflow/svelte';
   import '@xyflow/svelte/dist/style.css';
   import dagre from '@dagrejs/dagre';
-  import { api } from '../lib/api.js';
-  import AppNode from '../components/flow/AppNode.svelte';
-  import FlowControls from '../components/flow/FlowControls.svelte';
+  import { api } from '../../lib/api.js';
+  import AppNode from '../flow/AppNode.svelte';
+  import FlowControls from '../flow/FlowControls.svelte';
 
   let { params = {} } = $props();
 

--- a/cmd/archipulse/ui/src/components/views/ViewRouter.svelte
+++ b/cmd/archipulse/ui/src/components/views/ViewRouter.svelte
@@ -1,12 +1,11 @@
 <script>
   import { push } from 'svelte-spa-router';
-  import { VIEWS } from '../lib/views.js';
-  import TableView from '../components/views/TableView.svelte';
-  import ApplicationDashboard from '../components/views/ApplicationDashboard.svelte';
-  import ApplicationLandscapeMap from './ApplicationLandscapeMap.svelte';
-  import ApplicationCatalogueView from '../components/views/ApplicationCatalogueView.svelte';
-  import TechnologyCatalogueView from '../components/views/TechnologyCatalogueView.svelte';
-  import ElementCatalogueView from '../components/views/ElementCatalogueView.svelte';
+  import { VIEWS } from '../../lib/views.js';
+  import TableView from './TableView.svelte';
+  import ApplicationDashboard from './ApplicationDashboard.svelte';
+  import ApplicationCatalogueView from './ApplicationCatalogueView.svelte';
+  import TechnologyCatalogueView from './TechnologyCatalogueView.svelte';
+  import ElementCatalogueView from './ElementCatalogueView.svelte';
 
   export let params = {};
 

--- a/deploy/local/dex.yaml
+++ b/deploy/local/dex.yaml
@@ -1,7 +1,7 @@
 # Dex OIDC provider — local development config
 # Works with both:
 #   docker compose --profile oidc up
-#   dex serve dex.yaml  (native binary)
+#   dex serve deploy/local/dex.yaml  (native binary, desde la raíz del repo)
 
 issuer: http://localhost:5556/dex
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     image: ghcr.io/dexidp/dex:v2.45.1
     restart: unless-stopped
     volumes:
-      - ./dex.yaml:/etc/dex/config.yaml:ro
+      - ./deploy/local/dex.yaml:/etc/dex/config.yaml:ro
     ports:
       - "5556:5556"
     command: dex serve /etc/dex/config.yaml

--- a/internal/auth/bootstrap.go
+++ b/internal/auth/bootstrap.go
@@ -69,4 +69,3 @@ func bootstrapDemo(svc *Service) error {
 	}
 	return nil
 }
-

--- a/internal/auth/bootstrap.go
+++ b/internal/auth/bootstrap.go
@@ -1,9 +1,6 @@
 package auth
 
-import (
-	"errors"
-	"fmt"
-)
+import "fmt"
 
 // Bootstrap ensures the first admin user exists when the DB is empty,
 // and upserts the demo viewer account when demo mode is enabled.
@@ -73,18 +70,3 @@ func bootstrapDemo(svc *Service) error {
 	return nil
 }
 
-// LoginLocal authenticates a user by email + password.
-// Returns the signed JWT string on success.
-func LoginLocal(svc *Service, email, password string) (string, error) {
-	u, err := svc.Users.GetByEmail(email)
-	if errors.Is(err, ErrNotFound) {
-		return "", fmt.Errorf("invalid credentials")
-	}
-	if err != nil {
-		return "", err
-	}
-	if u.PasswordHash == nil || !CheckPassword(*u.PasswordHash, password) {
-		return "", fmt.Errorf("invalid credentials")
-	}
-	return IssueToken(svc.Cfg, u.ID.String(), u.Email, u.Role)
-}

--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -1,0 +1,19 @@
+package auth
+
+import "errors"
+
+// LoginLocal authenticates a user by email + password.
+// Returns the signed JWT string on success.
+func LoginLocal(svc *Service, email, password string) (string, error) {
+	u, err := svc.Users.GetByEmail(email)
+	if errors.Is(err, ErrNotFound) {
+		return "", errors.New("invalid credentials")
+	}
+	if err != nil {
+		return "", err
+	}
+	if u.PasswordHash == nil || !CheckPassword(*u.PasswordHash, password) {
+		return "", errors.New("invalid credentials")
+	}
+	return IssueToken(svc.Cfg, u.ID.String(), u.Email, u.Role)
+}


### PR DESCRIPTION
## Summary
- Mueve `dex.yaml` de la raíz a `deploy/local/dex.yaml` — la raíz solo tiene archivos de infraestructura estándar
- Actualiza el volume path en `docker-compose.yml`
- Extrae `LoginLocal` de `bootstrap.go` a `login.go` — separación de responsabilidades
- Mueve `ViewRouter`, `DependencyGraphView`, `CapabilityTree`, `ApplicationLandscapeMap` de `routes/` a `components/views/` — `routes/` queda solo con páginas reales (Login, Home, WorkspaceOverview)
- Corrige todos los imports relativos afectados

## Test plan
- [ ] `go test ./...` → todos los tests pasan
- [ ] `npm run build` en `cmd/archipulse/ui` → build limpio
- [ ] `dex serve deploy/local/dex.yaml` funciona
- [ ] `docker compose --profile oidc up` levanta Dex correctamente