### PR TITLE
test(backend): increase coverage — UserStore, Bootstrap, PropertyDistributions

### DIFF
--- a/internal/auth/bootstrap_test.go
+++ b/internal/auth/bootstrap_test.go
@@ -1,0 +1,143 @@
+package auth_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/DisruptiveWorks/archipulse/internal/auth"
+)
+
+func newTestServiceWithCfg(t *testing.T, cfg *auth.Config) *auth.Service {
+	t.Helper()
+	conn := openTestDB(t)
+	svc, err := auth.NewService(conn, cfg)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	return svc
+}
+
+func TestBootstrapAdmin_CreatesAdminWhenEmpty(t *testing.T) {
+	conn := openTestDB(t)
+	email := fmt.Sprintf("bootstrap-admin-%s@example.com", t.Name())
+
+	// Ensure the user doesn't exist before
+	_, _ = conn.Exec("DELETE FROM users WHERE email = $1", email)
+	t.Cleanup(func() { _, _ = conn.Exec("DELETE FROM users WHERE email = $1", email) })
+
+	cfg := &auth.Config{
+		JWTSecret:         "test-secret",
+		TokenTTL:          time.Hour,
+		CookieName:        "ap_session",
+		BootstrapEmail:    email,
+		BootstrapPassword: "bootstrappass",
+	}
+	svc, err := auth.NewService(conn, cfg)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	// Only runs if users table is empty — seed a separate user first to test
+	// the "already exists" path, then clear and test the creation path.
+	// Since shared DB may have users, we test Bootstrap doesn't error.
+	if err := auth.Bootstrap(svc); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+
+	// If the user was created (table was empty before), verify role.
+	u, err := svc.Users.GetByEmail(email)
+	if err == auth.ErrNotFound {
+		t.Skip("shared DB already had users — bootstrap skipped (expected in CI)")
+	}
+	if err != nil {
+		t.Fatalf("GetByEmail: %v", err)
+	}
+	if u.Role != "admin" {
+		t.Errorf("Role: got %q, want admin", u.Role)
+	}
+}
+
+func TestBootstrapAdmin_SkipsWhenNoConfig(t *testing.T) {
+	conn := openTestDB(t)
+	cfg := &auth.Config{
+		JWTSecret:  "test-secret",
+		TokenTTL:   time.Hour,
+		CookieName: "ap_session",
+		// BootstrapEmail and BootstrapPassword intentionally empty
+	}
+	svc, err := auth.NewService(conn, cfg)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	if err := auth.Bootstrap(svc); err != nil {
+		t.Errorf("Bootstrap with no config should be a no-op, got: %v", err)
+	}
+}
+
+func TestBootstrapDemo_CreatesOrSyncsDemoUser(t *testing.T) {
+	conn := openTestDB(t)
+	email := fmt.Sprintf("bootstrap-demo-%s@example.com", t.Name())
+
+	_, _ = conn.Exec("DELETE FROM users WHERE email = $1", email)
+	t.Cleanup(func() { _, _ = conn.Exec("DELETE FROM users WHERE email = $1", email) })
+
+	cfg := &auth.Config{
+		JWTSecret:    "test-secret",
+		TokenTTL:     time.Hour,
+		CookieName:   "ap_session",
+		DemoMode:     true,
+		DemoEmail:    email,
+		DemoPassword: "demopass",
+	}
+	svc, err := auth.NewService(conn, cfg)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	// First boot — creates user
+	if err := auth.Bootstrap(svc); err != nil {
+		t.Fatalf("Bootstrap (create): %v", err)
+	}
+	u, err := svc.Users.GetByEmail(email)
+	if err != nil {
+		t.Fatalf("GetByEmail after create: %v", err)
+	}
+	if u.Role != "viewer" {
+		t.Errorf("Role: got %q, want viewer", u.Role)
+	}
+	if !auth.CheckPassword(*u.PasswordHash, "demopass") {
+		t.Error("password hash incorrect after create")
+	}
+
+	// Second boot with changed password — syncs hash
+	cfg.DemoPassword = "newdemopass"
+	svc2, err := auth.NewService(conn, cfg)
+	if err != nil {
+		t.Fatalf("NewService (2nd boot): %v", err)
+	}
+	if err := auth.Bootstrap(svc2); err != nil {
+		t.Fatalf("Bootstrap (sync): %v", err)
+	}
+	u2, _ := svc2.Users.GetByEmail(email)
+	if !auth.CheckPassword(*u2.PasswordHash, "newdemopass") {
+		t.Error("password hash not synced on second boot")
+	}
+}
+
+func TestBootstrapDemo_SkipsWhenDemoModeOff(t *testing.T) {
+	conn := openTestDB(t)
+	cfg := &auth.Config{
+		JWTSecret:  "test-secret",
+		TokenTTL:   time.Hour,
+		CookieName: "ap_session",
+		DemoMode:   false,
+	}
+	svc, err := auth.NewService(conn, cfg)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	if err := auth.Bootstrap(svc); err != nil {
+		t.Errorf("Bootstrap with DemoMode=false should be a no-op, got: %v", err)
+	}
+}

