### PR TITLE
fix: sidebar loss and XY Flow init error in diagram viewer

### DIFF
--- a/cmd/archipulse/ui/src/App.svelte
+++ b/cmd/archipulse/ui/src/App.svelte
@@ -89,6 +89,14 @@
       return { wsId: m[1], viewName: vn, activeView: target };
     }
 
+    // Match /ws/:wsId/diagrams/:diagId
+    m = loc.match(/^\/ws\/([^/]+)\/diagrams\/([^/]+)$/);
+    if (m) return { wsId: m[1], viewName: null, activeView: null };
+
+    // Match /ws/:wsId/diagrams or /ws/:wsId/editor
+    m = loc.match(/^\/ws\/([^/]+)\/(diagrams|editor)$/);
+    if (m) return { wsId: m[1], viewName: null, activeView: null };
+
     // Match /ws/:wsId
     m = loc.match(/^\/ws\/([^/]+)$/);
     if (m) return { wsId: m[1], viewName: null, activeView: null };

--- a/cmd/archipulse/ui/src/components/views/DiagramView.svelte
+++ b/cmd/archipulse/ui/src/components/views/DiagramView.svelte
@@ -1,6 +1,5 @@
 <script>
   import { push } from 'svelte-spa-router';
-  import { writable } from 'svelte/store';
   import { SvelteFlow, Controls, Background, MiniMap } from '@xyflow/svelte';
   import '@xyflow/svelte/dist/style.css';
 
@@ -17,8 +16,8 @@
   let loading = true;
   let error = null;
 
-  const nodes = writable([]);
-  const edges = writable([]);
+  let nodes = [];
+  let edges = [];
 
   const nodeTypes = { archimate: ArchiMateNode };
 
@@ -28,33 +27,28 @@
     loading = true;
     error = null;
     data = null;
-    nodes.set([]);
-    edges.set([]);
+    nodes = [];
+    edges = [];
     try {
       data = await api.get('/workspaces/' + wsId + '/diagrams/' + diagId + '/render');
-      nodes.set(
-        (data.nodes || []).map(n => ({
-          id: n.element_id,
-          type: 'archimate',
-          position: { x: n.x, y: n.y },
-          data: { label: n.element_name, elementType: n.element_type },
-          style: `width:${n.w}px;height:${n.h}px;`,
-          draggable: false,
-          selectable: false,
-          connectable: false,
-        }))
-      );
-      edges.set(
-        (data.connections || []).map(c => ({
-          id: c.relationship_id,
-          source: c.source_element_id,
-          target: c.target_element_id,
-          style: 'stroke:#565f89;stroke-width:1.5px;',
-          markerEnd: { type: 'arrowClosed', color: '#565f89', width: 14, height: 10 },
-          animated: false,
-          selectable: false,
-        }))
-      );
+      nodes = (data.nodes || []).map(n => ({
+        id: n.element_id,
+        type: 'archimate',
+        position: { x: n.x, y: n.y },
+        data: { label: n.element_name, elementType: n.element_type },
+        style: `width:${n.w}px;height:${n.h}px;`,
+        draggable: false,
+        selectable: false,
+        connectable: false,
+      }));
+      edges = (data.connections || []).map(c => ({
+        id: c.relationship_id,
+        source: c.source_element_id,
+        target: c.target_element_id,
+        style: 'stroke:#565f89;stroke-width:1.5px;',
+        markerEnd: { type: 'arrowClosed', color: '#565f89', width: 14, height: 10 },
+        selectable: false,
+      }));
     } catch (e) {
       error = e.message;
     } finally {
@@ -83,8 +77,8 @@
 
     <div class="flex-1 border border-border rounded-lg overflow-hidden bg-[#0d0e14]">
       <SvelteFlow
-        {nodes}
-        {edges}
+        bind:nodes
+        bind:edges
         {nodeTypes}
         fitView
         fitViewOptions={{ padding: 0.12 }}


### PR DESCRIPTION
## Summary

- **Sidebar disappears on /editor and /diagrams routes**: `extractParams` in `App.svelte` only matched `/ws/:wsId`, `/ws/:wsId/view/...` and `/ws/:wsId/diagrams/:diagId` — missing `/editor`, `/diagrams`, and `/diagrams/:id`. Added the missing patterns so `wsId` is always extracted and the sidebar stays visible.
- **XY Flow "t is not iterable" error**: `DiagramView` was passing `writable()` stores to `<SvelteFlow nodes={...}>`, but `@xyflow/svelte` v1.5.2 expects plain arrays bound with `bind:nodes` / `bind:edges`. Switched to the correct API.

## Test plan

- [ ] Navigate to ArchiMate Editor → Editor — sidebar remains visible
- [ ] Navigate to ArchiMate Editor → Diagram List — sidebar remains visible
- [ ] Click a diagram — canvas renders nodes without console errors
- [ ] Pan, zoom, minimap all work