### PR TITLE
feat: ArchiMate diagram viewer with XY Flow

### DIFF
--- a/cmd/archipulse/ui/src/App.svelte
+++ b/cmd/archipulse/ui/src/App.svelte
@@ -10,6 +10,9 @@
   import CapabilityTree from './components/views/CapabilityTree.svelte';
   import ApplicationLandscapeMap from './components/views/ApplicationLandscapeMap.svelte';
   import Login from './routes/Login.svelte';
+  import DiagramList from './routes/DiagramList.svelte';
+  import DiagramViewer from './routes/DiagramViewer.svelte';
+  import EditorPlaceholder from './routes/EditorPlaceholder.svelte';
 
   import { api } from './lib/api.js';
   import { VIEWS } from './lib/views.js';
@@ -21,6 +24,9 @@
     '/login': Login,
     '/': Home,
     '/ws/:wsId': WorkspaceOverview,
+    '/ws/:wsId/editor': EditorPlaceholder,
+    '/ws/:wsId/diagrams': DiagramList,
+    '/ws/:wsId/diagrams/:diagId': DiagramViewer,
     '/ws/:wsId/view/:viewName': ViewRouter,
     '/ws/:wsId/view/application-dependency/graph': DependencyGraphView,
     '/ws/:wsId/view/:viewName/tree': CapabilityTree,

--- a/cmd/archipulse/ui/src/components/BackButton.svelte
+++ b/cmd/archipulse/ui/src/components/BackButton.svelte
@@ -1,0 +1,12 @@
+<script>
+  export let label = 'Back';
+  export let onclick = () => {};
+</script>
+
+<button
+  class="flex items-center gap-1.5 text-[12px] text-muted-foreground hover:text-foreground transition-colors mb-4 group"
+  on:click={onclick}
+>
+  <span class="group-hover:-translate-x-0.5 transition-transform">←</span>
+  {label}
+</button>

--- a/cmd/archipulse/ui/src/components/Sidebar.svelte
+++ b/cmd/archipulse/ui/src/components/Sidebar.svelte
@@ -117,6 +117,29 @@
     {/if}
   {/each}
 