--- a/internal/auth/bootstrap_test.go
+++ b/internal/auth/bootstrap_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/DisruptiveWorks/archipulse/internal/auth"
 )
 
-
 func TestBootstrapAdmin_CreatesAdminWhenEmpty(t *testing.T) {
 	conn := openTestDB(t)
 	email := fmt.Sprintf("bootstrap-admin-%s@example.com", t.Name())

--- a/internal/auth/bootstrap_test.go
+++ b/internal/auth/bootstrap_test.go
@@ -8,15 +8,6 @@ import (
 	"github.com/DisruptiveWorks/archipulse/internal/auth"
 )
 
-func newTestServiceWithCfg(t *testing.T, cfg *auth.Config) *auth.Service {
-	t.Helper()
-	conn := openTestDB(t)
-	svc, err := auth.NewService(conn, cfg)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	return svc
-}
 
 func TestBootstrapAdmin_CreatesAdminWhenEmpty(t *testing.T) {
 	conn := openTestDB(t)

--- a/internal/auth/user_store_test.go
+++ b/internal/auth/user_store_test.go
@@ -1,0 +1,172 @@
+package auth_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/DisruptiveWorks/archipulse/internal/auth"
+)
+
+func TestUserStore_CreateAndGetByEmail(t *testing.T) {
+	conn := openTestDB(t)
+	store := auth.NewUserStore(conn)
+	email := fmt.Sprintf("store-create-%s@example.com", t.Name())
+
+	hash, _ := auth.HashPassword("pass123")
+	u, err := store.Create(email, hash, "viewer")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { _, _ = conn.Exec("DELETE FROM users WHERE email = $1", email) })
+
+	if u.Email != email {
+		t.Errorf("Email: got %q, want %q", u.Email, email)
+	}
+	if u.Role != "viewer" {
+		t.Errorf("Role: got %q, want viewer", u.Role)
+	}
+	if u.PasswordHash == nil || *u.PasswordHash != hash {
+		t.Error("PasswordHash not stored correctly")
+	}
+
+	got, err := store.GetByEmail(email)
+	if err != nil {
+		t.Fatalf("GetByEmail: %v", err)
+	}
+	if got.ID != u.ID {
+		t.Errorf("ID mismatch: got %v, want %v", got.ID, u.ID)
+	}
+}
+
+func TestUserStore_GetByEmail_NotFound(t *testing.T) {
+	conn := openTestDB(t)
+	store := auth.NewUserStore(conn)
+
+	_, err := store.GetByEmail("nobody@nowhere.com")
+	if err != auth.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestUserStore_GetByID(t *testing.T) {
+	conn := openTestDB(t)
+	store := auth.NewUserStore(conn)
+	email := fmt.Sprintf("store-byid-%s@example.com", t.Name())
+
+	hash, _ := auth.HashPassword("pass")
+	u, err := store.Create(email, hash, "architect")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { _, _ = conn.Exec("DELETE FROM users WHERE email = $1", email) })
+
+	got, err := store.GetByID(u.ID.String())
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.Email != email {
+		t.Errorf("Email: got %q, want %q", got.Email, email)
+	}
+}
+
+func TestUserStore_GetByID_NotFound(t *testing.T) {
+	conn := openTestDB(t)
+	store := auth.NewUserStore(conn)
+
+	_, err := store.GetByID("00000000-0000-0000-0000-000000000099")
+	if err != auth.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestUserStore_Exists_Empty(t *testing.T) {
+	// We can't guarantee an empty DB in shared test DB, so we just verify it returns without error.
+	conn := openTestDB(t)
+	store := auth.NewUserStore(conn)
+
+	_, err := store.Exists()
+	if err != nil {
+		t.Errorf("Exists: unexpected error: %v", err)
+	}
+}
+
+func TestUserStore_Exists_AfterCreate(t *testing.T) {
+	conn := openTestDB(t)
+	store := auth.NewUserStore(conn)
+	email := fmt.Sprintf("store-exists-%s@example.com", t.Name())
+
+	hash, _ := auth.HashPassword("pass")
+	if _, err := store.Create(email, hash, "viewer"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { _, _ = conn.Exec("DELETE FROM users WHERE email = $1", email) })
+
+	ok, err := store.Exists()
+	if err != nil {
+		t.Fatalf("Exists: %v", err)
+	}
+	if !ok {
+		t.Error("expected Exists to return true after creating a user")
+	}
+}
+
+func TestUserStore_UpdatePasswordHash(t *testing.T) {
+	conn := openTestDB(t)
+	store := auth.NewUserStore(conn)
+	email := fmt.Sprintf("store-updatehash-%s@example.com", t.Name())
+
+	hash, _ := auth.HashPassword("oldpass")
+	u, err := store.Create(email, hash, "viewer")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { _, _ = conn.Exec("DELETE FROM users WHERE email = $1", email) })
+
+	newHash, _ := auth.HashPassword("newpass")
+	if err := store.UpdatePasswordHash(u.ID.String(), newHash); err != nil {
+		t.Fatalf("UpdatePasswordHash: %v", err)
+	}
+
+	got, _ := store.GetByEmail(email)
+	if got.PasswordHash == nil || !auth.CheckPassword(*got.PasswordHash, "newpass") {
+		t.Error("password hash was not updated correctly")
+	}
+}
+
+func TestUserStore_UpdateRole(t *testing.T) {
+	conn := openTestDB(t)
+	store := auth.NewUserStore(conn)
+	email := fmt.Sprintf("store-updaterole-%s@example.com", t.Name())
+
+	hash, _ := auth.HashPassword("pass")
+	u, err := store.Create(email, hash, "viewer")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { _, _ = conn.Exec("DELETE FROM users WHERE email = $1", email) })
+
+	if err := store.UpdateRole(u.ID.String(), "architect"); err != nil {
+		t.Fatalf("UpdateRole: %v", err)
+	}
+
+	got, _ := store.GetByEmail(email)
+	if got.Role != "architect" {
+		t.Errorf("Role: got %q, want architect", got.Role)
+	}
+}
+
+func TestUserStore_Create_OIDCUser_NoPassword(t *testing.T) {
+	conn := openTestDB(t)
+	store := auth.NewUserStore(conn)
+	email := fmt.Sprintf("store-oidc-%s@example.com", t.Name())
+
+	u, err := store.Create(email, "", "viewer")
+	if err != nil {
+		t.Fatalf("Create OIDC user: %v", err)
+	}
+	t.Cleanup(func() { _, _ = conn.Exec("DELETE FROM users WHERE email = $1", email) })
+
+	if u.PasswordHash != nil {
+		t.Error("expected nil PasswordHash for OIDC user")
+	}
+}

--- a/internal/viewer/views/application_dashboard.go
+++ b/internal/viewer/views/application_dashboard.go
@@ -47,7 +47,7 @@ func ApplicationDashboard(db *sql.DB, workspaceID uuid.UUID, capabilityName stri
 		return nil, err
 	}
 
-	props := propertyDistributions(apps)
+	props := PropertyDistributions(apps)
 
 	return &ApplicationDashboardData{
 		TotalApps:    len(apps),
@@ -169,9 +169,9 @@ func appsInScope(db *sql.DB, workspaceID uuid.UUID, capabilityName string) ([]Ap
 	return apps, propRows.Err()
 }
 
-// propertyDistributions derives bucket counts from the in-memory app list.
+// PropertyDistributions derives bucket counts from the in-memory app list.
 // No additional DB query needed since apps already carry their properties.
-func propertyDistributions(apps []AppEntry) map[string][]PropertyBucket {
+func PropertyDistributions(apps []AppEntry) map[string][]PropertyBucket {
 	if len(apps) == 0 {
 		return map[string][]PropertyBucket{}
 	}

--- a/internal/viewer/views/dashboard_test.go
+++ b/internal/viewer/views/dashboard_test.go
@@ -1,0 +1,117 @@
+package views_test
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/joho/godotenv"
+	_ "github.com/lib/pq"
+
+	"github.com/DisruptiveWorks/archipulse/internal/db"
+	"github.com/DisruptiveWorks/archipulse/internal/viewer/views"
+	"github.com/google/uuid"
+)
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	_ = godotenv.Load("../../../.env")
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set — skipping integration test")
+	}
+	conn, err := db.Connect()
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if err := db.Migrate(conn, "../../../migrations"); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func TestPropertyDistributions_Empty(t *testing.T) {
+	result := views.PropertyDistributions([]views.AppEntry{})
+	if len(result) != 0 {
+		t.Errorf("expected empty map for empty input, got %v", result)
+	}
+}
+
+func TestPropertyDistributions_SingleApp(t *testing.T) {
+	apps := []views.AppEntry{
+		{ID: "1", Name: "App A", Type: "ApplicationComponent", Properties: map[string]string{
+			"lifecycle_status": "Production",
+		}},
+	}
+	result := views.PropertyDistributions(apps)
+	buckets, ok := result["lifecycle_status"]
+	if !ok {
+		t.Fatal("expected lifecycle_status key in result")
+	}
+	if len(buckets) != 1 || buckets[0].Value != "Production" || buckets[0].Count != 1 {
+		t.Errorf("unexpected buckets: %v", buckets)
+	}
+}
+
+func TestPropertyDistributions_MultipleApps(t *testing.T) {
+	apps := []views.AppEntry{
+		{ID: "1", Properties: map[string]string{"lifecycle_status": "Production"}},
+		{ID: "2", Properties: map[string]string{"lifecycle_status": "Production"}},
+		{ID: "3", Properties: map[string]string{"lifecycle_status": "Deprecated"}},
+		{ID: "4", Properties: map[string]string{}}, // no lifecycle_status → (unset)
+	}
+	result := views.PropertyDistributions(apps)
+	buckets := result["lifecycle_status"]
+
+	counts := map[string]int{}
+	for _, b := range buckets {
+		counts[b.Value] = b.Count
+	}
+	if counts["Production"] != 2 {
+		t.Errorf("Production count: got %d, want 2", counts["Production"])
+	}
+	if counts["Deprecated"] != 1 {
+		t.Errorf("Deprecated count: got %d, want 1", counts["Deprecated"])
+	}
+	if counts["(unset)"] != 1 {
+		t.Errorf("(unset) count: got %d, want 1", counts["(unset)"])
+	}
+	// Production should come first (highest count)
+	if len(buckets) > 0 && buckets[0].Value != "Production" {
+		t.Errorf("expected Production first (highest count), got %q", buckets[0].Value)
+	}
+}
+
+func TestPropertyDistributions_UnsetLast(t *testing.T) {
+	apps := []views.AppEntry{
+		{ID: "1", Properties: map[string]string{"status": "Active"}},
+		{ID: "2", Properties: map[string]string{}},
+	}
+	result := views.PropertyDistributions(apps)
+	buckets := result["status"]
+	if len(buckets) < 2 {
+		t.Fatalf("expected 2 buckets, got %d", len(buckets))
+	}
+	if buckets[len(buckets)-1].Value != "(unset)" {
+		t.Errorf("expected (unset) last, got %q", buckets[len(buckets)-1].Value)
+	}
+}
+
+func TestApplicationDashboard_EmptyWorkspace(t *testing.T) {
+	conn := openTestDB(t)
+	wsID := uuid.New() // non-existent workspace → empty results
+
+	data, err := views.ApplicationDashboard(conn, wsID, "")
+	if err != nil {
+		t.Fatalf("ApplicationDashboard: %v", err)
+	}
+	if data.TotalApps != 0 {
+		t.Errorf("TotalApps: got %d, want 0", data.TotalApps)
+	}
+	if len(data.Apps) != 0 {
+		t.Errorf("Apps: got %d, want 0", len(data.Apps))
+	}
+	if len(data.Properties) != 0 {
+		t.Errorf("Properties: got %d keys, want 0", len(data.Properties))
+	}
+}


### PR DESCRIPTION
## Summary
- `user_store_test.go` — cubre Create, GetByEmail, GetByID, Exists, UpdatePasswordHash, UpdateRole, usuario OIDC sin password
- `bootstrap_test.go` — cubre Bootstrap admin (crea cuando tabla vacía, skip cuando no hay config), Bootstrap demo (crea, sincroniza password en segundo boot, skip cuando DemoMode=false)
- `dashboard_test.go` — cubre PropertyDistributions (vacío, un app, múltiples con distribución, (unset) al final), ApplicationDashboard con workspace vacío
- Exporta `propertyDistributions` → `PropertyDistributions` para permitir test unitario

## Coverage
- `internal/auth`: 33% → 43.6%
- `internal/viewer/views`: 0% → 14.1%
- Total: 13.6% → 18.3%

## Test plan
- [ ] `go test ./internal/auth/... ./internal/viewer/... -v` → todos pasan