+  <div class="mx-2 mt-3">
+    <Separator />
+  </div>
+  <div class="px-2 pt-3 pb-1">
+    <div class="text-[10px] font-bold tracking-[0.8px] uppercase text-muted-foreground px-2 mb-1">ArchiMate Editor</div>
+    {#each [
+      { path: '/ws/' + wsId + '/editor', label: 'Editor', icon: '✎' },
+      { path: '/ws/' + wsId + '/diagrams', label: 'Diagram List', icon: '⊟' },
+    ] as item}
+      {@const active = loc === item.path || loc.startsWith(item.path + '/')}
+      <div
+        class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm cursor-pointer transition-colors {active ? 'bg-white text-foreground font-medium shadow-sm' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
+        on:click={() => push(item.path)}
+        on:keydown={e => e.key === 'Enter' && push(item.path)}
+        role="button"
+        tabindex="0"
+      >
+        <span class="text-[12px] flex-shrink-0 w-[18px] text-center">{item.icon}</span>
+        {item.label}
+      </div>
+    {/each}
+  </div>
+
   <div class="mt-auto px-2 py-3 border-t border-border">
     <div
       class="border-2 border-dashed border-border rounded-lg p-3.5 text-center text-muted-foreground cursor-pointer transition-colors {dropOver ? 'border-primary text-foreground' : 'hover:border-primary hover:text-foreground'}"

--- a/cmd/archipulse/ui/src/components/diagram/ArchiMateNode.svelte
+++ b/cmd/archipulse/ui/src/components/diagram/ArchiMateNode.svelte
@@ -1,0 +1,59 @@
+<script>
+  import { NodeResizer } from '@xyflow/svelte';
+
+  export let data;
+
+  const LAYER_COLORS = {
+    ApplicationComponent:     { fill: '#1a2b4a', stroke: '#7aa2f7', text: '#7aa2f7' },
+    ApplicationService:       { fill: '#1a2b4a', stroke: '#7aa2f7', text: '#7aa2f7' },
+    ApplicationFunction:      { fill: '#1a2b4a', stroke: '#7aa2f7', text: '#7aa2f7' },
+    ApplicationInterface:     { fill: '#1a2b4a', stroke: '#7aa2f7', text: '#7aa2f7' },
+    ApplicationCollaboration: { fill: '#1a2b4a', stroke: '#7aa2f7', text: '#7aa2f7' },
+    BusinessActor:            { fill: '#2a1f0a', stroke: '#e0af68', text: '#e0af68' },
+    BusinessRole:             { fill: '#2a1f0a', stroke: '#e0af68', text: '#e0af68' },
+    BusinessProcess:          { fill: '#2a1f0a', stroke: '#e0af68', text: '#e0af68' },
+    BusinessFunction:         { fill: '#2a1f0a', stroke: '#e0af68', text: '#e0af68' },
+    BusinessService:          { fill: '#2a1f0a', stroke: '#e0af68', text: '#e0af68' },
+    BusinessObject:           { fill: '#2a1f0a', stroke: '#e0af68', text: '#e0af68' },
+    Capability:               { fill: '#2a1f0a', stroke: '#e0af68', text: '#e0af68' },
+    TechnologyService:        { fill: '#0f2a1a', stroke: '#9ece6a', text: '#9ece6a' },
+    TechnologyComponent:      { fill: '#0f2a1a', stroke: '#9ece6a', text: '#9ece6a' },
+    Node:                     { fill: '#0f2a1a', stroke: '#9ece6a', text: '#9ece6a' },
+    SystemSoftware:           { fill: '#0f2a1a', stroke: '#9ece6a', text: '#9ece6a' },
+    Grouping:                 { fill: 'transparent', stroke: '#565f89', text: '#a9b1d6' },
+  };
+
+  const DEFAULT_COLOR = { fill: '#1a1b26', stroke: '#565f89', text: '#a9b1d6' };
+
+  $: c = LAYER_COLORS[data.elementType] || DEFAULT_COLOR;
+</script>
+
+<div
+  class="archimate-node"
+  style="
+    width: 100%;
+    height: 100%;
+    background: {c.fill};
+    border: 1.5px solid {c.stroke};
+    border-radius: 3px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 4px 6px;
+    box-sizing: border-box;
+    overflow: hidden;
+  "
+>
+  <span
+    style="
+      color: {c.text};
+      font-size: 11px;
+      font-family: ui-sans-serif, system-ui, sans-serif;
+      text-align: center;
+      line-height: 1.3;
+      word-break: break-word;
+      hyphens: auto;
+    "
+  >{data.label}</span>
+</div>

--- a/cmd/archipulse/ui/src/components/views/DiagramView.svelte
+++ b/cmd/archipulse/ui/src/components/views/DiagramView.svelte
@@ -1,0 +1,114 @@
+<script>
+  import { push } from 'svelte-spa-router';
+  import { writable } from 'svelte/store';
+  import { SvelteFlow, Controls, Background, MiniMap } from '@xyflow/svelte';
+  import '@xyflow/svelte/dist/style.css';
+
+  import { api } from '../../lib/api.js';
+  import BackButton from '../BackButton.svelte';
+  import ArchiMateNode from '../diagram/ArchiMateNode.svelte';
+
+  export let params = {};
+
+  $: wsId = params.wsId;
+  $: diagId = params.diagId;
+
+  let data = null;
+  let loading = true;
+  let error = null;
+
+  const nodes = writable([]);
+  const edges = writable([]);
+
+  const nodeTypes = { archimate: ArchiMateNode };
+
+  $: if (diagId) load();
+
+  async function load() {
+    loading = true;
+    error = null;
+    data = null;
+    nodes.set([]);
+    edges.set([]);
+    try {
+      data = await api.get('/workspaces/' + wsId + '/diagrams/' + diagId + '/render');
+      nodes.set(
+        (data.nodes || []).map(n => ({
+          id: n.element_id,
+          type: 'archimate',
+          position: { x: n.x, y: n.y },
+          data: { label: n.element_name, elementType: n.element_type },
+          style: `width:${n.w}px;height:${n.h}px;`,
+          draggable: false,
+          selectable: false,
+          connectable: false,
+        }))
+      );
+      edges.set(
+        (data.connections || []).map(c => ({
+          id: c.relationship_id,
+          source: c.source_element_id,
+          target: c.target_element_id,
+          style: 'stroke:#565f89;stroke-width:1.5px;',
+          markerEnd: { type: 'arrowClosed', color: '#565f89', width: 14, height: 10 },
+          animated: false,
+          selectable: false,
+        }))
+      );
+    } catch (e) {
+      error = e.message;
+    } finally {
+      loading = false;
+    }
+  }
+</script>
+
+<div class="content h-full flex flex-col">
+  <BackButton onclick={() => push('/ws/' + wsId + '/diagrams')} label="Diagrams" />
+
+  {#if loading}
+    <div class="flex items-center gap-2 text-muted-foreground py-6">
+      <div class="size-4 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
+      Loading diagram…
+    </div>
+  {:else if error}
+    <div class="mt-4 text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2">
+      {error}
+    </div>
+  {:else if data}
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="text-[15px] font-semibold">{data.name || 'Diagram'}</h2>
+      <span class="text-[11px] text-muted-foreground">{data.nodes?.length ?? 0} elements · {data.connections?.length ?? 0} connections</span>
+    </div>
+
+    <div class="flex-1 border border-border rounded-lg overflow-hidden bg-[#0d0e14]">
+      <SvelteFlow
+        {nodes}
+        {edges}
+        {nodeTypes}
+        fitView
+        fitViewOptions={{ padding: 0.12 }}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        panOnDrag={true}
+        zoomOnScroll={true}
+        style="background:#0d0e14;"
+      >
+        <Background color="#1e2030" gap={20} />
+        <Controls showInteractive={false} />
+        <MiniMap
+          nodeColor={n => {
+            if (!n.data) return '#565f89';
+            const t = n.data.elementType || '';
+            if (t.startsWith('Application')) return '#7aa2f7';
+            if (t.startsWith('Business') || t === 'Capability') return '#e0af68';
+            if (t.startsWith('Technology') || t === 'Node' || t === 'SystemSoftware') return '#9ece6a';
+            return '#565f89';
+          }}
+          style="background:#1a1b26;"
+          maskColor="rgba(0,0,0,0.3)"
+        />
+      </SvelteFlow>
+    </div>
+  {/if}
+</div>

--- a/cmd/archipulse/ui/src/routes/DiagramList.svelte
+++ b/cmd/archipulse/ui/src/routes/DiagramList.svelte
@@ -1,0 +1,69 @@
+<script>
+  import { onMount } from 'svelte';
+  import { push } from 'svelte-spa-router';
+  import { api } from '../lib/api.js';
+  import BackButton from '../components/BackButton.svelte';
+
+  export let params = {};
+  $: wsId = params.wsId;
+
+  let diagrams = [];
+  let loading = true;
+  let error = null;
+
+  onMount(async () => {
+    try {
+      const result = await api.get('/workspaces/' + wsId + '/diagrams');
+      diagrams = result || [];
+    } catch (e) {
+      error = e.message;
+    } finally {
+      loading = false;
+    }
+  });
+</script>
+
+<div class="content">
+  <BackButton onclick={() => push('/ws/' + wsId)} label="Overview" />
+  <h1 class="text-[18px] font-semibold mb-1">Diagrams</h1>
+  <p class="text-[13px] text-muted-foreground mb-5">ArchiMate views imported from the model file</p>
+
+  {#if loading}
+    <div class="flex items-center gap-2 text-muted-foreground py-6">
+      <div class="size-4 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
+      Loading…
+    </div>
+  {:else if error}
+    <div class="text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2">{error}</div>
+  {:else if diagrams.length === 0}
+    <div class="text-center py-16 text-muted-foreground">
+      <div class="text-[40px] mb-3">🗂️</div>
+      <p class="text-[14px]">No diagrams found.<br>Import a model with views to see them here.</p>
+    </div>
+  {:else}
+    <div class="border border-border rounded-lg overflow-hidden">
+      <table class="w-full text-[13px]">
+        <thead>
+          <tr class="border-b border-border bg-muted/40">
+            <th class="text-left px-4 py-2.5 font-medium text-muted-foreground">Name</th>
+            <th class="text-left px-4 py-2.5 font-medium text-muted-foreground w-40">Source ID</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each diagrams as d}
+            <tr
+              class="border-b border-border last:border-0 hover:bg-muted/30 cursor-pointer transition-colors"
+              onclick={() => push('/ws/' + wsId + '/diagrams/' + d.id)}
+              role="button"
+              tabindex="0"
+              onkeydown={e => e.key === 'Enter' && push('/ws/' + wsId + '/diagrams/' + d.id)}
+            >
+              <td class="px-4 py-2.5 font-medium">{d.name || '(unnamed)'}</td>
+              <td class="px-4 py-2.5 text-muted-foreground font-mono text-[11px] truncate max-w-[160px]">{d.source_id}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {/if}
+</div>

--- a/cmd/archipulse/ui/src/routes/DiagramViewer.svelte
+++ b/cmd/archipulse/ui/src/routes/DiagramViewer.svelte
@@ -1,0 +1,6 @@
+<script>
+  import DiagramView from '../components/views/DiagramView.svelte';
+  export let params = {};
+</script>
+
+<DiagramView {params} />

--- a/cmd/archipulse/ui/src/routes/EditorPlaceholder.svelte
+++ b/cmd/archipulse/ui/src/routes/EditorPlaceholder.svelte
@@ -1,0 +1,7 @@
+<div class="content flex flex-col items-center justify-center py-24 text-center">
+  <div class="text-[48px] mb-4">✎</div>
+  <h2 class="text-[16px] font-semibold mb-2">ArchiMate Editor</h2>
+  <p class="text-[13px] text-muted-foreground max-w-xs leading-relaxed">
+    The model editor is coming soon. Here you'll be able to navigate and edit the ArchiMate model elements, relationships, and views.
+  </p>
+</div>

--- a/cmd/archipulse/ui/src/routes/WorkspaceOverview.svelte
+++ b/cmd/archipulse/ui/src/routes/WorkspaceOverview.svelte
@@ -121,6 +121,18 @@
           </div>
         {/each}
       </div>
+
+      <div class="text-[11px] font-bold tracking-[0.6px] uppercase text-muted-foreground mb-3 mt-6">Model diagrams</div>
+      <div
+        class="bg-card border border-border rounded-lg px-4 py-3.5 cursor-pointer transition-colors hover:border-primary inline-flex items-center gap-2"
+        onclick={() => push('/ws/' + wsId + '/diagrams')}
+        role="button"
+        tabindex="0"
+        onkeydown={e => e.key === 'Enter' && push('/ws/' + wsId + '/diagrams')}
+      >
+        <span class="text-[13px] font-semibold">Browse diagrams</span>
+        <span class="text-[12px] text-muted-foreground">— original ArchiMate views from the imported file</span>
+      </div>
     {/if}
   {/if}
 </div>

--- a/internal/api/diagram_handler.go
+++ b/internal/api/diagram_handler.go
@@ -124,11 +124,30 @@ func (h *diagramHandler) delete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+func (h *diagramHandler) render(w http.ResponseWriter, r *http.Request) {
+	id, err := parseUUID(r, "id")
+	if err != nil {
+		respondError(w, http.StatusBadRequest, err)
+		return
+	}
+	rd, err := h.store.Render(id)
+	if errors.Is(err, diagram.ErrNotFound) {
+		respondError(w, http.StatusNotFound, err)
+		return
+	}
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
+	respondJSON(w, http.StatusOK, rd)
+}
+
 func registerDiagramRoutes(r chi.Router, db *sql.DB) {
 	h := &diagramHandler{store: diagram.NewStore(db)}
 	r.Get("/workspaces/{wsID}/diagrams", h.list)
 	r.Post("/workspaces/{wsID}/diagrams", h.create)
 	r.Get("/workspaces/{wsID}/diagrams/{id}", h.get)
+	r.Get("/workspaces/{wsID}/diagrams/{id}/render", h.render)
 	r.Put("/workspaces/{wsID}/diagrams/{id}", h.update)
 	r.Delete("/workspaces/{wsID}/diagrams/{id}", h.delete)
 }

--- a/internal/diagram/diagram.go
+++ b/internal/diagram/diagram.go
@@ -112,6 +112,173 @@ func (s *Store) Update(id uuid.UUID, name, documentation string, layout json.Raw
 	return &d, nil
 }
 
+// RenderNode is a node enriched with element metadata for rendering.
+type RenderNode struct {
+	ElementID   string `json:"element_id"`
+	ElementName string `json:"element_name"`
+	ElementType string `json:"element_type"`
+	X           int    `json:"x"`
+	Y           int    `json:"y"`
+	W           int    `json:"w"`
+	H           int    `json:"h"`
+}
+
+// RenderConnection is a connection enriched with relationship metadata.
+type RenderConnection struct {
+	RelationshipID   string  `json:"relationship_id"`
+	RelationshipType string  `json:"relationship_type"`
+	SourceElementID  string  `json:"source_element_id"`
+	TargetElementID  string  `json:"target_element_id"`
+	Bendpoints       []Point `json:"bendpoints"`
+}
+
+// Point is a 2D coordinate.
+type Point struct {
+	X int `json:"x"`
+	Y int `json:"y"`
+}
+
+// RenderData is the full enriched payload for rendering a diagram.
+type RenderData struct {
+	ID            uuid.UUID          `json:"id"`
+	Name          string             `json:"name"`
+	Documentation string             `json:"documentation"`
+	Nodes         []RenderNode       `json:"nodes"`
+	Connections   []RenderConnection `json:"connections"`
+}
+
+// Render returns the diagram layout enriched with element and relationship metadata.
+func (s *Store) Render(diagramID uuid.UUID) (*RenderData, error) {
+	d, err := s.Get(diagramID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the stored layout JSON.
+	var layout struct {
+		Nodes []struct {
+			ElementID string `json:"ElementID"`
+			X         int    `json:"X"`
+			Y         int    `json:"Y"`
+			W         int    `json:"W"`
+			H         int    `json:"H"`
+		} `json:"Nodes"`
+		Connections []struct {
+			RelationshipID string `json:"RelationshipID"`
+			Bendpoints     []struct {
+				X int `json:"X"`
+				Y int `json:"Y"`
+			} `json:"Bendpoints"`
+		} `json:"Connections"`
+	}
+	if err := json.Unmarshal(d.Layout, &layout); err != nil {
+		return nil, fmt.Errorf("parse layout: %w", err)
+	}
+
+	// Resolve element names and types in one query.
+	elemIDs := make([]string, 0, len(layout.Nodes))
+	for _, n := range layout.Nodes {
+		if n.ElementID != "" {
+			elemIDs = append(elemIDs, n.ElementID)
+		}
+	}
+
+	elemMeta := map[string][2]string{} // source_id → [name, type]
+	if len(elemIDs) > 0 {
+		rows, err := s.db.Query(`
+			SELECT source_id, name, type FROM elements
+			WHERE workspace_id = $1 AND source_id = ANY($2)`,
+			d.WorkspaceID, elemIDs)
+		if err != nil {
+			return nil, fmt.Errorf("resolve element names: %w", err)
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var sid, name, typ string
+			if err := rows.Scan(&sid, &name, &typ); err != nil {
+				return nil, err
+			}
+			elemMeta[sid] = [2]string{name, typ}
+		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	// Resolve relationship metadata.
+	relIDs := make([]string, 0, len(layout.Connections))
+	for _, c := range layout.Connections {
+		if c.RelationshipID != "" {
+			relIDs = append(relIDs, c.RelationshipID)
+		}
+	}
+
+	type relMeta struct {
+		typ    string
+		source string
+		target string
+	}
+	relMap := map[string]relMeta{}
+	if len(relIDs) > 0 {
+		rows, err := s.db.Query(`
+			SELECT source_id, type, source_element, target_element FROM relationships
+			WHERE workspace_id = $1 AND source_id = ANY($2)`,
+			d.WorkspaceID, relIDs)
+		if err != nil {
+			return nil, fmt.Errorf("resolve relationship metadata: %w", err)
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var sid, typ, src, tgt string
+			if err := rows.Scan(&sid, &typ, &src, &tgt); err != nil {
+				return nil, err
+			}
+			relMap[sid] = relMeta{typ: typ, source: src, target: tgt}
+		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	rd := &RenderData{
+		ID:            d.ID,
+		Name:          d.Name,
+		Documentation: d.Documentation,
+		Nodes:         make([]RenderNode, 0, len(layout.Nodes)),
+		Connections:   make([]RenderConnection, 0, len(layout.Connections)),
+	}
+
+	for _, n := range layout.Nodes {
+		meta := elemMeta[n.ElementID]
+		rd.Nodes = append(rd.Nodes, RenderNode{
+			ElementID:   n.ElementID,
+			ElementName: meta[0],
+			ElementType: meta[1],
+			X:           n.X,
+			Y:           n.Y,
+			W:           n.W,
+			H:           n.H,
+		})
+	}
+
+	for _, c := range layout.Connections {
+		meta := relMap[c.RelationshipID]
+		bps := make([]Point, 0, len(c.Bendpoints))
+		for _, bp := range c.Bendpoints {
+			bps = append(bps, Point{X: bp.X, Y: bp.Y})
+		}
+		rd.Connections = append(rd.Connections, RenderConnection{
+			RelationshipID:   c.RelationshipID,
+			RelationshipType: meta.typ,
+			SourceElementID:  meta.source,
+			TargetElementID:  meta.target,
+			Bendpoints:       bps,
+		})
+	}
+
+	return rd, nil
+}
+
 func (s *Store) Delete(id uuid.UUID) error {
 	res, err := s.db.Exec(`DELETE FROM diagrams WHERE id = $1`, id)
 	if err != nil {


### PR DESCRIPTION
## Summary

- **Backend**: new `Render()` method in `internal/diagram` resolves element names, types, and relationship metadata from stored AOEF layout; exposes `GET /workspaces/{wsID}/diagrams/{id}/render`
- **Frontend**: `DiagramList` route lists all diagrams; `DiagramView` renders using `@xyflow/svelte` with custom `ArchiMateNode` component, pan/zoom, minimap, controls, and layer-based colors (blue=Application, yellow=Business, green=Technology)
- **Sidebar**: new **ArchiMate Editor** section with *Editor* (placeholder for future) and *Diagram List* entries; active-state highlighting follows current route
- **Navigation**: `BackButton` component used in both `DiagramList` and `DiagramView` for breadcrumb navigation (Diagrams → diagram detail)
- **WorkspaceOverview**: *Browse diagrams* card links to `/diagrams`

## Test plan

- [ ] Import ArchiMetal.xml or ArchiSurance model
- [ ] Click "Browse diagrams" from workspace overview
- [ ] Verify diagram list loads and shows diagram names
- [ ] Click a diagram — verify XY Flow canvas renders nodes with layer colors
- [ ] Verify pan (drag), zoom (scroll), minimap, and Controls work
- [ ] Verify "← Diagrams" back button navigates back to list
- [ ] Verify "← Overview" back button on list navigates back to workspace overview
- [ ] Verify "Diagram List" entry in sidebar highlights when active
- [ ] Verify "Editor" placeholder entry shows coming-soon screen