### PR TITLE
feat(diagram): ArchiMate 3 themed diagram viewer

### DIFF
--- a/cmd/archipulse/ui/src/components/Nav.svelte
+++ b/cmd/archipulse/ui/src/components/Nav.svelte
@@ -48,7 +48,7 @@
       </svg>
     </button>
   {/if}
-  <a class="nav-logo" href="#/" use:push={'/'}>
+  <a class="nav-logo" href="#/">
     <svg width="22" height="22" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
       <polygon points="16,2 27,8 27,22 16,28 5,22 5,8" fill="#E85D3A"/>
       <polygon points="16,9 22,13 22,21 16,25 10,21 10,13" fill="none" stroke="white" stroke-width="0.8" stroke-linejoin="round" opacity="0.4"/>

--- a/cmd/archipulse/ui/src/components/diagram/ArchiMateEdge.svelte
+++ b/cmd/archipulse/ui/src/components/diagram/ArchiMateEdge.svelte
@@ -1,0 +1,90 @@
+<script>
+  // Custom XY Flow edge that renders ArchiMate relationship types faithfully.
+  //
+  // Instead of using XY Flow's auto-routed handle positions, this component
+  // computes the path directly from the source/target node bounds and bendpoints
+  // stored in `data`. Markers (arrows, diamonds, circles) are defined globally
+  // in DiagramView via a hidden <svg><defs> and referenced by ID.
+  //
+  // Props passed by XY Flow: id, sourceX, sourceY, targetX, targetY, data, ...
+  // We only use `data`.
+
+  import { getRelationshipStyle, intersectNodeBoundary } from './archimate-edges.js';
+
+  export let data;
+
+  $: style     = getRelationshipStyle(data?.relationshipType);
+  $: bps       = data?.bendpoints || [];
+  $: srcBounds = data?.sourceBounds;
+  $: tgtBounds = data?.targetBounds;
+
+  $: srcCenter = srcBounds
+    ? { x: srcBounds.x + srcBounds.w / 2, y: srcBounds.y + srcBounds.h / 2 }
+    : { x: 0, y: 0 };
+  $: tgtCenter = tgtBounds
+    ? { x: tgtBounds.x + tgtBounds.w / 2, y: tgtBounds.y + tgtBounds.h / 2 }
+    : { x: 0, y: 0 };
+
+  // Use orthogonal snapping only when bendpoints define a routing lane.
+  // Direct connections (no bendpoints) use natural diagonal intersection.
+  $: hasBps = bps.length > 0;
+
+  $: startPt = intersectNodeBoundary(
+    srcBounds,
+    hasBps ? bps[0].x : tgtCenter.x,
+    hasBps ? bps[0].y : tgtCenter.y,
+    hasBps,
+  );
+  $: endPt = intersectNodeBoundary(
+    tgtBounds,
+    hasBps ? bps[bps.length - 1].x : srcCenter.x,
+    hasBps ? bps[bps.length - 1].y : srcCenter.y,
+    hasBps,
+  );
+
+  $: allPts = [startPt, ...bps, endPt];
+
+  // Build a smooth polyline: straight segments but with small rounded corners
+  // at intermediate bendpoints so the path looks clean rather than jagged.
+  function smoothPath(pts) {
+    if (pts.length < 2) return '';
+    if (pts.length === 2) return `M${pts[0].x},${pts[0].y} L${pts[1].x},${pts[1].y}`;
+    const r = 8; // corner radius in diagram units
+    let d = `M${pts[0].x},${pts[0].y}`;
+    for (let i = 1; i < pts.length - 1; i++) {
+      const prev = pts[i - 1];
+      const cur  = pts[i];
+      const next = pts[i + 1];
+      const d1 = Math.hypot(cur.x - prev.x, cur.y - prev.y);
+      const d2 = Math.hypot(next.x - cur.x, next.y - cur.y);
+      const t1 = Math.min(r, d1 / 2) / d1;
+      const t2 = Math.min(r, d2 / 2) / d2;
+      const bx = cur.x - (cur.x - prev.x) * t1;
+      const by = cur.y - (cur.y - prev.y) * t1;
+      const cx2 = cur.x + (next.x - cur.x) * t2;
+      const cy2 = cur.y + (next.y - cur.y) * t2;
+      d += ` L${bx.toFixed(1)},${by.toFixed(1)} Q${cur.x},${cur.y} ${cx2.toFixed(1)},${cy2.toFixed(1)}`;
+    }
+    d += ` L${pts[pts.length - 1].x},${pts[pts.length - 1].y}`;
+    return d;
+  }
+
+  $: pathD = smoothPath(allPts);
+
+  $: markerEnd   = style.end   ? `url(#am-${style.end})`   : undefined;
+  $: markerStart = style.start ? `url(#am-${style.start})` : undefined;
+</script>
+
+<!-- Invisible wider stroke for future hover/selection interactions -->
+<path d={pathD} fill="none" stroke="transparent" stroke-width="14" />
+
+<!-- Main edge path — stroke color propagates to markers via context-stroke -->
+<path
+  d={pathD}
+  fill="none"
+  stroke={style.stroke}
+  stroke-width={style.width}
+  stroke-dasharray={style.dash || undefined}
+  marker-end={markerEnd}
+  marker-start={markerStart}
+/>

--- a/cmd/archipulse/ui/src/components/diagram/ArchiMateNode.svelte
+++ b/cmd/archipulse/ui/src/components/diagram/ArchiMateNode.svelte
@@ -1,59 +1,97 @@
 <script>
-  import { NodeResizer } from '@xyflow/svelte';
+  import { Handle, Position } from '@xyflow/svelte';
+  import { getIcon, getColor } from './archimate-icons.js';
 
   export let data;
 
-  const LAYER_COLORS = {
-    ApplicationComponent:     { fill: '#1a2b4a', stroke: '#7aa2f7', text: '#7aa2f7' },
-    ApplicationService:       { fill: '#1a2b4a', stroke: '#7aa2f7', text: '#7aa2f7' },
-    ApplicationFunction:      { fill: '#1a2b4a', stroke: '#7aa2f7', text: '#7aa2f7' },
-    ApplicationInterface:     { fill: '#1a2b4a', stroke: '#7aa2f7', text: '#7aa2f7' },
-    ApplicationCollaboration: { fill: '#1a2b4a', stroke: '#7aa2f7', text: '#7aa2f7' },
-    BusinessActor:            { fill: '#2a1f0a', stroke: '#e0af68', text: '#e0af68' },
-    BusinessRole:             { fill: '#2a1f0a', stroke: '#e0af68', text: '#e0af68' },
-    BusinessProcess:          { fill: '#2a1f0a', stroke: '#e0af68', text: '#e0af68' },
-    BusinessFunction:         { fill: '#2a1f0a', stroke: '#e0af68', text: '#e0af68' },
-    BusinessService:          { fill: '#2a1f0a', stroke: '#e0af68', text: '#e0af68' },
-    BusinessObject:           { fill: '#2a1f0a', stroke: '#e0af68', text: '#e0af68' },
-    Capability:               { fill: '#2a1f0a', stroke: '#e0af68', text: '#e0af68' },
-    TechnologyService:        { fill: '#0f2a1a', stroke: '#9ece6a', text: '#9ece6a' },
-    TechnologyComponent:      { fill: '#0f2a1a', stroke: '#9ece6a', text: '#9ece6a' },
-    Node:                     { fill: '#0f2a1a', stroke: '#9ece6a', text: '#9ece6a' },
-    SystemSoftware:           { fill: '#0f2a1a', stroke: '#9ece6a', text: '#9ece6a' },
-    Grouping:                 { fill: 'transparent', stroke: '#565f89', text: '#a9b1d6' },
-  };
-
-  const DEFAULT_COLOR = { fill: '#1a1b26', stroke: '#565f89', text: '#a9b1d6' };
-
-  $: c = LAYER_COLORS[data.elementType] || DEFAULT_COLOR;
+  $: c = getColor(data.elementType);
+  $: icon = getIcon(data.elementType);
+  $: isContainer = data.isContainer || false;
+  $: dashed = c.dashed || false;
 </script>
 
+<Handle type="source" position={Position.Right} style="opacity:0;pointer-events:none;" />
+<Handle type="target" position={Position.Left} style="opacity:0;pointer-events:none;" />
 <div
-  class="archimate-node"
   style="
     width: 100%;
     height: 100%;
     background: {c.fill};
-    border: 1.5px solid {c.stroke};
-    border-radius: 3px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: 4px 6px;
+    border: 1.5px {dashed ? 'dashed' : 'solid'} {c.stroke};
+    border-radius: 4px;
+    position: relative;
+    font-family: ui-sans-serif, system-ui, sans-serif;
     box-sizing: border-box;
-    overflow: hidden;
+    overflow: visible;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
   "
 >
-  <span
+  <!-- Type icon — always top-right -->
+  <svg
+    viewBox="0 0 16 16"
+    width="16"
+    height="16"
     style="
-      color: {c.text};
-      font-size: 11px;
-      font-family: ui-sans-serif, system-ui, sans-serif;
-      text-align: center;
-      line-height: 1.3;
-      word-break: break-word;
-      hyphens: auto;
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      color: {c.stroke};
+      stroke: {c.stroke};
+      fill: none;
+      flex-shrink: 0;
+      overflow: visible;
+      pointer-events: none;
     "
-  >{data.label}</span>
+  >
+    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+    {@html icon}
+  </svg>
+
+  {#if isContainer}
+    <!-- Container: label at top, children rendered by XY Flow inside -->
+    <div style="
+      position: absolute;
+      top: 6px;
+      left: 0;
+      right: 22px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 8px;
+      box-sizing: border-box;
+    ">
+      <span style="
+        color: {c.text};
+        font-size: 11px;
+        font-weight: 600;
+        text-align: center;
+        line-height: 1.3;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+      ">{data.label}</span>
+    </div>
+  {:else}
+    <!-- Leaf: label centered -->
+    <div style="
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 4px 22px 4px 6px;
+      box-sizing: border-box;
+    ">
+      <span style="
+        color: {c.text};
+        font-size: 11px;
+        font-weight: 500;
+        text-align: center;
+        line-height: 1.35;
+        word-break: break-word;
+        hyphens: auto;
+      ">{data.label}</span>
+    </div>
+  {/if}
 </div>

--- a/cmd/archipulse/ui/src/components/diagram/ValueStreamNode.svelte
+++ b/cmd/archipulse/ui/src/components/diagram/ValueStreamNode.svelte
@@ -1,0 +1,82 @@
+<script>
+  // ValueStream: chevron/arrow shape per ArchiMate standard.
+  // Container (has children): flat-left arrow, label at top.
+  // Leaf step: shallow left-notch arrow, label centered.
+  import { Handle, Position } from '@xyflow/svelte';
+  export let data;
+
+  const AMBER = { fill: '#FFFBEB', stroke: '#D97706', text: '#78350F' };
+
+  // viewBox 0 0 100 40
+  // Both container and leaf: flat left (vertical), arrow right.
+  // Container uses a shallower arrow; leaf a proportionally deeper one.
+  $: points = data.isContainer
+    ? '0,0 88,0 100,20 88,40 0,40'
+    : '0,0 86,0 100,20 86,40 0,40';
+</script>
+
+<Handle type="source" position={Position.Right} style="opacity:0;pointer-events:none;" />
+<Handle type="target" position={Position.Left} style="opacity:0;pointer-events:none;" />
+<div style="width:100%;height:100%;position:relative;overflow:visible;pointer-events:none;">
+  <svg
+    viewBox="0 0 100 40"
+    preserveAspectRatio="none"
+    style="position:absolute;top:0;left:0;width:100%;height:100%;overflow:visible;pointer-events:none;"
+  >
+    <polygon
+      {points}
+      fill={AMBER.fill}
+      stroke={AMBER.stroke}
+      stroke-width="1.5"
+      vector-effect="non-scaling-stroke"
+    />
+  </svg>
+
+  {#if data.isContainer}
+    <!-- Container: label at top, children rendered by XY Flow inside -->
+    <div style="
+      position: absolute;
+      top: 6px;
+      left: 0;
+      right: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 14px;
+      box-sizing: border-box;
+      pointer-events: none;
+    ">
+      <span style="
+        color: {AMBER.text};
+        font-size: 11px;
+        font-weight: 600;
+        font-family: ui-sans-serif, system-ui, sans-serif;
+        text-align: center;
+        line-height: 1.3;
+      ">{data.label}</span>
+    </div>
+  {:else}
+    <!-- Leaf: label centered -->
+    <div style="
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 4px 18px;
+      box-sizing: border-box;
+      pointer-events: none;
+    ">
+      <span style="
+        color: {AMBER.text};
+        font-size: 11px;
+        font-weight: 500;
+        font-family: ui-sans-serif, system-ui, sans-serif;
+        text-align: center;
+        line-height: 1.35;
+        word-break: break-word;
+        hyphens: auto;
+      ">{data.label}</span>
+    </div>
+  {/if}
+</div>

--- a/cmd/archipulse/ui/src/components/diagram/archimate-edges.js
+++ b/cmd/archipulse/ui/src/components/diagram/archimate-edges.js
@@ -1,0 +1,82 @@
+// ArchiMate relationship visual styles.
+// Each entry defines the stroke, line style, and marker types for source/end.
+//
+// Marker types:
+//   filled-arrow   — solid filled arrowhead (Triggering, Flow, Assignment)
+//   open-arrow     — open V arrowhead (Association, Serving, Access, Influence)
+//   open-triangle  — hollow closed triangle (Realization, Specialization)
+//   filled-diamond — solid diamond at source (Composition)
+//   open-diamond   — hollow diamond at source (Aggregation)
+//   filled-circle  — solid circle at source (Assignment)
+
+export const RELATIONSHIP_STYLES = {
+  TriggeringRelationship:     { stroke: '#374151', width: 1.5, dash: null,  end: 'filled-arrow',  start: null },
+  FlowRelationship:           { stroke: '#374151', width: 1.5, dash: '8 4', end: 'filled-arrow',  start: null },
+  AssociationRelationship:    { stroke: '#9CA3AF', width: 1.2, dash: null,  end: 'open-arrow',    start: null },
+  CompositionRelationship:    { stroke: '#374151', width: 1.5, dash: null,  end: null,            start: 'filled-diamond' },
+  AggregationRelationship:    { stroke: '#374151', width: 1.5, dash: null,  end: null,            start: 'open-diamond' },
+  AssignmentRelationship:     { stroke: '#374151', width: 1.5, dash: null,  end: 'filled-arrow',  start: 'filled-circle' },
+  RealizationRelationship:    { stroke: '#6B7280', width: 1.5, dash: '8 4', end: 'open-triangle', start: null },
+  RealisationRelationship:    { stroke: '#6B7280', width: 1.5, dash: '8 4', end: 'open-triangle', start: null },
+  ServingRelationship:        { stroke: '#374151', width: 1.2, dash: null,  end: 'open-arrow',    start: null },
+  AccessRelationship:         { stroke: '#9CA3AF', width: 1.2, dash: '4 3', end: 'open-arrow',    start: null },
+  InfluenceRelationship:      { stroke: '#9CA3AF', width: 1.2, dash: '6 3', end: 'open-arrow',    start: null },
+  SpecializationRelationship: { stroke: '#374151', width: 1.5, dash: null,  end: 'open-triangle', start: null },
+};
+
+const DEFAULT_STYLE = { stroke: '#6B7280', width: 1.2, dash: null, end: 'filled-arrow', start: null };
+
+export function getRelationshipStyle(relType) {
+  if (!relType) return DEFAULT_STYLE;
+  if (RELATIONSHIP_STYLES[relType]) return RELATIONSHIP_STYLES[relType];
+  // Partial match for truncated type names
+  for (const [key, val] of Object.entries(RELATIONSHIP_STYLES)) {
+    if (relType.includes(key.replace('Relationship', ''))) return val;
+  }
+  return DEFAULT_STYLE;
+}
+
+// Compute where the edge exits/enters a node boundary toward point (px, py).
+//
+// orthogonal=true: bendpoint-driven routing — snap the exit/entry coordinate
+//   to the bendpoint lane so segments remain horizontal or vertical.
+// orthogonal=false: direct connection — use a diagonal ray from center so the
+//   edge exits through the most natural point on the border.
+export function intersectNodeBoundary(bounds, px, py, orthogonal = false) {
+  if (!bounds) return { x: px, y: py };
+  const cx = bounds.x + bounds.w / 2;
+  const cy = bounds.y + bounds.h / 2;
+  const dx = px - cx;
+  const dy = py - cy;
+  if (Math.abs(dx) < 0.1 && Math.abs(dy) < 0.1) return { x: cx, y: cy };
+  const hw = bounds.w / 2;
+  const hh = bounds.h / 2;
+  const left   = bounds.x;
+  const right  = bounds.x + bounds.w;
+  const top    = bounds.y;
+  const bottom = bounds.y + bounds.h;
+  const sx = dx !== 0 ? hw / Math.abs(dx) : Infinity;
+  const sy = dy !== 0 ? hh / Math.abs(dy) : Infinity;
+
+  if (orthogonal) {
+    // Snap exit/entry coordinate to the bendpoint lane
+    if (sy <= sx) {
+      return {
+        x: +(Math.max(left, Math.min(right, px))).toFixed(2),
+        y: dy < 0 ? top : bottom,
+      };
+    } else {
+      return {
+        x: dx < 0 ? left : right,
+        y: +(Math.max(top, Math.min(bottom, py))).toFixed(2),
+      };
+    }
+  } else {
+    // Diagonal ray intersection
+    const s = Math.min(sx, sy);
+    return {
+      x: +(cx + dx * s).toFixed(2),
+      y: +(cy + dy * s).toFixed(2),
+    };
+  }
+}

--- a/cmd/archipulse/ui/src/components/diagram/archimate-icons.js
+++ b/cmd/archipulse/ui/src/components/diagram/archimate-icons.js
@@ -1,0 +1,543 @@
+// ArchiMate 3 element type icons — inline SVG paths (viewBox 0 0 16 16)
+// Each entry is an SVG string to embed inside <svg viewBox="0 0 16 16">
+//
+// Shape vocabulary (per ArchiMate 3 standard):
+//   Actor      → stick figure
+//   Role       → cylinder (standing)
+//   Collaboration → two overlapping circles
+//   Interface  → lollipop (circle + stem + T-bar)
+//   Process    → right-pointing pentagon (flat left, pointed right)
+//   Function   → left-notch chevron (pointed left, flat right)
+//   Interaction → two overlapping circles (same as collab — context differentiates)
+//   Service    → oval / stadium
+//   Event      → trigger pentagon (flat right, notch-left)
+//   Object/Data → rectangle with lines
+//   Component  → rect with two plug tabs on left
+//   Node       → 3D box
+//   Cylinder   → vertical cylinder (Role, Stakeholder, SystemSoftware)
+//   Grouping   → dashed rect
+
+export const ICONS = {
+
+  // ── Business layer ───────────────────────────────────────────────────────
+
+  // Stick figure
+  BusinessActor: `
+    <circle cx="8" cy="3.5" r="2" stroke-width="1.2" fill="none"/>
+    <line x1="8" y1="5.5" x2="8" y2="10.5" stroke-width="1.2"/>
+    <line x1="4.5" y1="7.5" x2="11.5" y2="7.5" stroke-width="1.2"/>
+    <line x1="8" y1="10.5" x2="5.5" y2="14" stroke-width="1.2"/>
+    <line x1="8" y1="10.5" x2="10.5" y2="14" stroke-width="1.2"/>
+  `,
+
+  // Vertical cylinder
+  BusinessRole: `
+    <ellipse cx="8" cy="4.5" rx="5" ry="1.8" stroke-width="1.2" fill="none"/>
+    <line x1="3" y1="4.5" x2="3" y2="12" stroke-width="1.2"/>
+    <line x1="13" y1="4.5" x2="13" y2="12" stroke-width="1.2"/>
+    <ellipse cx="8" cy="12" rx="5" ry="1.8" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Two overlapping circles
+  BusinessCollaboration: `
+    <circle cx="5.5" cy="8" r="4" stroke-width="1.2" fill="none"/>
+    <circle cx="10.5" cy="8" r="4" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Lollipop — circle + stem + T-bar
+  BusinessInterface: `
+    <circle cx="8" cy="5" r="3" stroke-width="1.2" fill="none"/>
+    <line x1="8" y1="8" x2="8" y2="13.5" stroke-width="1.2"/>
+    <line x1="5.5" y1="13.5" x2="10.5" y2="13.5" stroke-width="1.2"/>
+  `,
+
+  // Notched right-pointing arrow — ArchiMate process symbol (confirmed correct)
+  BusinessProcess: `
+    <polygon points="1.5,5 9.5,5 9.5,2.5 14.5,8 9.5,13.5 9.5,11 1.5,11" stroke-width="1.4" fill="none" stroke-linejoin="round"/>
+  `,
+
+  // Thick open chevron pointing up — ArchiMate function symbol
+  BusinessFunction: `
+    <polygon points="8,3 14,8 14,13 8,8 2,13 2,8" stroke-width="1.4" fill="none" stroke-linejoin="round"/>
+  `,
+
+  // Two overlapping circles (same shape as collaboration)
+  BusinessInteraction: `
+    <circle cx="5.5" cy="8" r="4" stroke-width="1.2" fill="none"/>
+    <circle cx="10.5" cy="8" r="4" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Oval / stadium
+  BusinessService: `
+    <rect x="2" y="5.5" width="12" height="5" rx="2.5" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Trigger: flat right, notch on left (mirror of process)
+  BusinessEvent: `
+    <polygon points="4,5 14,5 14,11 4,11 1,8" stroke-width="1.2" fill="none" stroke-linejoin="round"/>
+  `,
+
+  // Rectangle with header line — standard BusinessObject notation
+  BusinessObject: `
+    <rect x="2" y="3" width="12" height="10" rx="1" stroke-width="1.2" fill="none"/>
+    <line x1="2" y1="6.5" x2="14" y2="6.5" stroke-width="1"/>
+  `,
+
+  // Rectangle with bottom tab (contract/document)
+  Contract: `
+    <rect x="3" y="2.5" width="10" height="10" rx="1" stroke-width="1.2" fill="none"/>
+    <line x1="3" y1="9.5" x2="13" y2="9.5" stroke-width="1"/>
+    <line x1="5" y1="11.5" x2="11" y2="11.5" stroke-width="1"/>
+  `,
+
+  // Rectangle with wavy bottom edge
+  Representation: `
+    <path d="M3,3 L13,3 L13,11 Q11,13 9,11 Q7,9 5,11 Q4,12 3,11 Z" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Rectangle with small left-side tab (product)
+  Product: `
+    <rect x="4" y="3" width="10" height="10" rx="1" stroke-width="1.2" fill="none"/>
+    <rect x="2" y="5" width="4" height="3" rx="0.5" stroke-width="1.2" fill="none"/>
+  `,
+
+  // ── Application layer ────────────────────────────────────────────────────
+
+  // Rect with two plug tabs on left
+  ApplicationComponent: `
+    <rect x="4" y="2" width="10" height="12" rx="1" stroke-width="1.2" fill="none"/>
+    <rect x="1" y="4.5" width="4" height="2.5" rx="0.5" stroke-width="1.2" fill="none"/>
+    <rect x="1" y="9" width="4" height="2.5" rx="0.5" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Two overlapping circles
+  ApplicationCollaboration: `
+    <circle cx="5.5" cy="8" r="4" stroke-width="1.2" fill="none"/>
+    <circle cx="10.5" cy="8" r="4" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Lollipop
+  ApplicationInterface: `
+    <circle cx="8" cy="5" r="3" stroke-width="1.2" fill="none"/>
+    <line x1="8" y1="8" x2="8" y2="13.5" stroke-width="1.2"/>
+    <line x1="5.5" y1="13.5" x2="10.5" y2="13.5" stroke-width="1.2"/>
+  `,
+
+  // Hollow right-pointing arrow
+  ApplicationProcess: `
+    <polyline points="2,5.5 11,5.5 14.5,8 11,10.5 2,10.5 2,5.5" stroke-width="1.2" fill="none" stroke-linejoin="round"/>
+  `,
+
+  // Thick open chevron pointing up — same as BusinessFunction
+  ApplicationFunction: `
+    <polygon points="8,3 14,8 14,13 8,8 2,13 2,8" stroke-width="1.4" fill="none" stroke-linejoin="round"/>
+  `,
+
+  // Two overlapping circles
+  ApplicationInteraction: `
+    <circle cx="5.5" cy="8" r="4" stroke-width="1.2" fill="none"/>
+    <circle cx="10.5" cy="8" r="4" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Oval
+  ApplicationService: `
+    <rect x="2" y="5.5" width="12" height="5" rx="2.5" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Trigger
+  ApplicationEvent: `
+    <polygon points="4,5 14,5 14,11 4,11 1,8" stroke-width="1.2" fill="none" stroke-linejoin="round"/>
+  `,
+
+  // Rectangle with header line (mirrors BusinessObject)
+  DataObject: `
+    <rect x="2" y="3" width="12" height="10" rx="1" stroke-width="1.2" fill="none"/>
+    <line x1="2" y1="6.5" x2="14" y2="6.5" stroke-width="1"/>
+  `,
+
+  // ── Technology layer ─────────────────────────────────────────────────────
+
+  // 3D box (isometric)
+  Node: `
+    <rect x="2" y="5" width="10" height="8" rx="1" stroke-width="1.2" fill="none"/>
+    <polyline points="2,5 5,2 14,2 14,10 12,13" stroke-width="1.2" fill="none" stroke-linejoin="round"/>
+    <line x1="12" y1="5" x2="14" y2="2" stroke-width="1.2"/>
+    <line x1="12" y1="5" x2="12" y2="13" stroke-width="1"/>
+  `,
+
+  // Device: 3D flat box
+  Device: `
+    <rect x="2" y="6" width="10" height="7" rx="1" stroke-width="1.2" fill="none"/>
+    <polyline points="2,6 4,3 13,3 13,10 12,13" stroke-width="1.2" fill="none" stroke-linejoin="round"/>
+    <line x1="12" y1="6" x2="13" y2="3" stroke-width="1.2"/>
+  `,
+
+  // Vertical cylinder
+  SystemSoftware: `
+    <ellipse cx="8" cy="4.5" rx="5" ry="1.8" stroke-width="1.2" fill="none"/>
+    <line x1="3" y1="4.5" x2="3" y2="12" stroke-width="1.2"/>
+    <line x1="13" y1="4.5" x2="13" y2="12" stroke-width="1.2"/>
+    <ellipse cx="8" cy="12" rx="5" ry="1.8" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Two overlapping circles
+  TechnologyCollaboration: `
+    <circle cx="5.5" cy="8" r="4" stroke-width="1.2" fill="none"/>
+    <circle cx="10.5" cy="8" r="4" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Lollipop
+  TechnologyInterface: `
+    <circle cx="8" cy="5" r="3" stroke-width="1.2" fill="none"/>
+    <line x1="8" y1="8" x2="8" y2="13.5" stroke-width="1.2"/>
+    <line x1="5.5" y1="13.5" x2="10.5" y2="13.5" stroke-width="1.2"/>
+  `,
+
+  // Notched right-pointing arrow — same as BusinessProcess
+  TechnologyProcess: `
+    <polygon points="1.5,5 9.5,5 9.5,2.5 14.5,8 9.5,13.5 9.5,11 1.5,11" stroke-width="1.4" fill="none" stroke-linejoin="round"/>
+  `,
+
+  // Thick open chevron pointing up — same as BusinessFunction
+  TechnologyFunction: `
+    <polygon points="8,3 14,8 14,13 8,8 2,13 2,8" stroke-width="1.4" fill="none" stroke-linejoin="round"/>
+  `,
+
+  // Two overlapping circles
+  TechnologyInteraction: `
+    <circle cx="5.5" cy="8" r="4" stroke-width="1.2" fill="none"/>
+    <circle cx="10.5" cy="8" r="4" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Oval
+  TechnologyService: `
+    <rect x="2" y="5.5" width="12" height="5" rx="2.5" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Trigger
+  TechnologyEvent: `
+    <polygon points="4,5 14,5 14,11 4,11 1,8" stroke-width="1.2" fill="none" stroke-linejoin="round"/>
+  `,
+
+  // Rect with two plug tabs (same as ApplicationComponent)
+  TechnologyComponent: `
+    <rect x="4" y="2" width="10" height="12" rx="1" stroke-width="1.2" fill="none"/>
+    <rect x="1" y="4.5" width="4" height="2.5" rx="0.5" stroke-width="1.2" fill="none"/>
+    <rect x="1" y="9" width="4" height="2.5" rx="0.5" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Dog-eared document
+  Artifact: `
+    <path d="M3,2 L11,2 L13,4 L13,14 L3,14 Z" stroke-width="1.2" fill="none"/>
+    <polyline points="11,2 11,4 13,4" stroke-width="1.2" fill="none"/>
+    <line x1="5.5" y1="7" x2="10.5" y2="7" stroke-width="1"/>
+    <line x1="5.5" y1="9.5" x2="10.5" y2="9.5" stroke-width="1"/>
+  `,
+
+  // Factory outline
+  Facility: `
+    <polyline points="2,13 2,7 5,7 5,10 8,7 8,10 11,7 11,10 14,7 14,13 2,13" stroke-width="1.2" fill="none" stroke-linejoin="round"/>
+  `,
+
+  // Gear
+  Equipment: `
+    <circle cx="8" cy="8" r="2.5" stroke-width="1.2" fill="none"/>
+    <circle cx="8" cy="8" r="4.5" stroke-width="0" fill="none"/>
+    <line x1="8" y1="1.5" x2="8" y2="3.5" stroke-width="2"/>
+    <line x1="8" y1="12.5" x2="8" y2="14.5" stroke-width="2"/>
+    <line x1="1.5" y1="8" x2="3.5" y2="8" stroke-width="2"/>
+    <line x1="12.5" y1="8" x2="14.5" y2="8" stroke-width="2"/>
+    <line x1="3.5" y1="3.5" x2="4.9" y2="4.9" stroke-width="2"/>
+    <line x1="11.1" y1="11.1" x2="12.5" y2="12.5" stroke-width="2"/>
+    <line x1="12.5" y1="3.5" x2="11.1" y2="4.9" stroke-width="2"/>
+    <line x1="4.9" y1="11.1" x2="3.5" y2="12.5" stroke-width="2"/>
+  `,
+
+  // Hexagon outline
+  Material: `
+    <polygon points="8,1.5 13.5,4.5 13.5,11.5 8,14.5 2.5,11.5 2.5,4.5" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Network: dots connected
+  CommunicationNetwork: `
+    <circle cx="8" cy="8" r="1.5" fill="currentColor"/>
+    <circle cx="3" cy="5" r="1.5" fill="currentColor"/>
+    <circle cx="13" cy="5" r="1.5" fill="currentColor"/>
+    <circle cx="3" cy="11" r="1.5" fill="currentColor"/>
+    <circle cx="13" cy="11" r="1.5" fill="currentColor"/>
+    <line x1="8" y1="8" x2="3" y2="5" stroke-width="1.2"/>
+    <line x1="8" y1="8" x2="13" y2="5" stroke-width="1.2"/>
+    <line x1="8" y1="8" x2="3" y2="11" stroke-width="1.2"/>
+    <line x1="8" y1="8" x2="13" y2="11" stroke-width="1.2"/>
+  `,
+
+  // Bidirectional arrow
+  Path: `
+    <line x1="1" y1="8" x2="15" y2="8" stroke-width="1.2"/>
+    <polyline points="4,5.5 1,8 4,10.5" stroke-width="1.2" fill="none"/>
+    <polyline points="12,5.5 15,8 12,10.5" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Double bidirectional arrow
+  DistributionNetwork: `
+    <line x1="1" y1="6" x2="15" y2="6" stroke-width="1.2"/>
+    <polyline points="4,3.5 1,6 4,8.5" stroke-width="1.2" fill="none"/>
+    <polyline points="12,3.5 15,6 12,8.5" stroke-width="1.2" fill="none"/>
+    <line x1="1" y1="10" x2="15" y2="10" stroke-width="1.2"/>
+    <polyline points="4,7.5 1,10 4,12.5" stroke-width="1.2" fill="none"/>
+    <polyline points="12,7.5 15,10 12,12.5" stroke-width="1.2" fill="none"/>
+  `,
+
+  // ── Motivation layer ─────────────────────────────────────────────────────
+
+  // Cylinder (same as role)
+  Stakeholder: `
+    <ellipse cx="8" cy="4.5" rx="5" ry="1.8" stroke-width="1.2" fill="none"/>
+    <line x1="3" y1="4.5" x2="3" y2="12" stroke-width="1.2"/>
+    <line x1="13" y1="4.5" x2="13" y2="12" stroke-width="1.2"/>
+    <ellipse cx="8" cy="12" rx="5" ry="1.8" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Compass wheel
+  Driver: `
+    <circle cx="8" cy="8" r="6" stroke-width="1.2" fill="none"/>
+    <circle cx="8" cy="8" r="1.5" stroke-width="1" fill="none"/>
+    <line x1="8" y1="2" x2="8" y2="6.5" stroke-width="1.5"/>
+    <line x1="8" y1="9.5" x2="8" y2="14" stroke-width="1.5"/>
+    <line x1="2" y1="8" x2="6.5" y2="8" stroke-width="1.5"/>
+    <line x1="9.5" y1="8" x2="14" y2="8" stroke-width="1.5"/>
+  `,
+
+  // Magnifying glass
+  Assessment: `
+    <circle cx="6.5" cy="6.5" r="4" stroke-width="1.2" fill="none"/>
+    <line x1="9.5" y1="9.5" x2="14" y2="14" stroke-width="1.5"/>
+  `,
+
+  // Bullseye (target)
+  Goal: `
+    <circle cx="8" cy="8" r="6" stroke-width="1.2" fill="none"/>
+    <circle cx="8" cy="8" r="3.5" stroke-width="1.2" fill="none"/>
+    <circle cx="8" cy="8" r="1.2" fill="currentColor"/>
+  `,
+
+  // Bullseye with outer ring filled (outcome = achieved goal)
+  Outcome: `
+    <circle cx="8" cy="8" r="6" stroke-width="1.2" fill="none"/>
+    <circle cx="8" cy="8" r="3.5" stroke-width="2.5" fill="none"/>
+    <circle cx="8" cy="8" r="1.2" fill="currentColor"/>
+  `,
+
+  // Exclamation mark
+  Principle: `
+    <line x1="8" y1="2.5" x2="8" y2="9.5" stroke-width="2" stroke-linecap="round"/>
+    <circle cx="8" cy="12.5" r="1.3" fill="currentColor"/>
+  `,
+
+  // Parallelogram (slanted rectangle)
+  Requirement: `
+    <polygon points="4,3.5 14,3.5 12,12.5 2,12.5" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Parallelogram (more slanted)
+  Constraint: `
+    <polygon points="5,3.5 14,3.5 11,12.5 2,12.5" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Oval
+  Value: `
+    <ellipse cx="8" cy="8" rx="6.5" ry="4" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Cloud / speech bubble
+  Meaning: `
+    <path d="M4,11 Q1,11 1,8 Q1,5.5 3.5,5 Q3.5,2 6.5,2 Q8.5,2 9.5,3.5 Q10.5,2 12,2 Q14.5,2 14.5,5 Q15,5.5 15,8 Q15,11 12,11 L6,13 Z" stroke-width="1.2" fill="none"/>
+  `,
+
+  // ── Strategy layer ───────────────────────────────────────────────────────
+
+  // Three vertical bars (resource/bar chart)
+  Resource: `
+    <rect x="2" y="7" width="3" height="6" rx="0.5" stroke-width="1.2" fill="none"/>
+    <rect x="6.5" y="4" width="3" height="9" rx="0.5" stroke-width="1.2" fill="none"/>
+    <rect x="11" y="5.5" width="3" height="7.5" rx="0.5" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Stacked rectangles
+  Capability: `
+    <rect x="2" y="9.5" width="12" height="3.5" rx="0.5" stroke-width="1.2" fill="none"/>
+    <rect x="3.5" y="6" width="9" height="3.5" rx="0.5" stroke-width="1.2" fill="none"/>
+    <rect x="5" y="2.5" width="6" height="3.5" rx="0.5" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Chevron (same as Function — ValueStream reuses)
+  ValueStream: `
+    <polygon points="5,5 13,5 13,11 5,11 2,8" stroke-width="1.2" fill="none" stroke-linejoin="round"/>
+  `,
+
+  // Bold arrow with target circle at tip
+  CourseOfAction: `
+    <line x1="1" y1="8" x2="12" y2="8" stroke-width="2" stroke-linecap="round"/>
+    <polyline points="9,5 13,8 9,11" stroke-width="1.8" fill="none" stroke-linejoin="round"/>
+  `,
+
+  // ── Implementation & Migration layer ─────────────────────────────────────
+
+  // Clipboard
+  WorkPackage: `
+    <rect x="3" y="4" width="10" height="11" rx="1" stroke-width="1.2" fill="none"/>
+    <path d="M6,4 L6,2.5 Q6,1.5 8,1.5 Q10,1.5 10,2.5 L10,4" stroke-width="1.2" fill="none"/>
+    <line x1="5.5" y1="7.5" x2="10.5" y2="7.5" stroke-width="1"/>
+    <line x1="5.5" y1="10" x2="9" y2="10" stroke-width="1"/>
+  `,
+
+  // Trigger (same shape as event)
+  ImplementationEvent: `
+    <polygon points="4,5 14,5 14,11 4,11 1,8" stroke-width="1.2" fill="none" stroke-linejoin="round"/>
+  `,
+
+  // Wave / scroll shape
+  Deliverable: `
+    <path d="M2,4 Q2,2 4,2 L12,2 Q14,2 14,4 L14,12 Q14,14 12,14 Q10,14 10,12 Q10,10 8,10 L2,10 Z" stroke-width="1.2" fill="none"/>
+  `,
+
+  // Three horizontal lines (plateau = stable period)
+  Plateau: `
+    <line x1="2" y1="5" x2="14" y2="5" stroke-width="2" stroke-linecap="round"/>
+    <line x1="2" y1="8" x2="14" y2="8" stroke-width="2" stroke-linecap="round"/>
+    <line x1="2" y1="11" x2="14" y2="11" stroke-width="2" stroke-linecap="round"/>
+  `,
+
+  // Circle with horizontal line (gap / difference)
+  Gap: `
+    <circle cx="8" cy="8" r="6" stroke-width="1.2" fill="none"/>
+    <line x1="2" y1="8" x2="14" y2="8" stroke-width="1.5"/>
+  `,
+
+  // ── Physical / Composite ─────────────────────────────────────────────────
+
+  // Map pin
+  Location: `
+    <circle cx="8" cy="6" r="4" stroke-width="1.2" fill="none"/>
+    <path d="M4.5,9 Q5,13 8,15 Q11,13 11.5,9" stroke-width="1.2" fill="none"/>
+  `,
+
+  // ── Grouping ─────────────────────────────────────────────────────────────
+  Grouping: `
+    <rect x="1.5" y="1.5" width="13" height="13" rx="1.5" stroke-width="1.2" fill="none" stroke-dasharray="3 2"/>
+  `,
+};
+
+// Fallback for unknown types
+export const DEFAULT_ICON = `
+  <rect x="3" y="3" width="10" height="10" rx="1.5" stroke-width="1.2" fill="none"/>
+`;
+
+export function getIcon(elementType) {
+  return ICONS[elementType] || DEFAULT_ICON;
+}
+
+// ── Layer color palette ───────────────────────────────────────────────────
+// Hues follow the ArchiMate 3 layer convention; saturation is toned down
+// from the standard to be easier on the eye (per project preference).
+//
+//  Business          → amber
+//  Application       → blue
+//  Technology        → green  (user prefers our green over standard cyan)
+//  Motivation        → violet
+//  Strategy          → gold   (distinct from business amber)
+//  Implementation    → rose
+//  Physical/Location → pink/fuchsia
+
+const BUSINESS  = { fill: '#FFFBEB', stroke: '#D97706', text: '#78350F' };
+const APP       = { fill: '#EFF6FF', stroke: '#2563EB', text: '#1E3A8A' };
+const TECH      = { fill: '#F0FDF4', stroke: '#16A34A', text: '#14532D' };
+const MOTIV     = { fill: '#FAF5FF', stroke: '#7C3AED', text: '#3B0764' };
+const STRATEGY  = { fill: '#FEFCE8', stroke: '#B45309', text: '#78350F' };
+const IMPL      = { fill: '#FFF1F2', stroke: '#BE123C', text: '#881337' };
+const PHYSICAL  = { fill: '#FDF4FF', stroke: '#A21CAF', text: '#701A75' };
+
+export const LAYER_COLORS = {
+  // Business
+  BusinessActor:         BUSINESS,
+  BusinessRole:          BUSINESS,
+  BusinessCollaboration: BUSINESS,
+  BusinessInterface:     BUSINESS,
+  BusinessProcess:       BUSINESS,
+  BusinessFunction:      BUSINESS,
+  BusinessInteraction:   BUSINESS,
+  BusinessService:       BUSINESS,
+  BusinessEvent:         BUSINESS,
+  BusinessObject:        BUSINESS,
+  Contract:              BUSINESS,
+  Representation:        BUSINESS,
+  Product:               BUSINESS,
+
+  // Application
+  ApplicationComponent:     APP,
+  ApplicationCollaboration: APP,
+  ApplicationInterface:     APP,
+  ApplicationProcess:       APP,
+  ApplicationFunction:      APP,
+  ApplicationInteraction:   APP,
+  ApplicationService:       APP,
+  ApplicationEvent:         APP,
+  DataObject:               APP,
+
+  // Technology
+  Node:                   TECH,
+  Device:                 TECH,
+  SystemSoftware:         TECH,
+  TechnologyCollaboration:TECH,
+  TechnologyInterface:    TECH,
+  TechnologyProcess:      TECH,
+  TechnologyFunction:     TECH,
+  TechnologyInteraction:  TECH,
+  TechnologyService:      TECH,
+  TechnologyEvent:        TECH,
+  Artifact:               TECH,
+  Facility:               TECH,
+  Equipment:              TECH,
+  Material:               TECH,
+  CommunicationNetwork:   TECH,
+  Path:                   TECH,
+  DistributionNetwork:    TECH,
+  TechnologyComponent:    TECH,
+
+  // Motivation
+  Stakeholder:  MOTIV,
+  Driver:       MOTIV,
+  Assessment:   MOTIV,
+  Goal:         MOTIV,
+  Outcome:      MOTIV,
+  Principle:    MOTIV,
+  Requirement:  MOTIV,
+  Constraint:   MOTIV,
+  Value:        MOTIV,
+  Meaning:      MOTIV,
+
+  // Strategy
+  Resource:       STRATEGY,
+  Capability:     STRATEGY,
+  ValueStream:    STRATEGY,
+  CourseOfAction: STRATEGY,
+
+  // Implementation & Migration
+  WorkPackage:         IMPL,
+  ImplementationEvent: IMPL,
+  Deliverable:         IMPL,
+  Plateau:             IMPL,
+  Gap:                 IMPL,
+
+  // Physical / Composite
+  Location: PHYSICAL,
+
+  // Grouping — transparent with dashed border
+  Grouping: { fill: 'rgba(249,250,251,0.5)', stroke: '#9CA3AF', text: '#374151', dashed: true },
+};
+
+export const DEFAULT_COLOR = { fill: '#F9FAFB', stroke: '#6B7280', text: '#374151' };
+
+export function getColor(elementType) {
+  return LAYER_COLORS[elementType] || DEFAULT_COLOR;
+}

--- a/cmd/archipulse/ui/src/components/views/DiagramView.svelte
+++ b/cmd/archipulse/ui/src/components/views/DiagramView.svelte
@@ -1,11 +1,14 @@
 <script>
   import { push } from 'svelte-spa-router';
-  import { SvelteFlow, Controls, Background, MiniMap } from '@xyflow/svelte';
+  import { SvelteFlow, Controls, Background, MiniMap, Panel, ConnectionMode } from '@xyflow/svelte';
   import '@xyflow/svelte/dist/style.css';
 
   import { api } from '../../lib/api.js';
   import BackButton from '../BackButton.svelte';
   import ArchiMateNode from '../diagram/ArchiMateNode.svelte';
+  import ValueStreamNode from '../diagram/ValueStreamNode.svelte';
+  import ArchiMateEdge from '../diagram/ArchiMateEdge.svelte';
+  import { getColor } from '../diagram/archimate-icons.js';
 
   export let params = {};
 
@@ -19,9 +22,19 @@
   let nodes = [];
   let edges = [];
 
-  const nodeTypes = { archimate: ArchiMateNode };
+  const nodeTypes = { archimate: ArchiMateNode, valuestream: ValueStreamNode };
+  const edgeTypes = { archimate: ArchiMateEdge };
 
   $: if (diagId) load();
+
+  // ── MiniMap color ──────────────────────────────────────────────────────────
+
+  function minimapColor(n) {
+    if (!n.data) return '#D1D5DB';
+    return getColor(n.data.elementType).stroke;
+  }
+
+  // ── Load ──────────────────────────────────────────────────────────────────
 
   async function load() {
     loading = true;
@@ -31,24 +44,76 @@
     edges = [];
     try {
       data = await api.get('/workspaces/' + wsId + '/diagrams/' + diagId + '/render');
-      nodes = (data.nodes || []).map(n => ({
-        id: n.element_id,
-        type: 'archimate',
-        position: { x: n.x, y: n.y },
-        data: { label: n.element_name, elementType: n.element_type },
-        style: `width:${n.w}px;height:${n.h}px;`,
-        draggable: false,
-        selectable: false,
-        connectable: false,
-      }));
-      edges = (data.connections || []).map(c => ({
-        id: c.relationship_id,
-        source: c.source_element_id,
-        target: c.target_element_id,
-        style: 'stroke:#565f89;stroke-width:1.5px;',
-        markerEnd: { type: 'arrowClosed', color: '#565f89', width: 14, height: 10 },
-        selectable: false,
-      }));
+
+      const rawNodes = data.nodes || [];
+
+      // Build a lookup of raw node data (absolute coords) for boundary intersection.
+      const nodeById = {};
+      for (const n of rawNodes) nodeById[n.element_id] = n;
+
+      // Nodes that appear as a parent_element_id of another node are containers.
+      const containerIds = new Set(
+        rawNodes.filter(n => n.parent_element_id).map(n => n.parent_element_id)
+      );
+
+      // XY Flow requires parent nodes to appear before their children in the array.
+      const sorted = [];
+      const seen = new Set();
+
+      function visit(n) {
+        if (seen.has(n.element_id)) return;
+        if (n.parent_element_id && !seen.has(n.parent_element_id)) {
+          const parent = nodeById[n.parent_element_id];
+          if (parent) visit(parent);
+        }
+        seen.add(n.element_id);
+        sorted.push(n);
+      }
+      for (const n of rawNodes) visit(n);
+
+      nodes = sorted.map(n => {
+        const parentId = n.parent_element_id || null;
+        const parent = parentId ? nodeById[parentId] : null;
+        const isContainer = containerIds.has(n.element_id);
+        const isVS = n.element_type === 'ValueStream';
+
+        // XY Flow child positions must be relative to their direct parent.
+        const position = parent
+          ? { x: n.x - parent.x, y: n.y - parent.y }
+          : { x: n.x, y: n.y };
+
+        return {
+          id: n.element_id,
+          type: isVS ? 'valuestream' : 'archimate',
+          position,
+          ...(parentId ? { parentId, extent: 'parent' } : {}),
+          data: { label: n.element_name, elementType: n.element_type, isContainer },
+          style: `width:${n.w}px;height:${n.h}px;`,
+          draggable: false,
+          selectable: true,
+          connectable: false,
+        };
+      });
+
+      // Edges: pass raw bounds (absolute coords) and bendpoints so ArchiMateEdge
+      // can compute the path without relying on XY Flow's handle positions.
+      edges = (data.connections || []).map(c => {
+        const src = nodeById[c.source_element_id];
+        const tgt = nodeById[c.target_element_id];
+        return {
+          id: c.relationship_id,
+          source: c.source_element_id,
+          target: c.target_element_id,
+          type: 'archimate',
+          data: {
+            relationshipType: c.relationship_type,
+            bendpoints: c.bendpoints || [],
+            sourceBounds: src ? { x: src.x, y: src.y, w: src.w, h: src.h } : null,
+            targetBounds: tgt ? { x: tgt.x, y: tgt.y, w: tgt.w, h: tgt.h } : null,
+          },
+          selectable: false,
+        };
+      });
     } catch (e) {
       error = e.message;
     } finally {
@@ -56,6 +121,52 @@
     }
   }
 </script>
+
+<!--
+  Global ArchiMate SVG marker definitions.
+  Defined here (outside any SVG) as a hidden SVG so they are accessible
+  via url(#...) from the XY Flow edge SVG on the same page.
+  Markers use `context-stroke` to inherit the edge's stroke color.
+-->
+<svg width="0" height="0" style="position:absolute;overflow:hidden;pointer-events:none;">
+  <defs>
+    <!-- Filled arrowhead — Triggering, Flow, Assignment end -->
+    <marker id="am-filled-arrow" viewBox="0 0 8 6" markerWidth="8" markerHeight="6"
+      refX="8" refY="3" orient="auto">
+      <polygon points="0,0 8,3 0,6" fill="context-stroke" />
+    </marker>
+
+    <!-- Open V arrowhead — Association, Serving, Access, Influence -->
+    <marker id="am-open-arrow" viewBox="0 0 8 8" markerWidth="8" markerHeight="8"
+      refX="7" refY="4" orient="auto">
+      <path d="M 0,0 L 7,4 L 0,8" fill="none" stroke="context-stroke" stroke-width="1.4" />
+    </marker>
+
+    <!-- Hollow closed triangle — Realization, Specialization -->
+    <marker id="am-open-triangle" viewBox="0 0 10 8" markerWidth="10" markerHeight="8"
+      refX="10" refY="4" orient="auto">
+      <polygon points="0,0 10,4 0,8" fill="#F8FAFC" stroke="context-stroke" stroke-width="1.4" />
+    </marker>
+
+    <!-- Filled diamond at source — Composition -->
+    <marker id="am-filled-diamond" viewBox="-1 -1 14 10" markerWidth="14" markerHeight="10"
+      refX="0" refY="4" orient="auto">
+      <polygon points="0,4 6,0 12,4 6,8" fill="context-stroke" />
+    </marker>
+
+    <!-- Hollow diamond at source — Aggregation -->
+    <marker id="am-open-diamond" viewBox="-1 -1 14 10" markerWidth="14" markerHeight="10"
+      refX="0" refY="4" orient="auto">
+      <polygon points="0,4 6,0 12,4 6,8" fill="#F8FAFC" stroke="context-stroke" stroke-width="1.4" />
+    </marker>
+
+    <!-- Filled circle at source — Assignment -->
+    <marker id="am-filled-circle" viewBox="-1 -1 10 10" markerWidth="8" markerHeight="8"
+      refX="0" refY="4" orient="auto">
+      <circle cx="4" cy="4" r="4" fill="context-stroke" />
+    </marker>
+  </defs>
+</svg>
 
 <div class="content h-full flex flex-col">
   <BackButton onclick={() => push('/ws/' + wsId + '/diagrams')} label="Diagrams" />
@@ -75,34 +186,63 @@
       <span class="text-[11px] text-muted-foreground">{data.nodes?.length ?? 0} elements · {data.connections?.length ?? 0} connections</span>
     </div>
 
-    <div class="flex-1 border border-border rounded-lg overflow-hidden bg-[#0d0e14]">
+    <div class="flex-1 border border-border rounded-lg overflow-hidden" style="background:#F8FAFC;">
       <SvelteFlow
         bind:nodes
         bind:edges
         {nodeTypes}
+        {edgeTypes}
         fitView
-        fitViewOptions={{ padding: 0.12 }}
+        fitViewOptions={{ padding: 0.1 }}
         nodesDraggable={false}
         nodesConnectable={false}
         panOnDrag={true}
         zoomOnScroll={true}
-        style="background:#0d0e14;"
+        colorMode="light"
+        connectionMode={ConnectionMode.Loose}
+        style="background:#F8FAFC;"
       >
-        <Background color="#1e2030" gap={20} />
+        <Background color="#E5E7EB" gap={20} size={1} />
         <Controls showInteractive={false} />
         <MiniMap
-          nodeColor={n => {
-            if (!n.data) return '#565f89';
-            const t = n.data.elementType || '';
-            if (t.startsWith('Application')) return '#7aa2f7';
-            if (t.startsWith('Business') || t === 'Capability') return '#e0af68';
-            if (t.startsWith('Technology') || t === 'Node' || t === 'SystemSoftware') return '#9ece6a';
-            return '#565f89';
-          }}
-          style="background:#1a1b26;"
-          maskColor="rgba(0,0,0,0.3)"
+          nodeColor={minimapColor}
+          style="background:#F1F5F9;border:1px solid #E2E8F0;border-radius:8px;"
+          maskColor="rgba(100,116,139,0.15)"
         />
+        <Panel position="top-right">
+          <div style="
+            background:white;
+            border:1px solid #E5E7EB;
+            border-radius:8px;
+            padding:8px 10px;
+            font-size:11px;
+            font-family:ui-sans-serif,system-ui,sans-serif;
+            color:#374151;
+            display:flex;
+            flex-direction:column;
+            gap:4px;
+            box-shadow:0 1px 4px rgba(0,0,0,0.08);
+          ">
+            <div style="display:flex;align-items:center;gap:6px;"><span style="width:12px;height:12px;border-radius:2px;background:#FFFBEB;border:1.5px solid #D97706;flex-shrink:0;"></span>Business</div>
+            <div style="display:flex;align-items:center;gap:6px;"><span style="width:12px;height:12px;border-radius:2px;background:#EFF6FF;border:1.5px solid #2563EB;flex-shrink:0;"></span>Application</div>
+            <div style="display:flex;align-items:center;gap:6px;"><span style="width:12px;height:12px;border-radius:2px;background:#F0FDF4;border:1.5px solid #16A34A;flex-shrink:0;"></span>Technology</div>
+            <div style="display:flex;align-items:center;gap:6px;"><span style="width:12px;height:12px;border-radius:2px;background:#FAF5FF;border:1.5px solid #7C3AED;flex-shrink:0;"></span>Motivation</div>
+            <div style="display:flex;align-items:center;gap:6px;"><span style="width:12px;height:12px;border-radius:2px;background:#FEFCE8;border:1.5px solid #B45309;flex-shrink:0;"></span>Strategy</div>
+            <div style="display:flex;align-items:center;gap:6px;"><span style="width:12px;height:12px;border-radius:2px;background:#FFF1F2;border:1.5px solid #BE123C;flex-shrink:0;"></span>Implementation</div>
+            <div style="display:flex;align-items:center;gap:6px;"><span style="width:12px;height:12px;border-radius:2px;background:#FDF4FF;border:1.5px solid #A21CAF;flex-shrink:0;"></span>Physical</div>
+          </div>
+        </Panel>
       </SvelteFlow>
     </div>
   {/if}
 </div>
+
+<style>
+  :global(.svelte-flow .svelte-flow__edges) {
+    z-index: 10;
+    pointer-events: none;
+  }
+  :global(.svelte-flow__edge) {
+    pointer-events: all;
+  }
+</style>

--- a/cmd/archipulse/ui/src/routes/DiagramList.svelte
+++ b/cmd/archipulse/ui/src/routes/DiagramList.svelte
@@ -10,6 +10,11 @@
   let diagrams = [];
   let loading = true;
   let error = null;
+  let search = '';
+
+  $: filtered = search.trim()
+    ? diagrams.filter(d => (d.name || '').toLowerCase().includes(search.trim().toLowerCase()))
+    : diagrams;
 
   onMount(async () => {
     try {
@@ -25,8 +30,18 @@
 
 <div class="content">
   <BackButton onclick={() => push('/ws/' + wsId)} label="Overview" />
-  <h1 class="text-[18px] font-semibold mb-1">Diagrams</h1>
-  <p class="text-[13px] text-muted-foreground mb-5">ArchiMate views imported from the model file</p>
+
+  <div class="flex items-start justify-between gap-4 mb-5">
+    <div>
+      <h1 class="text-[18px] font-semibold mb-0.5">Diagrams</h1>
+      <p class="text-[13px] text-muted-foreground">ArchiMate views imported from the model file</p>
+    </div>
+    {#if !loading && !error && diagrams.length > 0}
+      <span class="text-[12px] text-muted-foreground bg-muted border border-border rounded-full px-2.5 py-0.5 mt-1 flex-shrink-0">
+        {filtered.length} / {diagrams.length}
+      </span>
+    {/if}
+  </div>
 
   {#if loading}
     <div class="flex items-center gap-2 text-muted-foreground py-6">
@@ -41,29 +56,51 @@
       <p class="text-[14px]">No diagrams found.<br>Import a model with views to see them here.</p>
     </div>
   {:else}
-    <div class="border border-border rounded-lg overflow-hidden">
-      <table class="w-full text-[13px]">
-        <thead>
-          <tr class="border-b border-border bg-muted/40">
-            <th class="text-left px-4 py-2.5 font-medium text-muted-foreground">Name</th>
-            <th class="text-left px-4 py-2.5 font-medium text-muted-foreground w-40">Source ID</th>
-          </tr>
-        </thead>
-        <tbody>
-          {#each diagrams as d}
-            <tr
-              class="border-b border-border last:border-0 hover:bg-muted/30 cursor-pointer transition-colors"
-              onclick={() => push('/ws/' + wsId + '/diagrams/' + d.id)}
-              role="button"
-              tabindex="0"
-              onkeydown={e => e.key === 'Enter' && push('/ws/' + wsId + '/diagrams/' + d.id)}
-            >
-              <td class="px-4 py-2.5 font-medium">{d.name || '(unnamed)'}</td>
-              <td class="px-4 py-2.5 text-muted-foreground font-mono text-[11px] truncate max-w-[160px]">{d.source_id}</td>
-            </tr>
-          {/each}
-        </tbody>
-      </table>
+    <div class="relative mb-4">
+      <span class="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-[14px] pointer-events-none">⌕</span>
+      <input
+        type="text"
+        bind:value={search}
+        placeholder="Search diagrams…"
+        class="w-full bg-card border border-border rounded-lg pl-8 pr-3 py-2 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-primary transition-colors"
+      />
+      {#if search}
+        <button
+          class="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground text-[16px] leading-none"
+          onclick={() => search = ''}
+        >×</button>
+      {/if}
     </div>
+
+    {#if filtered.length === 0}
+      <div class="text-center py-10 text-muted-foreground">
+        <p class="text-[13px]">No diagrams match "<span class="text-foreground">{search}</span>"</p>
+      </div>
+    {:else}
+      <div class="border border-border rounded-lg overflow-hidden">
+        <table class="w-full text-[13px]">
+          <thead>
+            <tr class="border-b border-border bg-muted/40">
+              <th class="text-left px-4 py-2.5 font-medium text-muted-foreground">Name</th>
+              <th class="text-left px-4 py-2.5 font-medium text-muted-foreground w-40 hidden sm:table-cell">Source ID</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each filtered as d}
+              <tr
+                class="border-b border-border last:border-0 hover:bg-muted/30 cursor-pointer transition-colors"
+                onclick={() => push('/ws/' + wsId + '/diagrams/' + d.id)}
+                role="button"
+                tabindex="0"
+                onkeydown={e => e.key === 'Enter' && push('/ws/' + wsId + '/diagrams/' + d.id)}
+              >
+                <td class="px-4 py-3 font-medium">{d.name || '(unnamed)'}</td>
+                <td class="px-4 py-3 text-muted-foreground font-mono text-[11px] truncate max-w-[160px] hidden sm:table-cell">{d.source_id}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    {/if}
   {/if}
 </div>

--- a/cmd/archipulse/ui/vite.config.js
+++ b/cmd/archipulse/ui/vite.config.js
@@ -14,6 +14,11 @@ export default defineConfig({
     },
   },
   base: './',
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8080',
+    },
+  },
   build: {
     outDir: 'dist',
     emptyOutDir: true,

--- a/examples/ArchiMetal.xml
+++ b/examples/ArchiMetal.xml
@@ -1,0 +1,12028 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model xmlns="http://www.opengroup.org/xsd/archimate/3.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengroup.org/xsd/archimate/3.0/ http://www.opengroup.org/xsd/archimate/3.1/archimate3_Diagram.xsd" identifier="id-e42df43bd2104e9aa7ccc8fd25a80ac6">
+  <name xml:lang="es">ArchiMetal</name>
+  <elements>
+    <element identifier="id-1e3683a995704e0bb1abe93aeba4d203" xsi:type="ValueStream">
+      <name xml:lang="es">Produce Steel Products</name>
+    </element>
+    <element identifier="id-fc034ab99bfa4b9e9ae7f51fa8de905f" xsi:type="ValueStream">
+      <name xml:lang="es">Procure Raw Materials</name>
+    </element>
+    <element identifier="id-c93b9d430cd2423b95c52c610e12f720" xsi:type="ValueStream">
+      <name xml:lang="es">Manufacture Steel Products</name>
+    </element>
+    <element identifier="id-281d523a5a0e45e686b8d9c6726a5be9" xsi:type="ValueStream">
+      <name xml:lang="es">Store Products</name>
+    </element>
+    <element identifier="id-051bc17974ef4cedb0424a31e975d727" xsi:type="ValueStream">
+      <name xml:lang="es">Sell Products</name>
+    </element>
+    <element identifier="id-53228d509e7c444dbf57f5dd19df3484" xsi:type="ValueStream">
+      <name xml:lang="es">Distribute Products</name>
+    </element>
+    <element identifier="id-9d3639bc0b2c46deafc67db505ca796b" xsi:type="Product">
+      <name xml:lang="es">Steel Product</name>
+    </element>
+    <element identifier="id-10b667b736514a2da297f4dea0a14645" xsi:type="Contract">
+      <name xml:lang="es">Steel Contract</name>
+    </element>
+    <element identifier="id-51c3a5a5d0c343df91c73e182a373148" xsi:type="Representation">
+      <name xml:lang="es">Contract</name>
+    </element>
+    <element identifier="id-8737a76acd9c4d1fbb2a4ffc86cb2993" xsi:type="BusinessCollaboration">
+      <name xml:lang="es">Internal Teams</name>
+    </element>
+    <element identifier="id-70e443457ba447cf9f7be64c0a2e0ad1" xsi:type="BusinessActor">
+      <name xml:lang="es">ArchiMetal</name>
+    </element>
+    <element identifier="id-b50ea84ae74845f3b8001028c0558e90" xsi:type="BusinessActor">
+      <name xml:lang="es">Commercial</name>
+    </element>
+    <element identifier="id-5987ea5989b34bb3b7b3b7df0c5d7596" xsi:type="BusinessActor">
+      <name xml:lang="es">Customer Relations</name>
+    </element>
+    <element identifier="id-3bc7d428ccea48739c4d442f9f2364e7" xsi:type="BusinessActor">
+      <name xml:lang="es">DC Benelux</name>
+    </element>
+    <element identifier="id-ca27484ed8934cd2bb57cec774298909" xsi:type="BusinessActor">
+      <name xml:lang="es">DC East Europe</name>
+    </element>
+    <element identifier="id-f96b2f70a48e42bb83646b89292b1286" xsi:type="BusinessActor">
+      <name xml:lang="es">DC Spain</name>
+    </element>
+    <element identifier="id-65c1620fd1284553b20818224030a84d" xsi:type="BusinessActor">
+      <name xml:lang="es">Distribution</name>
+    </element>
+    <element identifier="id-628c9b29c1254f3c8d0aea92d13e5d65" xsi:type="BusinessActor">
+      <name xml:lang="es">Finance</name>
+    </element>
+    <element identifier="id-86d6a2f695b74347a264354315c8656f" xsi:type="BusinessActor">
+      <name xml:lang="es">HQ</name>
+    </element>
+    <element identifier="id-b6d4eb2c1e184d33897f7862f6317033" xsi:type="BusinessActor">
+      <name xml:lang="es">HR</name>
+    </element>
+    <element identifier="id-eee6f468492e48efb54f44db721f75aa" xsi:type="BusinessActor">
+      <name xml:lang="es">Logistics</name>
+    </element>
+    <element identifier="id-dae853c3fdda4da9a99c066d144cc617" xsi:type="BusinessActor">
+      <name xml:lang="es">Procurement</name>
+    </element>
+    <element identifier="id-761d6b44b0084191bb0574b9b2c4e949" xsi:type="BusinessActor">
+      <name xml:lang="es">Production</name>
+    </element>
+    <element identifier="id-ca35f8df80974169b04c1ffd58c12493" xsi:type="BusinessActor">
+      <name xml:lang="es">Production Center</name>
+    </element>
+    <element identifier="id-2bcc0251b630425ea4c325246a35f5b8" xsi:type="BusinessActor">
+      <name xml:lang="es">Quality Mgmt</name>
+    </element>
+    <element identifier="id-6118370573ec480e85a1d4b2eed6eacd" xsi:type="BusinessActor">
+      <name xml:lang="es">Sales</name>
+    </element>
+    <element identifier="id-23b94c08d0494535bd9804b94923f83e" xsi:type="BusinessActor">
+      <name xml:lang="es">Customer Service</name>
+    </element>
+    <element identifier="id-1a7757e999c54d6085462db7df22a296" xsi:type="BusinessActor">
+      <name xml:lang="es">Customer</name>
+    </element>
+    <element identifier="id-d95e1aa70fcd4c8bba40177204ebca8d" xsi:type="BusinessActor">
+      <name xml:lang="es">Supply Partner</name>
+    </element>
+    <element identifier="id-50fbcd5489444693bcbc3efe86d1df80" xsi:type="BusinessActor">
+      <name xml:lang="es">Transportation Partner</name>
+    </element>
+    <element identifier="id-c35cc8ce1a73415080bf804d76727b72" xsi:type="BusinessFunction">
+      <name xml:lang="es">ArchiMetal Operations</name>
+    </element>
+    <element identifier="id-5fb09df777514d79afbec30bf3a49c72" xsi:type="BusinessFunction">
+      <name xml:lang="es">Procurement</name>
+    </element>
+    <element identifier="id-a6992b23c09c44dba47e8e06ad7655c5" xsi:type="BusinessFunction">
+      <name xml:lang="es">Logistics</name>
+    </element>
+    <element identifier="id-bb08ebde1b25412bb52d9e4d35afa404" xsi:type="BusinessFunction">
+      <name xml:lang="es">Production</name>
+    </element>
+    <element identifier="id-9341d876214745edb68cdc91b7b8ffe7" xsi:type="BusinessFunction">
+      <name xml:lang="es">Marketing</name>
+    </element>
+    <element identifier="id-ec198d6b44094aea97ee9bb93659c30d" xsi:type="BusinessFunction">
+      <name xml:lang="es">Sales</name>
+    </element>
+    <element identifier="id-04e04b7fccd14a7a88229604fccc7a86" xsi:type="BusinessFunction">
+      <name xml:lang="es">Service</name>
+    </element>
+    <element identifier="id-eb2a8dd22fad4020b70d683b9adf85bc" xsi:type="BusinessFunction">
+      <name xml:lang="es">DC Customer Relations</name>
+    </element>
+    <element identifier="id-d4ae5cd23a3f4c04b5778446859595ab" xsi:type="BusinessFunction">
+      <name xml:lang="es">Commercial</name>
+    </element>
+    <element identifier="id-6bb84a70a70c4899963d5370b82d42af" xsi:type="BusinessFunction">
+      <name xml:lang="es">DC Finance</name>
+    </element>
+    <element identifier="id-94aed85cd04d4960b53f9db553d91e1c" xsi:type="BusinessFunction">
+      <name xml:lang="es">Distribution</name>
+    </element>
+    <element identifier="id-15b84bcdf6374633b8225b636f14f140" xsi:type="BusinessFunction">
+      <name xml:lang="es">Finance</name>
+    </element>
+    <element identifier="id-1ba327b721494627b45b68e6ab88ce73" xsi:type="BusinessFunction">
+      <name xml:lang="es">Customer Relationship Management</name>
+    </element>
+    <element identifier="id-abb6ad8f13864cdd9a545391293aac2f" xsi:type="BusinessFunction">
+      <name xml:lang="es">Enterprise: Marketing &amp; Sales</name>
+    </element>
+    <element identifier="id-6bff6aab31d24eafb56cc8d19c39a349" xsi:type="BusinessFunction">
+      <name xml:lang="es">Enterprise: Order Processing</name>
+    </element>
+    <element identifier="id-7f6504f22c8341f98fbb7a8f2040fb86" xsi:type="BusinessFunction">
+      <name xml:lang="es">Enterprise: Production Scheduling (Global)</name>
+    </element>
+    <element identifier="id-d004969cca104c28b670b1df84895480" xsi:type="BusinessFunction">
+      <name xml:lang="es">Control: Production Scheduling (Local)</name>
+    </element>
+    <element identifier="id-d750071fabad4b9498b391c0439ad8a9" xsi:type="BusinessFunction">
+      <name xml:lang="es">Control: Production Control</name>
+    </element>
+    <element identifier="id-e73fde26e4094a1c9f97edfb48139287" xsi:type="BusinessService">
+      <name xml:lang="es">Metal Products and Services</name>
+    </element>
+    <element identifier="id-d02d8886a7934dc898143a97a8376606" xsi:type="BusinessService">
+      <name xml:lang="es">Delivery Service</name>
+    </element>
+    <element identifier="id-73d6be570bd344aeb933d06b9566af35" xsi:type="BusinessService">
+      <name xml:lang="es">Develop Contract Service</name>
+    </element>
+    <element identifier="id-cbc5896e78284e23b5bbca5e9a15dc76" xsi:type="BusinessService">
+      <name xml:lang="es">Invoicing Service</name>
+    </element>
+    <element identifier="id-633f46a9f9f84bbda07115037faf71eb" xsi:type="BusinessService">
+      <name xml:lang="es">Order Information Service</name>
+    </element>
+    <element identifier="id-c160bb04a89643a880d79a2dce37bd38" xsi:type="BusinessService">
+      <name xml:lang="es">Order Registration Service</name>
+    </element>
+    <element identifier="id-5f7aebddd3ad4a0593301978fca34bab" xsi:type="BusinessService">
+      <name xml:lang="es">Customer Risk Assessment Service</name>
+    </element>
+    <element identifier="id-8108cbbc4ed64abbbe5b87014468f35b" xsi:type="BusinessService">
+      <name xml:lang="es">Customer Approval Service</name>
+    </element>
+    <element identifier="id-c8586b2db2314b17852d6e100b1c633f" xsi:type="BusinessObject">
+      <name xml:lang="es">Sales Pipeline</name>
+    </element>
+    <element identifier="id-b184c5661a354a80a26061333635c927" xsi:type="BusinessObject">
+      <name xml:lang="es">Customer Information</name>
+    </element>
+    <element identifier="id-2b87582d36d143db98c8e258b24655f1" xsi:type="BusinessObject">
+      <name xml:lang="es">Pricing Policy</name>
+    </element>
+    <element identifier="id-d970cdcf5ac247698017f1e9732e2a07" xsi:type="BusinessObject">
+      <name xml:lang="es">Profile</name>
+    </element>
+    <element identifier="id-b42e8f45867b487ca2ccd136ebfafde7" xsi:type="BusinessObject">
+      <name xml:lang="es">Transaction History</name>
+    </element>
+    <element identifier="id-b56b5c461fc94c06b00ed6d33955fcb2" xsi:type="BusinessObject">
+      <name xml:lang="es">Customer Credit Profile</name>
+    </element>
+    <element identifier="id-e59bb5647dc6486c8ea1d08b67c19bc1" xsi:type="BusinessObject">
+      <name xml:lang="es">Interaction History</name>
+    </element>
+    <element identifier="id-0bed0f0876c6428fa25879de80d47208" xsi:type="BusinessObject">
+      <name xml:lang="es">Contract Data</name>
+    </element>
+    <element identifier="id-fde9a2a74e544857bcdcd5c127214475" xsi:type="BusinessObject">
+      <name xml:lang="es">Order Status</name>
+    </element>
+    <element identifier="id-260c70cf6aad4a17b0d321e5674b57c4" xsi:type="BusinessObject">
+      <name xml:lang="es">Credit Risk Policy</name>
+    </element>
+    <element identifier="id-17ef9d3c310b4a5aa7463cd6d85db619" xsi:type="BusinessObject">
+      <name xml:lang="es">Contact</name>
+    </element>
+    <element identifier="id-d1edd2e27b3c48f0b4753883ba9ef65f" xsi:type="BusinessObject">
+      <name xml:lang="es">Lead</name>
+    </element>
+    <element identifier="id-3c646c52bc8e45cfafa3b767bb3af35f" xsi:type="BusinessObject">
+      <name xml:lang="es">Opportunity</name>
+    </element>
+    <element identifier="id-389fa5299bd54976a7e31306656cbb42" xsi:type="BusinessObject">
+      <name xml:lang="es">Deal</name>
+    </element>
+    <element identifier="id-86a95bbd46c448b4ad517306a911c2e9" xsi:type="BusinessObject">
+      <name xml:lang="es">Product Data</name>
+    </element>
+    <element identifier="id-d527ba03811741ebb7569d1b04442a25" xsi:type="BusinessObject">
+      <name xml:lang="es">Order Data</name>
+    </element>
+    <element identifier="id-5f42eca753994b2eb284dd75b26a7cb2" xsi:type="BusinessObject">
+      <name xml:lang="es">Shipping Order Data</name>
+    </element>
+    <element identifier="id-17b8b5467ec44bb3be416b7d71bd2a07" xsi:type="BusinessObject">
+      <name xml:lang="es">Inventory Data</name>
+    </element>
+    <element identifier="id-86819b7c2aef41b2b13dc893c50ea3ec" xsi:type="BusinessObject">
+      <name xml:lang="es">Production Order Data</name>
+    </element>
+    <element identifier="id-b1b2c63ef02c42eb88310f21fe662e87" xsi:type="BusinessObject">
+      <name xml:lang="es">Customer Order Data</name>
+    </element>
+    <element identifier="id-201410bdce59449d817eda936fc5ef57" xsi:type="BusinessObject">
+      <name xml:lang="es">Distribution Data</name>
+    </element>
+    <element identifier="id-8d9a138abbbd49248dda77330d209ac2" xsi:type="BusinessObject">
+      <name xml:lang="es">Shipping Order Data</name>
+    </element>
+    <element identifier="id-6547822784014590b1f6ce403d11dab6" xsi:type="BusinessObject">
+      <name xml:lang="es">Schedule Confirmation (Global)</name>
+    </element>
+    <element identifier="id-76fccb108cf0417894987ca3241ac9da" xsi:type="BusinessObject">
+      <name xml:lang="es">Schedule Confirmation (Local)</name>
+    </element>
+    <element identifier="id-2915da9943da4ffd8ce7db5f564b8560" xsi:type="BusinessObject">
+      <name xml:lang="es">Production Confirmation</name>
+    </element>
+    <element identifier="id-41f5b1884333497abc39d31394864829" xsi:type="BusinessObject">
+      <name xml:lang="es">Order</name>
+    </element>
+    <element identifier="id-c70aca3eba1040fc8561439d8b0f4bc5" xsi:type="BusinessObject">
+      <name xml:lang="es">Production Requirement</name>
+    </element>
+    <element identifier="id-251afb2b14b44e369b91879e8be1a7b2" xsi:type="BusinessObject">
+      <name xml:lang="es">Production Schedule Update (Site/Area-Sepcific)</name>
+    </element>
+    <element identifier="id-c5ae1afc36664d8c8b6f17c160aa6369" xsi:type="BusinessObject">
+      <name xml:lang="es">Production Schedule (Cell/Unit/Line-Specific)</name>
+    </element>
+    <element identifier="id-770e063936e4428c8107dae96d3d3cc7" xsi:type="BusinessObject">
+      <name xml:lang="es">Add New Production Schedule</name>
+    </element>
+    <element identifier="id-11ccd99fca024f548aa717079047a2d6" xsi:type="BusinessObject">
+      <name xml:lang="es">New Schedule</name>
+    </element>
+    <element identifier="id-d908916d313d4fac9b2a6cd132eaf4c6" xsi:type="BusinessObject">
+      <name xml:lang="es">Production Status Request</name>
+    </element>
+    <element identifier="id-e27c7d476c4f4facb9f78e3d7edd041d" xsi:type="BusinessObject">
+      <name xml:lang="es">Production Status</name>
+    </element>
+    <element identifier="id-d3f6658ad824487fadc62b80a9709b5c" xsi:type="BusinessObject">
+      <name xml:lang="es">Schedule Revision</name>
+    </element>
+    <element identifier="id-3748eb9ccc5844c8832b299b26ce3eea" xsi:type="BusinessObject">
+      <name xml:lang="es">Schedule Revision Confirmation</name>
+    </element>
+    <element identifier="id-d3d12d7b7e494f32a29a96499f6f66b1" xsi:type="BusinessObject">
+      <name xml:lang="es">Add New Equipment</name>
+    </element>
+    <element identifier="id-08c08f4c8e6a4a50b14e523530a5c14f" xsi:type="BusinessObject">
+      <name xml:lang="es">New Equipment Confirmation</name>
+    </element>
+    <element identifier="id-56a4ef970d314200bc4e95d8ea928093" xsi:type="BusinessProcess">
+      <name xml:lang="es">Develop Contract</name>
+    </element>
+    <element identifier="id-eb6681ab4dd94ce3996ade5875bdf3ef" xsi:type="BusinessProcess">
+      <name xml:lang="es">Register Order</name>
+    </element>
+    <element identifier="id-b7900be563de46529b9fc8d1975b2b37" xsi:type="BusinessProcess">
+      <name xml:lang="es">Inform Customer on Order</name>
+    </element>
+    <element identifier="id-103caa122d7e4d63a5b6479756634453" xsi:type="BusinessProcess">
+      <name xml:lang="es">Invoicing</name>
+    </element>
+    <element identifier="id-8584078cf77640869fc4b4ff7a60d00d" xsi:type="BusinessProcess">
+      <name xml:lang="es">Shipping</name>
+    </element>
+    <element identifier="id-8c910863999445c0b2afceb98acbefff" xsi:type="BusinessProcess">
+      <name xml:lang="es">Transmit Orders</name>
+    </element>
+    <element identifier="id-f4676bc1d45f43e89921d3e0303037b1" xsi:type="BusinessProcess">
+      <name xml:lang="es">Process DC Order</name>
+    </element>
+    <element identifier="id-322294a1d3b441b2a55c57b8dca6e7ff" xsi:type="BusinessProcess">
+      <name xml:lang="es">Process Customer Order</name>
+    </element>
+    <element identifier="id-590b2196df43475cb4e2cd018686ea66" xsi:type="BusinessProcess">
+      <name xml:lang="es">Track Customer Order</name>
+    </element>
+    <element identifier="id-16a56de036194eb79b44068f44ee244d" xsi:type="BusinessProcess">
+      <name xml:lang="es">Approve Customer Data</name>
+    </element>
+    <element identifier="id-6ce3b2f185874049ad30f4b5d7a1491d" xsi:type="BusinessProcess">
+      <name xml:lang="es">Register Customer</name>
+    </element>
+    <element identifier="id-b0f8301b5a2744279cb027be12751c25" xsi:type="BusinessProcess">
+      <name xml:lang="es">Evaluate Credit Risk</name>
+    </element>
+    <element identifier="id-c4b62300152b4eab912ff382a166ce9f" xsi:type="BusinessProcess">
+      <name xml:lang="es">Define Pricing Policy</name>
+    </element>
+    <element identifier="id-66ed398ab28e442ea5516dd44cdc0a49" xsi:type="BusinessProcess">
+      <name xml:lang="es">Accept Proposal</name>
+    </element>
+    <element identifier="id-2372f409993a4d7c943255a5277337b1" xsi:type="BusinessProcess">
+      <name xml:lang="es">Send to Customer</name>
+    </element>
+    <element identifier="id-d17a14d6490b493590904eee8473936c" xsi:type="BusinessProcess">
+      <name xml:lang="es">Create Order</name>
+    </element>
+    <element identifier="id-3a3aa1f975794029b3d192f1dcefc361" xsi:type="BusinessProcess">
+      <name xml:lang="es">Verify Total Exposure to Customer</name>
+    </element>
+    <element identifier="id-9331a6d1c1f54746841c1c6908d8b9e8" xsi:type="BusinessProcess">
+      <name xml:lang="es">Accept Order</name>
+    </element>
+    <element identifier="id-f7bd6d6664424100b329cb8b0ed40510" xsi:type="BusinessProcess">
+      <name xml:lang="es">Prepare Notification Message</name>
+    </element>
+    <element identifier="id-a9bbb7a79a9b4d568f6f66917f0b40d1" xsi:type="BusinessProcess">
+      <name xml:lang="es">Send Notification to Customer</name>
+    </element>
+    <element identifier="id-458d93fe1e2f4c51a43bae8e26b96aa4" xsi:type="BusinessProcess">
+      <name xml:lang="es">Check Availability</name>
+    </element>
+    <element identifier="id-cef7496ae5d84bfa8b4de2882dbbb248" xsi:type="BusinessProcess">
+      <name xml:lang="es">Create Production Order</name>
+    </element>
+    <element identifier="id-26bb007b0934471f9c05d188e9589372" xsi:type="BusinessProcess">
+      <name xml:lang="es">Create Shipping Order</name>
+    </element>
+    <element identifier="id-c4d0ce61237a4b03a3f27f9d1b009e55" xsi:type="BusinessProcess">
+      <name xml:lang="es">Update Customer Order</name>
+    </element>
+    <element identifier="id-53efc358b55540f0a4d75652777c457d" xsi:type="BusinessProcess">
+      <name xml:lang="es">Enter Order</name>
+    </element>
+    <element identifier="id-dfc0afa8475c4f559f13403e85a7f08e" xsi:type="BusinessProcess">
+      <name xml:lang="es">Plan Order</name>
+    </element>
+    <element identifier="id-2ec461c4dfd9428985b462c120b0fb79" xsi:type="BusinessProcess">
+      <name xml:lang="es">Develop Approved Proposal</name>
+    </element>
+    <element identifier="id-5f2f67e939914b59905c8b33282320ef" xsi:type="BusinessProcess">
+      <name xml:lang="es">Design</name>
+    </element>
+    <element identifier="id-5360e04f3f2b4d858aaaf6229e79b09a" xsi:type="BusinessProcess">
+      <name xml:lang="es">Price</name>
+    </element>
+    <element identifier="id-ffae0a20ba5a4960b55d50ff0b15dd68" xsi:type="BusinessProcess">
+      <name xml:lang="es">Schedule</name>
+    </element>
+    <element identifier="id-d6fd3df3ae0b4a56b96f5d22d1293f91" xsi:type="BusinessProcess">
+      <name xml:lang="es">Activate Plan</name>
+    </element>
+    <element identifier="id-434f18b593744f43914399d59d52b4e2" xsi:type="BusinessProcess">
+      <name xml:lang="es">Activate Delivery Schedule</name>
+    </element>
+    <element identifier="id-e09baac983c64a8abf359b5ead3f2b26" xsi:type="BusinessProcess">
+      <name xml:lang="es">Ready Production Line</name>
+    </element>
+    <element identifier="id-a33fd073b4ba4e508cbe3ab2dd3ebc6a" xsi:type="BusinessProcess">
+      <name xml:lang="es">Produce Order</name>
+    </element>
+    <element identifier="id-4b13dd7b55374db8846d4660064beefd" xsi:type="BusinessProcess">
+      <name xml:lang="es">Send Dlivery Orders</name>
+    </element>
+    <element identifier="id-c578fa3dcee04225a0144fa71920eeb6" xsi:type="BusinessEvent">
+      <name xml:lang="es">Customer Order</name>
+    </element>
+    <element identifier="id-8fa16f9c69894e46ba236ae0230911bc" xsi:type="BusinessEvent">
+      <name xml:lang="es">Customer Order Registered</name>
+    </element>
+    <element identifier="id-6191979d2f304476ab02f638d4ece684" xsi:type="BusinessEvent">
+      <name xml:lang="es">Customer Order Update</name>
+    </element>
+    <element identifier="id-bbd25ba605ba4eafaa1ab945552f0449" xsi:type="BusinessEvent">
+      <name xml:lang="es">Inquiry</name>
+    </element>
+    <element identifier="id-185e92e049434c4f954cc9b68957879f" xsi:type="BusinessEvent">
+      <name xml:lang="es">New Order Received</name>
+    </element>
+    <element identifier="id-1ddb1228062a4a1997ec7e977f7f4e3d" xsi:type="BusinessEvent">
+      <name xml:lang="es">Contract in Place</name>
+    </element>
+    <element identifier="id-d15443baa07a4291a075f402917fe007" xsi:type="BusinessRole">
+      <name xml:lang="es">Sales Representative</name>
+    </element>
+    <element identifier="id-e0af5fde22f148fd830c3b8f62c44038" xsi:type="BusinessRole">
+      <name xml:lang="es">Credit Specialist</name>
+    </element>
+    <element identifier="id-569bfe90e09e4c4ea87799bb9cf23274" xsi:type="BusinessRole">
+      <name xml:lang="es">Manufacturing Engineer</name>
+    </element>
+    <element identifier="id-5af8778d34c44cac8d30b4736484ff53" xsi:type="BusinessRole">
+      <name xml:lang="es">Customer Representative</name>
+    </element>
+    <element identifier="id-0cedc365b4d4417f9d2a45c1f7cd5e12" xsi:type="BusinessRole">
+      <name xml:lang="es">Account Manager</name>
+    </element>
+    <element identifier="id-cdda390a32864677a1dfe234de530add" xsi:type="BusinessRole">
+      <name xml:lang="es">Sales Manager</name>
+    </element>
+    <element identifier="id-946bfea9e17e42aa8f0184f2ef94b6f1" xsi:type="BusinessRole">
+      <name xml:lang="es">Proposal Specialist</name>
+    </element>
+    <element identifier="id-1ae1d77701f5419eae23f0ce50730604" xsi:type="BusinessRole">
+      <name xml:lang="es">Production Manager</name>
+    </element>
+    <element identifier="id-ad64cacb19e34896829b2a462615fd7b" xsi:type="BusinessRole">
+      <name xml:lang="es">Production Planner</name>
+    </element>
+    <element identifier="id-3b89b7e81d7d4052affd44601b6e7a83" xsi:type="BusinessRole">
+      <name xml:lang="es">Logistics Planner</name>
+    </element>
+    <element identifier="id-300c7dd906cb45b4b0b8e6bb0828221f" xsi:type="DataObject">
+      <name xml:lang="es">CRM Data</name>
+    </element>
+    <element identifier="id-b8ba463d96e7480e8099014269c938e8" xsi:type="ApplicationCollaboration">
+      <name xml:lang="es">Total Customer Debt</name>
+    </element>
+    <element identifier="id-4c50a5c4b84a49128b53481ac94f3430" xsi:type="ApplicationCollaboration">
+      <name xml:lang="es">Customer Order Status</name>
+    </element>
+    <element identifier="id-9a865b3c106b4c5cb4800029ac3d54a7" xsi:type="ApplicationService">
+      <name xml:lang="es">CRM</name>
+    </element>
+    <element identifier="id-8dd7f9e048c54837a99fdc6dc101ff29" xsi:type="ApplicationService">
+      <name xml:lang="es">ERP</name>
+    </element>
+    <element identifier="id-ba8ce89c442d457c845d849f2ba0b8e5" xsi:type="ApplicationService">
+      <name xml:lang="es">Customer Data Mgmt</name>
+    </element>
+    <element identifier="id-72854cd1e4ff40a1bdf77773165e2bdc" xsi:type="ApplicationService">
+      <name xml:lang="es">Quoting</name>
+    </element>
+    <element identifier="id-226179e7cbaa4a919383bdd4e44b41dc" xsi:type="ApplicationService">
+      <name xml:lang="es">Sales Pipeline Mgmt</name>
+    </element>
+    <element identifier="id-99bc4a3c85954400915f6e7433440cb0" xsi:type="ApplicationService">
+      <name xml:lang="es">Query</name>
+    </element>
+    <element identifier="id-e9a3e42545534d519a9221494e2afb44" xsi:type="ApplicationService">
+      <name xml:lang="es">Social Interaction</name>
+    </element>
+    <element identifier="id-a4e2426aa6344ff49a4d9f5a22b67ad9" xsi:type="ApplicationService">
+      <name xml:lang="es">Analytics</name>
+    </element>
+    <element identifier="id-5c6ae3c285034247837fe4118e5c76d9" xsi:type="ApplicationService">
+      <name xml:lang="es">Order Status Mgmt</name>
+    </element>
+    <element identifier="id-2dbbbff37e7644338f16ac2fbf784265" xsi:type="ApplicationService">
+      <name xml:lang="es">Reporting</name>
+    </element>
+    <element identifier="id-3e0c53acd20e49d491f78cf0d33475d6" xsi:type="ApplicationService">
+      <name xml:lang="es">Customer Administration Service</name>
+    </element>
+    <element identifier="id-deab2ec93baa49a28e95cb01ae59f7c3" xsi:type="ApplicationService">
+      <name xml:lang="es">Customer Credit Analysis Service</name>
+    </element>
+    <element identifier="id-0d58563f7c7647b8a9eb8d050ec6034b" xsi:type="ApplicationService">
+      <name xml:lang="es">Contract Creating Service</name>
+    </element>
+    <element identifier="id-eed49dfc6a754e3fbbcff474c2ee1b8d" xsi:type="ApplicationService">
+      <name xml:lang="es">Contract Printing Service</name>
+    </element>
+    <element identifier="id-65db965489624a89893068173a39cf59" xsi:type="ApplicationService">
+      <name xml:lang="es">Verify Customer Exposure Service</name>
+    </element>
+    <element identifier="id-815c2b316d7848279b068a86a0a2ddea" xsi:type="ApplicationService">
+      <name xml:lang="es">Order Aministration Service</name>
+    </element>
+    <element identifier="id-c9eb53d707564096a8727df622f078bb" xsi:type="ApplicationService">
+      <name xml:lang="es">Total Customer Debt Information Service</name>
+    </element>
+    <element identifier="id-1cd9ba40fb81440b89ca6b9b81264bf4" xsi:type="ApplicationService">
+      <name xml:lang="es">Customer Order Tracking Service</name>
+    </element>
+    <element identifier="id-c521cb12763d4ab3993c3c45b66dc5d4" xsi:type="ApplicationService">
+      <name xml:lang="es">Customer Information Service</name>
+    </element>
+    <element identifier="id-cb9b699fb1fc478c8a8f436b20038f0f" xsi:type="ApplicationService">
+      <name xml:lang="es">Product Availability Consultation</name>
+    </element>
+    <element identifier="id-06fe133456074678b8f6a19e6aa5906b" xsi:type="ApplicationService">
+      <name xml:lang="es">Production Order Creation Service</name>
+    </element>
+    <element identifier="id-c1d7e78cb9a8486cb0365b0c3eafdbd9" xsi:type="ApplicationService">
+      <name xml:lang="es">Shipping Order Creation Service</name>
+    </element>
+    <element identifier="id-cfa3f50f73694f23a2ef50c482a320b9" xsi:type="ApplicationService">
+      <name xml:lang="es">Customer Order Administration Service</name>
+    </element>
+    <element identifier="id-3237b47e6ecc442b87d63a2c0ff8077c" xsi:type="ApplicationComponent">
+      <name xml:lang="es">Integrated Customer-Centric Solution</name>
+    </element>
+    <element identifier="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="ApplicationComponent">
+      <name xml:lang="es">EAI Bus</name>
+    </element>
+    <element identifier="id-2a8eb6786915456d92df41a8b9349314" xsi:type="ApplicationComponent">
+      <name xml:lang="es">BI Toolset</name>
+    </element>
+    <element identifier="id-4e06ee45db904a88aa46e9dce611528e" xsi:type="ApplicationComponent">
+      <name xml:lang="es">CRM System</name>
+    </element>
+    <element identifier="id-c728f7f622be468380062354ffbf4f57" xsi:type="ApplicationComponent">
+      <name xml:lang="es">ERP Application</name>
+    </element>
+    <element identifier="id-e26375257d8440228f37158ecf5b8524" xsi:type="ApplicationComponent">
+      <name xml:lang="es">Customer Order Monitoring Application</name>
+    </element>
+    <element identifier="id-a9c72e1cb5344e3ab7a8a7bc8271776d" xsi:type="ApplicationComponent">
+      <name xml:lang="es">Inventory</name>
+    </element>
+    <element identifier="id-2eec1a4a343142c09574a74d773e2224" xsi:type="ApplicationComponent">
+      <name xml:lang="es">Materials Manaement</name>
+    </element>
+    <element identifier="id-927db0f85d244a08b92e4925eb053d2b" xsi:type="ApplicationComponent">
+      <name xml:lang="es">Production Planning</name>
+    </element>
+    <element identifier="id-df71ee7baba64cfbb35bcd00ed36040c" xsi:type="ApplicationComponent">
+      <name xml:lang="es">Financial (PC)</name>
+    </element>
+    <element identifier="id-68903f066cfc4959a4e940405e47f6cd" xsi:type="ApplicationComponent">
+      <name xml:lang="es">Shipping Application (PC)</name>
+    </element>
+    <element identifier="id-5538d8de4e6c4918a62221922988c957" xsi:type="ApplicationComponent">
+      <name xml:lang="es">Production Scheduling</name>
+    </element>
+    <element identifier="id-132442dad80345129362408c87cdde9b" xsi:type="ApplicationComponent">
+      <name xml:lang="es">Invoicing (Distribution)</name>
+    </element>
+    <element identifier="id-641d335281ca4b53932f250e695f1f94" xsi:type="ApplicationComponent">
+      <name xml:lang="es">Distributors Management</name>
+    </element>
+    <element identifier="id-970722b900b14871becf437967275425" xsi:type="ApplicationComponent">
+      <name xml:lang="es">DC Order Management</name>
+    </element>
+    <element identifier="id-9d0751d373ec482b925d0f28f04f6608" xsi:type="ApplicationComponent">
+      <name xml:lang="es">Order Management Applications</name>
+    </element>
+    <element identifier="id-021e6ea0d09f433f92532777a5980497" xsi:type="ApplicationComponent">
+      <name xml:lang="es">Customer Data Mangement Application</name>
+    </element>
+    <element identifier="id-51d42a1da36a42c2811e84ff8952cb58" xsi:type="ApplicationComponent">
+      <name xml:lang="es">Shipping Application (DC)</name>
+    </element>
+    <element identifier="id-3dfec7838acb47f588677d6e8f948fd9" xsi:type="ApplicationComponent">
+      <name xml:lang="es">Financial Application (DC)</name>
+    </element>
+    <element identifier="id-09b37e64a61d4c4183f49930d1237509" xsi:type="ApplicationComponent">
+      <name xml:lang="es">Invoice Application (DC)</name>
+    </element>
+    <element identifier="id-3eb0685faebf42cfa81567c6a4e7db24" xsi:type="ApplicationComponent">
+      <name xml:lang="es">Financial Application (HQ)</name>
+    </element>
+    <element identifier="id-1c00d69a990445f7a53257a2b8a185b6" xsi:type="DataObject">
+      <name xml:lang="es">PROCESS</name>
+    </element>
+    <element identifier="id-f1f36d4abf914d598a9b032762310b30" xsi:type="DataObject">
+      <name xml:lang="es">ACKNOWLEDGE</name>
+    </element>
+    <element identifier="id-e127038f87cb42959f5a9be4c63ac400" xsi:type="DataObject">
+      <name xml:lang="es">New Schedule</name>
+    </element>
+    <element identifier="id-8e6db4ddae3a41c2a7fe819cb7c140db" xsi:type="DataObject">
+      <name xml:lang="es">New Schedule ID</name>
+    </element>
+    <element identifier="id-85f3e58459cf4566a8984eb0261305df" xsi:type="DataObject">
+      <name xml:lang="es">GET</name>
+    </element>
+    <element identifier="id-0b43aa7ad1e34ecfac49e9107b204ed6" xsi:type="DataObject">
+      <name xml:lang="es">SHOW</name>
+    </element>
+    <element identifier="id-de3928a8ce2d4a0c8777d3c53213e57e" xsi:type="DataObject">
+      <name xml:lang="es">Status Requested</name>
+    </element>
+    <element identifier="id-54d1145720594f2784b21ce4e4ca0ed0" xsi:type="DataObject">
+      <name xml:lang="es">Status</name>
+    </element>
+    <element identifier="id-3e585eea23014b888f64de613fe21d3c" xsi:type="DataObject">
+      <name xml:lang="es">SYNC CHANGE</name>
+    </element>
+    <element identifier="id-20aa4381e31143b697919991db4db30b" xsi:type="DataObject">
+      <name xml:lang="es">CHANGE</name>
+    </element>
+    <element identifier="id-cf388ea8144942eeb6a7d23d2fc9d9e5" xsi:type="DataObject">
+      <name xml:lang="es">Change Requested</name>
+    </element>
+    <element identifier="id-d40e8b39852a401db024c671bc95209d" xsi:type="DataObject">
+      <name xml:lang="es">Change Made</name>
+    </element>
+    <element identifier="id-f32c66917de74091bdd5a9624452f2c3" xsi:type="DataObject">
+      <name xml:lang="es">New Equipment Requested</name>
+    </element>
+    <element identifier="id-89f4b36253eb49fcbf5f75119cf5ff24" xsi:type="DataObject">
+      <name xml:lang="es">New Equipment ID</name>
+    </element>
+    <element identifier="id-32425a437e9b4d6e88c7ea527389db79" xsi:type="TechnologyProcess">
+      <name xml:lang="es">Logistics Process</name>
+    </element>
+    <element identifier="id-d894787e002341deb3688fbc1084e63c" xsi:type="TechnologyProcess">
+      <name xml:lang="es">Physical Production Process</name>
+    </element>
+    <element identifier="id-809e6563310c4e15b7697fa525023abf" xsi:type="TechnologyProcess">
+      <name xml:lang="es">Transportation</name>
+    </element>
+    <element identifier="id-868a037328914ca79d43352cdccc890f" xsi:type="TechnologyProcess">
+      <name xml:lang="es">Storage</name>
+    </element>
+    <element identifier="id-330b37e7d3bf425a8da334998ed4b559" xsi:type="TechnologyProcess">
+      <name xml:lang="es">Transportation</name>
+    </element>
+    <element identifier="id-e36661dac4014c0bb54cc138c8af5485" xsi:type="TechnologyProcess">
+      <name xml:lang="es">Casting</name>
+    </element>
+    <element identifier="id-cfa53abb5fea4aac8c1ad6901b1b2470" xsi:type="TechnologyProcess">
+      <name xml:lang="es">Processing Raw Materials</name>
+    </element>
+    <element identifier="id-493d8b255dcd4c249087ff7e85f0f16a" xsi:type="TechnologyProcess">
+      <name xml:lang="es">Rolling</name>
+    </element>
+    <element identifier="id-169ba8405759474db2179d246f01216d" xsi:type="TechnologyProcess">
+      <name xml:lang="es">Steel Making</name>
+    </element>
+    <element identifier="id-e79b5c486e7b472ea4db37e0d5a19efb" xsi:type="Material">
+      <name xml:lang="es">Coal</name>
+    </element>
+    <element identifier="id-a9ed7174af0548d5b138b47fba446282" xsi:type="Material">
+      <name xml:lang="es">Iron Ore</name>
+    </element>
+    <element identifier="id-64e6961cbc5b4c03b984593db7d9ae8a" xsi:type="DistributionNetwork">
+      <name xml:lang="es">Conveyor Belts</name>
+    </element>
+    <element identifier="id-3bfc5d5eae14479aa57922a2f99ab3d6" xsi:type="Facility">
+      <name xml:lang="es">Cokes Factory</name>
+    </element>
+    <element identifier="id-143ca1ce20d2492caf819e0787d23823" xsi:type="Facility">
+      <name xml:lang="es">Pallet Factory</name>
+    </element>
+    <element identifier="id-e54ac98461364b6f89be0d7ce49996b0" xsi:type="Facility">
+      <name xml:lang="es">Sinter Factory</name>
+    </element>
+    <element identifier="id-5903ad80d51e413dab64159cdf1f6fd0" xsi:type="Material">
+      <name xml:lang="es">Cokes</name>
+    </element>
+    <element identifier="id-02c0f4e1301f46cfbf2453b11e1c6de0" xsi:type="Material">
+      <name xml:lang="es">Pallets</name>
+    </element>
+    <element identifier="id-0cc3e6f3dca340b58f7b177619936176" xsi:type="Material">
+      <name xml:lang="es">Sinters</name>
+    </element>
+    <element identifier="id-3d3294e5d139473e965cacb7ad9e4e7f" xsi:type="Facility">
+      <name xml:lang="es">Blast Furnace</name>
+    </element>
+    <element identifier="id-23d2166d570f40bdad1417d39f10373f" xsi:type="DistributionNetwork">
+      <name xml:lang="es">Rail Transport</name>
+    </element>
+    <element identifier="id-4364086f4188452084a6168dcbd7b186" xsi:type="Material">
+      <name xml:lang="es">Liquid Iron</name>
+    </element>
+    <element identifier="id-cf389c783061458f822a388324e89b09" xsi:type="Material">
+      <name xml:lang="es">Scrap</name>
+    </element>
+    <element identifier="id-1d8b234a0add4fdca68c71514f32e981" xsi:type="Material">
+      <name xml:lang="es">Oxygen</name>
+    </element>
+    <element identifier="id-9d1d0adbfe2c43cba2db422b4ca184cc" xsi:type="Facility">
+      <name xml:lang="es">Steel Plant</name>
+    </element>
+    <element identifier="id-64a3c89d49ff447f9dab07ddcaf002ec" xsi:type="Material">
+      <name xml:lang="es">Steel Slabs</name>
+    </element>
+    <element identifier="id-2ce4621d4a164842b29cce506cde7a68" xsi:type="Facility">
+      <name xml:lang="es">Hot Strip Mill</name>
+    </element>
+    <element identifier="id-131c1792801b40a49a9041661dec5ed8" xsi:type="Material">
+      <name xml:lang="es">Finished Steel</name>
+    </element>
+    <element identifier="id-8b9b1e49a27848f68fea836a25a610d6" xsi:type="Facility">
+      <name xml:lang="es">Warehouse</name>
+    </element>
+    <element identifier="id-64e12c6aa1954c6486e01bda92a18d82" xsi:type="SystemSoftware">
+      <name xml:lang="es">Process Control Software</name>
+    </element>
+    <element identifier="id-dc154c48f080459ca6e29d7f1edaf050" xsi:type="Equipment">
+      <name xml:lang="es">Roll</name>
+    </element>
+    <element identifier="id-7d3aa9ac0b804060a502de4b8ad537fc" xsi:type="Node">
+      <name xml:lang="es">Roll Line</name>
+    </element>
+    <element identifier="id-40f1e7bdf4c74241b1ac5763b3aa9d50" xsi:type="TechnologyService">
+      <name xml:lang="es">Database Service</name>
+    </element>
+    <element identifier="id-79c6674039c14444a51dc8f5c7491b23" xsi:type="TechnologyService">
+      <name xml:lang="es">Language Service</name>
+    </element>
+    <element identifier="id-6ace217c8c624d229ee2cc11528d52e4" xsi:type="TechnologyService">
+      <name xml:lang="es">Messaging Service</name>
+    </element>
+    <element identifier="id-772a5d3d408142a28ab040048e09e7ff" xsi:type="TechnologyService">
+      <name xml:lang="es">Network Service</name>
+    </element>
+    <element identifier="id-094df2608dbf49078615591a945c3681" xsi:type="TechnologyFunction">
+      <name xml:lang="es">Authentication &amp; Authorization</name>
+    </element>
+    <element identifier="id-b0541156f9194546bd0922c13349649a" xsi:type="Node">
+      <name xml:lang="es">Distributed Servers</name>
+    </element>
+    <element identifier="id-7eb87af87eb349d9b8a5a8b5cbad8856" xsi:type="SystemSoftware">
+      <name xml:lang="es">DBMS</name>
+    </element>
+    <element identifier="id-4196a1f9d7464198aad03a7a67bfc82e" xsi:type="SystemSoftware">
+      <name xml:lang="es">Operating System</name>
+    </element>
+    <element identifier="id-9d76a90f5163422494119c99f6a908f3" xsi:type="Node">
+      <name xml:lang="es">Mainframe</name>
+    </element>
+    <element identifier="id-a1337fb63ca144ad9473d94406ab187e" xsi:type="Node">
+      <name xml:lang="es">Partition 1</name>
+    </element>
+    <element identifier="id-f0b5bad31d9246ba8689143d271f6c38" xsi:type="Node">
+      <name xml:lang="es">Partition 2</name>
+    </element>
+    <element identifier="id-7bd8507070fc42b2802ffc882e48484e" xsi:type="CommunicationNetwork">
+      <name xml:lang="es">LAN</name>
+    </element>
+    <element identifier="id-2f548011437a41048be837f74c3f4d00" xsi:type="SystemSoftware">
+      <name xml:lang="es">Message Queuing</name>
+    </element>
+    <element identifier="id-0b84596d01f04499b880d15e58879759" xsi:type="Device">
+      <name xml:lang="es">Hardware Device 1</name>
+    </element>
+    <element identifier="id-69f1b9c8a59146a8938218dc363b3895" xsi:type="Device">
+      <name xml:lang="es">Hardware Device 2</name>
+    </element>
+    <element identifier="id-4b6a9ff03a9b4b1689350806c022f681" xsi:type="Requirement">
+      <name xml:lang="es">Unified View of Customer Company-Wide</name>
+    </element>
+    <element identifier="id-9960fb227da24f57b727e05fd81a7739" xsi:type="Requirement">
+      <name xml:lang="es">Customer Data Integration and Standardization</name>
+    </element>
+    <element identifier="id-fcb1db6aa783410aa3856df684699fd3" xsi:type="Stakeholder">
+      <name xml:lang="es">Management</name>
+    </element>
+    <element identifier="id-8939bfb16933425c952bd4ca553d90e2" xsi:type="Stakeholder">
+      <name xml:lang="es">Customer</name>
+    </element>
+    <element identifier="id-f31166117d504940a2268fb1dcb0bbc7" xsi:type="Stakeholder">
+      <name xml:lang="es">Building Products Manufacturer</name>
+    </element>
+    <element identifier="id-985c644ebbe343c5a32fc36353e0535d" xsi:type="Driver">
+      <name xml:lang="es">Business Performance</name>
+    </element>
+    <element identifier="id-41f712023d8b4f9babb41249355dfc7b" xsi:type="Driver">
+      <name xml:lang="es">Customer Satisfaction</name>
+    </element>
+    <element identifier="id-1008ebfba144417f8e8a58e889c3b9c6" xsi:type="Driver">
+      <name xml:lang="es">Service Quality</name>
+    </element>
+    <element identifier="id-3fe71c490fc64bf3bb22c73bff890b38" xsi:type="Driver">
+      <name xml:lang="es">On-Time Delivery</name>
+    </element>
+    <element identifier="id-773494ddbf30427a8218ff76abbe0d5f" xsi:type="Assessment">
+      <name xml:lang="es">Average Revenue per Customer is Too Low</name>
+    </element>
+    <element identifier="id-bf3da697d4314f33bcb03ae7ed84d665" xsi:type="Assessment">
+      <name xml:lang="es">Inefficient Order Fulfillment</name>
+    </element>
+    <element identifier="id-73a045146ae94517bca67365cd206c1a" xsi:type="Assessment">
+      <name xml:lang="es">Lack of Global and Consistent View Over Customer</name>
+    </element>
+    <element identifier="id-e929318a3ae441ba9dd96b8d4623557a" xsi:type="Assessment">
+      <name xml:lang="es">Lead Time to Customer too Long</name>
+    </element>
+    <element identifier="id-4c52d1762cb8468c92950f0bc509e045" xsi:type="Assessment">
+      <name xml:lang="es">Suboptimal Sales Processes</name>
+    </element>
+    <element identifier="id-70189a83837444a798183ae73a7bc5b2" xsi:type="Assessment">
+      <name xml:lang="es">Underdeveloped Customer Relationship</name>
+    </element>
+    <element identifier="id-26dae395ffb343dcbb3a410b88d3021d" xsi:type="Assessment">
+      <name xml:lang="es">Suboptimal Client Profiling</name>
+    </element>
+    <element identifier="id-db9483ab0a3b4f1eb7259e53426eee09" xsi:type="Assessment">
+      <name xml:lang="es">Market Pressure for Service Innovation</name>
+    </element>
+    <element identifier="id-58df809904fa4baf8b5b7c28c53d20b0" xsi:type="Assessment">
+      <name xml:lang="es">Order Already Designed and Priced</name>
+    </element>
+    <element identifier="id-4aee877b6bfd42619217ccb2547b68ba" xsi:type="Assessment">
+      <name xml:lang="es">Price Out-of-Date</name>
+    </element>
+    <element identifier="id-3fd6818a449e46559476e24456f63196" xsi:type="Assessment">
+      <name xml:lang="es">Design Still Valid</name>
+    </element>
+    <element identifier="id-b9d676d91e5e40ebaa9338c0e87463bf" xsi:type="Goal">
+      <name xml:lang="es">Innovate Customer Services</name>
+    </element>
+    <element identifier="id-f19bc7ea65c94679b97db1774cb2ef34" xsi:type="Goal">
+      <name xml:lang="es">Improve Client Profiling</name>
+    </element>
+    <element identifier="id-d57beba0aeca4d5884d9f79cee2cacad" xsi:type="Goal">
+      <name xml:lang="es">Improve Customer Relationship Management</name>
+    </element>
+    <element identifier="id-a0f64c7e0e3b43c6a9ea32a9b35e99eb" xsi:type="Goal">
+      <name xml:lang="es">Improve Marketing/Service Strategy</name>
+    </element>
+    <element identifier="id-877622cb13a744b1baa7d9e94576aa25" xsi:type="Goal">
+      <name xml:lang="es">Complete Building</name>
+    </element>
+    <element identifier="id-f11c2b0d08c44572995ce0a180edc174" xsi:type="Goal">
+      <name xml:lang="es">Obtain Beams</name>
+    </element>
+    <element identifier="id-d676a607a130483a961a4a1de0179094" xsi:type="Goal">
+      <name xml:lang="es">Manufacture Beams</name>
+    </element>
+    <element identifier="id-fbc7c240895b4e0397b9aea45e0618bf" xsi:type="WorkPackage">
+      <name xml:lang="es">CRM Transformation Program</name>
+    </element>
+    <element identifier="id-4d7f4fc0971947f787ba6b4fa2ff3fa0" xsi:type="WorkPackage">
+      <name xml:lang="es">CRM Project</name>
+    </element>
+    <element identifier="id-4cf5ebcb7c0b4c01bfb2c6934504ba8f" xsi:type="WorkPackage">
+      <name xml:lang="es">Cutomer Order Monitoring Project</name>
+    </element>
+    <element identifier="id-2f8dd2120d55460896baf324b937dfd6" xsi:type="Deliverable">
+      <name xml:lang="es">Redesigned Business Process</name>
+    </element>
+    <element identifier="id-8e83c502c9924312923992e8b255bff1" xsi:type="Deliverable">
+      <name xml:lang="es">Deployed CRM Application</name>
+    </element>
+    <element identifier="id-d81bb5d2f5274f239d10b8a210a2fa8b" xsi:type="Deliverable">
+      <name xml:lang="es">Redesigned Business Processes (Target)</name>
+    </element>
+    <element identifier="id-e429c90e3c69458f9131f11c48669677" xsi:type="Deliverable">
+      <name xml:lang="es">Deployed Customer Order Monitoring Application</name>
+    </element>
+    <element identifier="id-58761ca77a6d49818b06fd0021959839" xsi:type="Plateau">
+      <name xml:lang="es">Current State</name>
+    </element>
+    <element identifier="id-be22e5fb2b804f32b1087966af591ec4" xsi:type="Plateau">
+      <name xml:lang="es">Transition State</name>
+    </element>
+    <element identifier="id-faeb172be6704b9d992fe8646d3028f0" xsi:type="Plateau">
+      <name xml:lang="es">Target State</name>
+    </element>
+    <element identifier="id-c3e80fb693bd48ebbfe756c998d7384b" xsi:type="Grouping">
+      <name xml:lang="es">Factories</name>
+    </element>
+    <element identifier="id-8b75218115db49b9aecd0501d04d5545" xsi:type="Location">
+      <name xml:lang="es">Production Center</name>
+    </element>
+    <element identifier="id-93c74e2f4b8b4b0491164e6d79c445d6" xsi:type="Location">
+      <name xml:lang="es">Distribution Center</name>
+    </element>
+    <element identifier="id-26586078852645d59ea8b14781701c65" xsi:type="Location">
+      <name xml:lang="es">HQ</name>
+    </element>
+    <element identifier="id-0c7864041e1546d38b8f0cef3bb638ab" xsi:type="AndJunction">
+      <name xml:lang="es">Junction</name>
+    </element>
+    <element identifier="id-72b88e880fe74bc1b6c30caa12640289" xsi:type="AndJunction">
+      <name xml:lang="es">Junction</name>
+    </element>
+  </elements>
+  <relationships>
+    <relationship identifier="id-41a7e9a05f634d78b0905a8377bbb636" source="id-3bc7d428ccea48739c4d442f9f2364e7" target="id-65c1620fd1284553b20818224030a84d" xsi:type="Composition" />
+    <relationship identifier="id-bfdad74a7fac4bfe85f85ae3f89b5b8f" source="id-3bc7d428ccea48739c4d442f9f2364e7" target="id-5987ea5989b34bb3b7b3b7df0c5d7596" xsi:type="Composition" />
+    <relationship identifier="id-787a4cc6202d4b01a2fdc74dcfe2fd57" source="id-3bc7d428ccea48739c4d442f9f2364e7" target="id-b50ea84ae74845f3b8001028c0558e90" xsi:type="Composition" />
+    <relationship identifier="id-621760440b4e4f8eb1b08d0c23e5ee49" source="id-ca35f8df80974169b04c1ffd58c12493" target="id-6118370573ec480e85a1d4b2eed6eacd" xsi:type="Composition" />
+    <relationship identifier="id-f42ba8a6bdc143f2984f4e4921ca2de2" source="id-ca35f8df80974169b04c1ffd58c12493" target="id-761d6b44b0084191bb0574b9b2c4e949" xsi:type="Composition" />
+    <relationship identifier="id-caea252e989343969654c9a981e9e25c" source="id-ca35f8df80974169b04c1ffd58c12493" target="id-eee6f468492e48efb54f44db721f75aa" xsi:type="Composition" />
+    <relationship identifier="id-2e44ec61777c449bbc4d01d28db2a7ef" source="id-ca35f8df80974169b04c1ffd58c12493" target="id-dae853c3fdda4da9a99c066d144cc617" xsi:type="Composition" />
+    <relationship identifier="id-90888cc5c1eb44b8ad54e7e8b392c9ea" source="id-86d6a2f695b74347a264354315c8656f" target="id-b6d4eb2c1e184d33897f7862f6317033" xsi:type="Composition" />
+    <relationship identifier="id-1fb891470a8b42d2b0f87e92885a14e6" source="id-86d6a2f695b74347a264354315c8656f" target="id-628c9b29c1254f3c8d0aea92d13e5d65" xsi:type="Composition" />
+    <relationship identifier="id-c538f1bf4f144469aa207e73bd8189c5" source="id-86d6a2f695b74347a264354315c8656f" target="id-2bcc0251b630425ea4c325246a35f5b8" xsi:type="Composition" />
+    <relationship identifier="id-68ec6264cc3e4faf97177c0b496099bf" source="id-70e443457ba447cf9f7be64c0a2e0ad1" target="id-3bc7d428ccea48739c4d442f9f2364e7" xsi:type="Composition" />
+    <relationship identifier="id-d07e45f34c934ad88f656e41c7186a08" source="id-70e443457ba447cf9f7be64c0a2e0ad1" target="id-ca35f8df80974169b04c1ffd58c12493" xsi:type="Composition" />
+    <relationship identifier="id-f7739d8d47624648bee67824e68ccae4" source="id-70e443457ba447cf9f7be64c0a2e0ad1" target="id-ca27484ed8934cd2bb57cec774298909" xsi:type="Composition" />
+    <relationship identifier="id-9f43bd5578534fc5824e27a572a22cf9" source="id-70e443457ba447cf9f7be64c0a2e0ad1" target="id-f96b2f70a48e42bb83646b89292b1286" xsi:type="Composition" />
+    <relationship identifier="id-76a6723cd0824465a7a1d77014d8b6ff" source="id-70e443457ba447cf9f7be64c0a2e0ad1" target="id-86d6a2f695b74347a264354315c8656f" xsi:type="Composition" />
+    <relationship identifier="id-f3bf5f25f60e4c89b7f6b9de305ff28c" source="id-fc034ab99bfa4b9e9ae7f51fa8de905f" target="id-c93b9d430cd2423b95c52c610e12f720" xsi:type="Triggering" />
+    <relationship identifier="id-eb38b69298ee46dfbe0d976f84d8d262" source="id-c93b9d430cd2423b95c52c610e12f720" target="id-281d523a5a0e45e686b8d9c6726a5be9" xsi:type="Triggering" />
+    <relationship identifier="id-6f5c6dceb0594ca8ba8be8e85214b686" source="id-281d523a5a0e45e686b8d9c6726a5be9" target="id-051bc17974ef4cedb0424a31e975d727" xsi:type="Triggering" />
+    <relationship identifier="id-7e623a892b494202b7fa8ea6a1a06c80" source="id-051bc17974ef4cedb0424a31e975d727" target="id-53228d509e7c444dbf57f5dd19df3484" xsi:type="Triggering" />
+    <relationship identifier="id-cd6c3aeb94cf4cefbfd3df75082d8fe7" source="id-1e3683a995704e0bb1abe93aeba4d203" target="id-c93b9d430cd2423b95c52c610e12f720" xsi:type="Composition" />
+    <relationship identifier="id-77773be25be24129bd660aab1c749b7f" source="id-1e3683a995704e0bb1abe93aeba4d203" target="id-051bc17974ef4cedb0424a31e975d727" xsi:type="Composition" />
+    <relationship identifier="id-ce665fc5db4d4e3cad11c6dec73e70b4" source="id-1e3683a995704e0bb1abe93aeba4d203" target="id-fc034ab99bfa4b9e9ae7f51fa8de905f" xsi:type="Composition" />
+    <relationship identifier="id-7d9525874e154f8fb292970c5cda6ddb" source="id-1e3683a995704e0bb1abe93aeba4d203" target="id-281d523a5a0e45e686b8d9c6726a5be9" xsi:type="Composition" />
+    <relationship identifier="id-9a8d56e3053a422e9009a70dc23b28f5" source="id-1e3683a995704e0bb1abe93aeba4d203" target="id-53228d509e7c444dbf57f5dd19df3484" xsi:type="Composition" />
+    <relationship identifier="id-61b7abe559c64c4ea18fcba54c1ae17e" source="id-ca35f8df80974169b04c1ffd58c12493" target="id-a6992b23c09c44dba47e8e06ad7655c5" xsi:type="Assignment" />
+    <relationship identifier="id-91cf3830343346699650c97c4962a76c" source="id-ca35f8df80974169b04c1ffd58c12493" target="id-bb08ebde1b25412bb52d9e4d35afa404" xsi:type="Assignment" />
+    <relationship identifier="id-46390cc95d6246c08208fa25fb06aa49" source="id-cfa53abb5fea4aac8c1ad6901b1b2470" target="id-169ba8405759474db2179d246f01216d" xsi:type="Triggering" />
+    <relationship identifier="id-1d368509cab740e4bcfc5fdf91b827a2" source="id-169ba8405759474db2179d246f01216d" target="id-e36661dac4014c0bb54cc138c8af5485" xsi:type="Triggering" />
+    <relationship identifier="id-0eb3c88263d84399bb798d8e24afa00b" source="id-e36661dac4014c0bb54cc138c8af5485" target="id-493d8b255dcd4c249087ff7e85f0f16a" xsi:type="Triggering" />
+    <relationship identifier="id-33cdf3f2d9e344199ba50e2ab92e4ec3" source="id-493d8b255dcd4c249087ff7e85f0f16a" target="id-868a037328914ca79d43352cdccc890f" xsi:type="Triggering" />
+    <relationship identifier="id-dee89864271043df898a92ae5b001fd7" source="id-868a037328914ca79d43352cdccc890f" target="id-330b37e7d3bf425a8da334998ed4b559" xsi:type="Triggering" />
+    <relationship identifier="id-aab1dbccb34f4d43b104b4a8c5f70a37" source="id-d894787e002341deb3688fbc1084e63c" target="id-bb08ebde1b25412bb52d9e4d35afa404" xsi:type="Realization" />
+    <relationship identifier="id-94ecdff105684a36bcf339a4bda8499e" source="id-32425a437e9b4d6e88c7ea527389db79" target="id-a6992b23c09c44dba47e8e06ad7655c5" xsi:type="Realization" />
+    <relationship identifier="id-905f8841ef2f4debbdae6ae27fec16c7" source="id-d894787e002341deb3688fbc1084e63c" target="id-cfa53abb5fea4aac8c1ad6901b1b2470" xsi:type="Composition" />
+    <relationship identifier="id-b38253cbaf7b48ad9cb0307b851e2ea8" source="id-d894787e002341deb3688fbc1084e63c" target="id-e36661dac4014c0bb54cc138c8af5485" xsi:type="Composition" />
+    <relationship identifier="id-ff4fba53c3c24676af1e7cefaef702c9" source="id-d894787e002341deb3688fbc1084e63c" target="id-169ba8405759474db2179d246f01216d" xsi:type="Composition" />
+    <relationship identifier="id-5345754f72ee4a339dbd8c95879a865f" source="id-d894787e002341deb3688fbc1084e63c" target="id-493d8b255dcd4c249087ff7e85f0f16a" xsi:type="Composition" />
+    <relationship identifier="id-aabd8faaeb1943cd90c517f625d3ae17" source="id-32425a437e9b4d6e88c7ea527389db79" target="id-868a037328914ca79d43352cdccc890f" xsi:type="Composition" />
+    <relationship identifier="id-06e6805296004d95b46ab40f2e633b2e" source="id-32425a437e9b4d6e88c7ea527389db79" target="id-330b37e7d3bf425a8da334998ed4b559" xsi:type="Composition" />
+    <relationship identifier="id-11d4a56d51c3476aafda510d68127aeb" source="id-e79b5c486e7b472ea4db37e0d5a19efb" target="id-64e6961cbc5b4c03b984593db7d9ae8a" xsi:type="Association" />
+    <relationship identifier="id-a921b99ac27d48daaa7f4257f848df46" source="id-a9ed7174af0548d5b138b47fba446282" target="id-64e6961cbc5b4c03b984593db7d9ae8a" xsi:type="Association" />
+    <relationship identifier="id-f0f98883b8ad4d30af589b98c62a7098" source="id-c3e80fb693bd48ebbfe756c998d7384b" target="id-3bfc5d5eae14479aa57922a2f99ab3d6" xsi:type="Composition" />
+    <relationship identifier="id-04266827af764ac095b38c36d16c0ddf" source="id-c3e80fb693bd48ebbfe756c998d7384b" target="id-e54ac98461364b6f89be0d7ce49996b0" xsi:type="Composition" />
+    <relationship identifier="id-49833304877847309113437178ce88d1" source="id-c3e80fb693bd48ebbfe756c998d7384b" target="id-143ca1ce20d2492caf819e0787d23823" xsi:type="Composition" />
+    <relationship identifier="id-bed57c56146f445780694bb9c7b097e0" source="id-c3e80fb693bd48ebbfe756c998d7384b" target="id-cfa53abb5fea4aac8c1ad6901b1b2470" xsi:type="Assignment" />
+    <relationship identifier="id-e290eaf5e13d42828c1998b01b6c9028" source="id-3bfc5d5eae14479aa57922a2f99ab3d6" target="id-e79b5c486e7b472ea4db37e0d5a19efb" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-86ee34f4fdb14ac4957aa6ea6ef34e6a" source="id-e54ac98461364b6f89be0d7ce49996b0" target="id-a9ed7174af0548d5b138b47fba446282" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-47095985ccd84fd49165d5854bbda0af" source="id-143ca1ce20d2492caf819e0787d23823" target="id-a9ed7174af0548d5b138b47fba446282" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-6f9d014c9eeb44aba2a3f468e1f09c7d" source="id-3bfc5d5eae14479aa57922a2f99ab3d6" target="id-5903ad80d51e413dab64159cdf1f6fd0" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-ff93f89996444d5e96d293c778a769e5" source="id-143ca1ce20d2492caf819e0787d23823" target="id-02c0f4e1301f46cfbf2453b11e1c6de0" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-8934907edada473fa5878d326d9a47d1" source="id-e54ac98461364b6f89be0d7ce49996b0" target="id-0cc3e6f3dca340b58f7b177619936176" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-25649e1af41945b4b77cda1050fa9904" source="id-3d3294e5d139473e965cacb7ad9e4e7f" target="id-5903ad80d51e413dab64159cdf1f6fd0" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-ac83455bf9384f09b5dfb7d04f8d5d4d" source="id-3d3294e5d139473e965cacb7ad9e4e7f" target="id-02c0f4e1301f46cfbf2453b11e1c6de0" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-444656e2076d467c96a713b0a58a058f" source="id-3d3294e5d139473e965cacb7ad9e4e7f" target="id-0cc3e6f3dca340b58f7b177619936176" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-d155f8d0a8e84fb6b20de1e991a7e56d" source="id-3d3294e5d139473e965cacb7ad9e4e7f" target="id-169ba8405759474db2179d246f01216d" xsi:type="Assignment" />
+    <relationship identifier="id-fb0e9ab738a840a69b6711d3ed7e7725" source="id-23d2166d570f40bdad1417d39f10373f" target="id-809e6563310c4e15b7697fa525023abf" xsi:type="Assignment" />
+    <relationship identifier="id-b9257449c58a4d5e868cc2142dd128c7" source="id-3bfc5d5eae14479aa57922a2f99ab3d6" target="id-23d2166d570f40bdad1417d39f10373f" xsi:type="Association" />
+    <relationship identifier="id-a5b2a14f9da845529fa6a4cc6e589e71" source="id-3d3294e5d139473e965cacb7ad9e4e7f" target="id-23d2166d570f40bdad1417d39f10373f" xsi:type="Association" />
+    <relationship identifier="id-6816b6a7ed46492a87251d726ec06d7a" source="id-3d3294e5d139473e965cacb7ad9e4e7f" target="id-4364086f4188452084a6168dcbd7b186" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-a5beea4740974139825a59c15b6d8dfa" source="id-9d1d0adbfe2c43cba2db422b4ca184cc" target="id-4364086f4188452084a6168dcbd7b186" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-b063cacf85f6455f915ba818b5dda91d" source="id-9d1d0adbfe2c43cba2db422b4ca184cc" target="id-cf389c783061458f822a388324e89b09" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-4657a2510445450fb2a5a8f28e4c8e33" source="id-9d1d0adbfe2c43cba2db422b4ca184cc" target="id-1d8b234a0add4fdca68c71514f32e981" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-8c2a1aee70be437bb9e08b17947d781d" source="id-9d1d0adbfe2c43cba2db422b4ca184cc" target="id-e36661dac4014c0bb54cc138c8af5485" xsi:type="Assignment" />
+    <relationship identifier="id-2b4fc33da23c481b9f315c3b3802eb0e" source="id-9d1d0adbfe2c43cba2db422b4ca184cc" target="id-64a3c89d49ff447f9dab07ddcaf002ec" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-69b7bdfe1fe947c092947aa785e55822" source="id-2ce4621d4a164842b29cce506cde7a68" target="id-64a3c89d49ff447f9dab07ddcaf002ec" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-92b485ef57bb4833baa3de4f30d3cf93" source="id-2ce4621d4a164842b29cce506cde7a68" target="id-493d8b255dcd4c249087ff7e85f0f16a" xsi:type="Assignment" />
+    <relationship identifier="id-63a47bfb8a6c4976b0cf9b05737ab7b6" source="id-9d3639bc0b2c46deafc67db505ca796b" target="id-10b667b736514a2da297f4dea0a14645" xsi:type="Composition" />
+    <relationship identifier="id-382ff4a3c8e34fb6922341e6d713e425" source="id-9d3639bc0b2c46deafc67db505ca796b" target="id-131c1792801b40a49a9041661dec5ed8" xsi:type="Composition" />
+    <relationship identifier="id-db7373bcc3314ebbb731ef7e07d26388" source="id-2ce4621d4a164842b29cce506cde7a68" target="id-131c1792801b40a49a9041661dec5ed8" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-39e52a103c804df8a13a9340ae3012db" source="id-8b9b1e49a27848f68fea836a25a610d6" target="id-131c1792801b40a49a9041661dec5ed8" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-73f64dea1cb446d197c2196ecb8e38e3" source="id-8b9b1e49a27848f68fea836a25a610d6" target="id-868a037328914ca79d43352cdccc890f" xsi:type="Assignment" />
+    <relationship identifier="id-e742d45767a04a99a009bf800315f50f" source="id-9d1d0adbfe2c43cba2db422b4ca184cc" target="id-23d2166d570f40bdad1417d39f10373f" xsi:type="Association" />
+    <relationship identifier="id-8aa225cf93f945b790e82a0dacf6a2c0" source="id-2ce4621d4a164842b29cce506cde7a68" target="id-23d2166d570f40bdad1417d39f10373f" xsi:type="Association" />
+    <relationship identifier="id-e645861dcfa348e4908b38a236f7c987" source="id-8b9b1e49a27848f68fea836a25a610d6" target="id-23d2166d570f40bdad1417d39f10373f" xsi:type="Association" />
+    <relationship identifier="id-57ef78b12639485391ba16c6f77a23a8" source="id-2ce4621d4a164842b29cce506cde7a68" target="id-7d3aa9ac0b804060a502de4b8ad537fc" xsi:type="Composition" />
+    <relationship identifier="id-e3360c30fe79439aad031c4ab0179f73" source="id-dc154c48f080459ca6e29d7f1edaf050" target="id-64e12c6aa1954c6486e01bda92a18d82" xsi:type="Flow">
+      <name xml:lang="es">monitor</name>
+    </relationship>
+    <relationship identifier="id-77d3c7ec3c7d40b792c69a7e77fc05fc" source="id-64e12c6aa1954c6486e01bda92a18d82" target="id-dc154c48f080459ca6e29d7f1edaf050" xsi:type="Flow">
+      <name xml:lang="es">control</name>
+    </relationship>
+    <relationship identifier="id-059ee2d9df774b37a6cf5f3781474078" source="id-7d3aa9ac0b804060a502de4b8ad537fc" target="id-64e12c6aa1954c6486e01bda92a18d82" xsi:type="Composition" />
+    <relationship identifier="id-56006141b9f84774bf187017b6b4bbfd" source="id-7d3aa9ac0b804060a502de4b8ad537fc" target="id-dc154c48f080459ca6e29d7f1edaf050" xsi:type="Composition" />
+    <relationship identifier="id-fe5b1c1a7b7b4feb8c332646fb491054" source="id-985c644ebbe343c5a32fc36353e0535d" target="id-fcb1db6aa783410aa3856df684699fd3" xsi:type="Association" />
+    <relationship identifier="id-ffd2cd9166134f5696a00d225c52da64" source="id-41f712023d8b4f9babb41249355dfc7b" target="id-fcb1db6aa783410aa3856df684699fd3" xsi:type="Association" />
+    <relationship identifier="id-0348cd1eb1584e9b8c3e227e3ac1e452" source="id-4c52d1762cb8468c92950f0bc509e045" target="id-985c644ebbe343c5a32fc36353e0535d" xsi:type="Association" />
+    <relationship identifier="id-19d3440bf3644351a243e4643a1a10d8" source="id-e929318a3ae441ba9dd96b8d4623557a" target="id-985c644ebbe343c5a32fc36353e0535d" xsi:type="Association" />
+    <relationship identifier="id-d3469f3809b4441d942adf3ef2741833" source="id-e929318a3ae441ba9dd96b8d4623557a" target="id-41f712023d8b4f9babb41249355dfc7b" xsi:type="Association" />
+    <relationship identifier="id-7669e65ab1034b6d878df79babb655a5" source="id-773494ddbf30427a8218ff76abbe0d5f" target="id-4c52d1762cb8468c92950f0bc509e045" xsi:type="Influence" />
+    <relationship identifier="id-ba744d730a164cf0b0c5719100b2569c" source="id-73a045146ae94517bca67365cd206c1a" target="id-4c52d1762cb8468c92950f0bc509e045" xsi:type="Influence" />
+    <relationship identifier="id-7b538a04c895462c9ccf34c555b3fcbc" source="id-bf3da697d4314f33bcb03ae7ed84d665" target="id-4c52d1762cb8468c92950f0bc509e045" xsi:type="Influence" />
+    <relationship identifier="id-3b75b3117c164ed78c02b13d9d72f03b" source="id-bf3da697d4314f33bcb03ae7ed84d665" target="id-e929318a3ae441ba9dd96b8d4623557a" xsi:type="Influence" />
+    <relationship identifier="id-3bda25cdcd914997bcfbce7508a2b52f" source="id-41f712023d8b4f9babb41249355dfc7b" target="id-8939bfb16933425c952bd4ca553d90e2" xsi:type="Association" />
+    <relationship identifier="id-5e4ced2c083341aaa1d43e43cc386f59" source="id-1008ebfba144417f8e8a58e889c3b9c6" target="id-fcb1db6aa783410aa3856df684699fd3" xsi:type="Association" />
+    <relationship identifier="id-29cf98286e404826813e3fd5d363faa4" source="id-1008ebfba144417f8e8a58e889c3b9c6" target="id-8939bfb16933425c952bd4ca553d90e2" xsi:type="Association" />
+    <relationship identifier="id-edbfed03abca46d0b0fa9f301af49848" source="id-70189a83837444a798183ae73a7bc5b2" target="id-1008ebfba144417f8e8a58e889c3b9c6" xsi:type="Association" />
+    <relationship identifier="id-284558569ac940e1a5b0e3000096850f" source="id-db9483ab0a3b4f1eb7259e53426eee09" target="id-1008ebfba144417f8e8a58e889c3b9c6" xsi:type="Association" />
+    <relationship identifier="id-a2a0c2f582964d98ae5e90d434018f18" source="id-26dae395ffb343dcbb3a410b88d3021d" target="id-70189a83837444a798183ae73a7bc5b2" xsi:type="Association" />
+    <relationship identifier="id-30522f5fa02146338ce89262dba83fb5" source="id-b9d676d91e5e40ebaa9338c0e87463bf" target="id-70189a83837444a798183ae73a7bc5b2" xsi:type="Association" />
+    <relationship identifier="id-02ed4c260f494d798413cd888ed9a225" source="id-a0f64c7e0e3b43c6a9ea32a9b35e99eb" target="id-db9483ab0a3b4f1eb7259e53426eee09" xsi:type="Association" />
+    <relationship identifier="id-52fd056560dc472a9e3437d3fecd4bbc" source="id-d57beba0aeca4d5884d9f79cee2cacad" target="id-db9483ab0a3b4f1eb7259e53426eee09" xsi:type="Association" />
+    <relationship identifier="id-c2bea22fcc67491e8f94e92c284a6ffe" source="id-d57beba0aeca4d5884d9f79cee2cacad" target="id-26dae395ffb343dcbb3a410b88d3021d" xsi:type="Association" />
+    <relationship identifier="id-13604f57255f42d2aba9fa1285d8425f" source="id-f19bc7ea65c94679b97db1774cb2ef34" target="id-26dae395ffb343dcbb3a410b88d3021d" xsi:type="Association" />
+    <relationship identifier="id-8bb3d6c2686a47bea3048439d73a7961" source="id-4b6a9ff03a9b4b1689350806c022f681" target="id-f19bc7ea65c94679b97db1774cb2ef34" xsi:type="Realization" />
+    <relationship identifier="id-6bc9b8fd5f864ec1b28f44033ab4bc34" source="id-4b6a9ff03a9b4b1689350806c022f681" target="id-d57beba0aeca4d5884d9f79cee2cacad" xsi:type="Realization" />
+    <relationship identifier="id-e18e110381a244d9b7ca1213c59aaa3a" source="id-4b6a9ff03a9b4b1689350806c022f681" target="id-a0f64c7e0e3b43c6a9ea32a9b35e99eb" xsi:type="Realization" />
+    <relationship identifier="id-46c475168f184342aff3386fa1a409f8" source="id-4b6a9ff03a9b4b1689350806c022f681" target="id-9960fb227da24f57b727e05fd81a7739" xsi:type="Aggregation" />
+    <relationship identifier="id-0c9b384a0f314c48bd6fd49c1a23367d" source="id-e73fde26e4094a1c9f97edfb48139287" target="id-1a7757e999c54d6085462db7df22a296" xsi:type="Serving" />
+    <relationship identifier="id-ccec811b82164a469276ca27701eb708" source="id-c35cc8ce1a73415080bf804d76727b72" target="id-e73fde26e4094a1c9f97edfb48139287" xsi:type="Realization" />
+    <relationship identifier="id-d637c518c2804e4bbf700a2a00cea06e" source="id-c35cc8ce1a73415080bf804d76727b72" target="id-15b84bcdf6374633b8225b636f14f140" xsi:type="Composition" />
+    <relationship identifier="id-f8c2d334855e42aea1b8b3dddfae3511" source="id-c35cc8ce1a73415080bf804d76727b72" target="id-9341d876214745edb68cdc91b7b8ffe7" xsi:type="Composition" />
+    <relationship identifier="id-4aeb5830e5be44a59f41e38852b51e10" source="id-c35cc8ce1a73415080bf804d76727b72" target="id-a6992b23c09c44dba47e8e06ad7655c5" xsi:type="Composition" />
+    <relationship identifier="id-bcb70aebfdf34d72ad32102c1edff687" source="id-c35cc8ce1a73415080bf804d76727b72" target="id-bb08ebde1b25412bb52d9e4d35afa404" xsi:type="Composition" />
+    <relationship identifier="id-d6ae7cd1b2014e8f8b9d0b0d38c41c60" source="id-c35cc8ce1a73415080bf804d76727b72" target="id-04e04b7fccd14a7a88229604fccc7a86" xsi:type="Composition" />
+    <relationship identifier="id-dcee7b146bd64c8b80fbb6460181cf41" source="id-c35cc8ce1a73415080bf804d76727b72" target="id-ec198d6b44094aea97ee9bb93659c30d" xsi:type="Composition" />
+    <relationship identifier="id-86bc53efc09a4d01b5d863ea4da169a1" source="id-50fbcd5489444693bcbc3efe86d1df80" target="id-a6992b23c09c44dba47e8e06ad7655c5" xsi:type="Association" />
+    <relationship identifier="id-dbfb1e8203a64297b4b46862578575d1" source="id-d95e1aa70fcd4c8bba40177204ebca8d" target="id-bb08ebde1b25412bb52d9e4d35afa404" xsi:type="Association" />
+    <relationship identifier="id-6213dcf0f30b45409a2b720997924d23" source="id-c8586b2db2314b17852d6e100b1c633f" target="id-3c646c52bc8e45cfafa3b767bb3af35f" xsi:type="Composition" />
+    <relationship identifier="id-bd55ed3c11c1404e8d577f749890f91f" source="id-c8586b2db2314b17852d6e100b1c633f" target="id-17ef9d3c310b4a5aa7463cd6d85db619" xsi:type="Composition" />
+    <relationship identifier="id-9e1687fda55a4ad3ae72f552ab81fa35" source="id-c8586b2db2314b17852d6e100b1c633f" target="id-d1edd2e27b3c48f0b4753883ba9ef65f" xsi:type="Composition" />
+    <relationship identifier="id-8ab746b84c13420787ea6833f3f740ef" source="id-c8586b2db2314b17852d6e100b1c633f" target="id-389fa5299bd54976a7e31306656cbb42" xsi:type="Composition" />
+    <relationship identifier="id-73834b75835342c0852e918d323d1b4b" source="id-c35cc8ce1a73415080bf804d76727b72" target="id-c8586b2db2314b17852d6e100b1c633f" xsi:type="Access" accessType="Access" />
+    <relationship identifier="id-b3157f38393e4f3d91a6a7c006c87b44" source="id-b184c5661a354a80a26061333635c927" target="id-fde9a2a74e544857bcdcd5c127214475" xsi:type="Composition" />
+    <relationship identifier="id-e90321392fce4177b7d95e581a45fac6" source="id-b184c5661a354a80a26061333635c927" target="id-d970cdcf5ac247698017f1e9732e2a07" xsi:type="Composition" />
+    <relationship identifier="id-5bc5b1f4ab2a4ca59d7b576654d10be3" source="id-b184c5661a354a80a26061333635c927" target="id-b42e8f45867b487ca2ccd136ebfafde7" xsi:type="Composition" />
+    <relationship identifier="id-5199875c53ef4161be35819c68faee1b" source="id-b184c5661a354a80a26061333635c927" target="id-b56b5c461fc94c06b00ed6d33955fcb2" xsi:type="Composition" />
+    <relationship identifier="id-e7b2e1e8377d4a62988ec81702d8f805" source="id-b184c5661a354a80a26061333635c927" target="id-e59bb5647dc6486c8ea1d08b67c19bc1" xsi:type="Composition" />
+    <relationship identifier="id-69ffc5d95d864033870d64dd6f2cd029" source="id-b184c5661a354a80a26061333635c927" target="id-0bed0f0876c6428fa25879de80d47208" xsi:type="Composition" />
+    <relationship identifier="id-1cc784cdeb4748e0a841245b478cdbe9" source="id-c35cc8ce1a73415080bf804d76727b72" target="id-b184c5661a354a80a26061333635c927" xsi:type="Access" accessType="Access" />
+    <relationship identifier="id-7128fc52b41645f2883190e4afd5803a" source="id-9a865b3c106b4c5cb4800029ac3d54a7" target="id-5c6ae3c285034247837fe4118e5c76d9" xsi:type="Composition" />
+    <relationship identifier="id-3a583934bb6e4b35a95ffd55de3f0b3d" source="id-9a865b3c106b4c5cb4800029ac3d54a7" target="id-226179e7cbaa4a919383bdd4e44b41dc" xsi:type="Composition" />
+    <relationship identifier="id-c214b5cca9994a1e8588c4108eccac9a" source="id-9a865b3c106b4c5cb4800029ac3d54a7" target="id-a4e2426aa6344ff49a4d9f5a22b67ad9" xsi:type="Composition" />
+    <relationship identifier="id-8f8860b230a54eb3875dc5396b9d361f" source="id-9a865b3c106b4c5cb4800029ac3d54a7" target="id-72854cd1e4ff40a1bdf77773165e2bdc" xsi:type="Composition" />
+    <relationship identifier="id-118f040562a4476087aa2fe88f8631b1" source="id-9a865b3c106b4c5cb4800029ac3d54a7" target="id-ba8ce89c442d457c845d849f2ba0b8e5" xsi:type="Composition" />
+    <relationship identifier="id-c54f7e7ec880417881622de16ae01249" source="id-9a865b3c106b4c5cb4800029ac3d54a7" target="id-99bc4a3c85954400915f6e7433440cb0" xsi:type="Composition" />
+    <relationship identifier="id-8b57d961a22f4ee7a37280bcf0605c3b" source="id-9a865b3c106b4c5cb4800029ac3d54a7" target="id-2dbbbff37e7644338f16ac2fbf784265" xsi:type="Composition" />
+    <relationship identifier="id-4355814ad2bd40fa8e7bf2b06e237f9b" source="id-9a865b3c106b4c5cb4800029ac3d54a7" target="id-e9a3e42545534d519a9221494e2afb44" xsi:type="Composition" />
+    <relationship identifier="id-09d464beef544058aa2967e77f4436ba" source="id-9a865b3c106b4c5cb4800029ac3d54a7" target="id-c35cc8ce1a73415080bf804d76727b72" xsi:type="Serving" />
+    <relationship identifier="id-614ca33606b04853b992a8370c914142" source="id-3237b47e6ecc442b87d63a2c0ff8077c" target="id-9a865b3c106b4c5cb4800029ac3d54a7" xsi:type="Realization" />
+    <relationship identifier="id-7856a54511f24730a8d64f4147c5ea4c" source="id-2a8eb6786915456d92df41a8b9349314" target="id-4e06ee45db904a88aa46e9dce611528e" xsi:type="Association" />
+    <relationship identifier="id-cfa2c2b556254127b249c4ab0c58e425" source="id-c728f7f622be468380062354ffbf4f57" target="id-4e06ee45db904a88aa46e9dce611528e" xsi:type="Association" />
+    <relationship identifier="id-9ccfdf80797d431b8b281efbe4bb6753" source="id-3237b47e6ecc442b87d63a2c0ff8077c" target="id-4e06ee45db904a88aa46e9dce611528e" xsi:type="Composition" />
+    <relationship identifier="id-4bfc7945edb744ac9f74fe9621726447" source="id-3237b47e6ecc442b87d63a2c0ff8077c" target="id-c728f7f622be468380062354ffbf4f57" xsi:type="Composition" />
+    <relationship identifier="id-6c4dbbfad1be42b6b9a8c4f81556cb43" source="id-3237b47e6ecc442b87d63a2c0ff8077c" target="id-2a8eb6786915456d92df41a8b9349314" xsi:type="Composition" />
+    <relationship identifier="id-bce367c94f9c417791e8bb987f220248" source="id-4e06ee45db904a88aa46e9dce611528e" target="id-300c7dd906cb45b4b0b8e6bb0828221f" xsi:type="Access" accessType="Access" />
+    <relationship identifier="id-9b86b5def09747ccba106869f577267b" source="id-300c7dd906cb45b4b0b8e6bb0828221f" target="id-b184c5661a354a80a26061333635c927" xsi:type="Realization" />
+    <relationship identifier="id-fb680925b6944ad49547daeb63178de8" source="id-300c7dd906cb45b4b0b8e6bb0828221f" target="id-c8586b2db2314b17852d6e100b1c633f" xsi:type="Realization" />
+    <relationship identifier="id-8b5f76ead5464ebdace7dd4ffaacae91" source="id-d02d8886a7934dc898143a97a8376606" target="id-1a7757e999c54d6085462db7df22a296" xsi:type="Serving" />
+    <relationship identifier="id-854eab2f9d8446708ff00fc216fd026e" source="id-cbc5896e78284e23b5bbca5e9a15dc76" target="id-1a7757e999c54d6085462db7df22a296" xsi:type="Serving" />
+    <relationship identifier="id-8e1e118effae4e4abbb7307191a4b76f" source="id-633f46a9f9f84bbda07115037faf71eb" target="id-1a7757e999c54d6085462db7df22a296" xsi:type="Serving" />
+    <relationship identifier="id-26a00b70891e43dd8e23d2386956d1c5" source="id-c160bb04a89643a880d79a2dce37bd38" target="id-1a7757e999c54d6085462db7df22a296" xsi:type="Serving" />
+    <relationship identifier="id-eafcc2e35d494c069d65233cc5431572" source="id-73d6be570bd344aeb933d06b9566af35" target="id-1a7757e999c54d6085462db7df22a296" xsi:type="Serving" />
+    <relationship identifier="id-3037bdfa443f472588e0f4233a423eec" source="id-3bc7d428ccea48739c4d442f9f2364e7" target="id-eb6681ab4dd94ce3996ade5875bdf3ef" xsi:type="Assignment" />
+    <relationship identifier="id-2d8ad9219a084314b9f6b34f0bbcb2ab" source="id-3bc7d428ccea48739c4d442f9f2364e7" target="id-56a4ef970d314200bc4e95d8ea928093" xsi:type="Assignment" />
+    <relationship identifier="id-ade5af23ad054833950877e5d28a9743" source="id-3bc7d428ccea48739c4d442f9f2364e7" target="id-b7900be563de46529b9fc8d1975b2b37" xsi:type="Assignment" />
+    <relationship identifier="id-026d56fafee84728936bb106a423b4b5" source="id-3bc7d428ccea48739c4d442f9f2364e7" target="id-8584078cf77640869fc4b4ff7a60d00d" xsi:type="Assignment" />
+    <relationship identifier="id-d9dd6f2624c94bd5be7bdebe95037219" source="id-3bc7d428ccea48739c4d442f9f2364e7" target="id-103caa122d7e4d63a5b6479756634453" xsi:type="Assignment" />
+    <relationship identifier="id-dcc7e7bbdea2449fb76e4ce82ff7131d" source="id-8584078cf77640869fc4b4ff7a60d00d" target="id-d02d8886a7934dc898143a97a8376606" xsi:type="Realization" />
+    <relationship identifier="id-ddf77800e82040caa3ab3ae7f93da8ae" source="id-103caa122d7e4d63a5b6479756634453" target="id-cbc5896e78284e23b5bbca5e9a15dc76" xsi:type="Realization" />
+    <relationship identifier="id-8b40148638df402990222b414ed12358" source="id-b7900be563de46529b9fc8d1975b2b37" target="id-633f46a9f9f84bbda07115037faf71eb" xsi:type="Realization" />
+    <relationship identifier="id-b2f6b889474f475d9e537bc7767dc572" source="id-eb6681ab4dd94ce3996ade5875bdf3ef" target="id-c160bb04a89643a880d79a2dce37bd38" xsi:type="Realization" />
+    <relationship identifier="id-6e814dc25573414a8051b8d98d9ea3cb" source="id-56a4ef970d314200bc4e95d8ea928093" target="id-73d6be570bd344aeb933d06b9566af35" xsi:type="Realization" />
+    <relationship identifier="id-4e2b77700d624c3fa6193891741156ac" source="id-eb6681ab4dd94ce3996ade5875bdf3ef" target="id-8c910863999445c0b2afceb98acbefff" xsi:type="Flow" />
+    <relationship identifier="id-dbbe3f8f66224ef292695f41c4ee60b1" source="id-8c910863999445c0b2afceb98acbefff" target="id-b7900be563de46529b9fc8d1975b2b37" xsi:type="Flow" />
+    <relationship identifier="id-68dd5f1df64840cd82fc19f574db7884" source="id-3bc7d428ccea48739c4d442f9f2364e7" target="id-8c910863999445c0b2afceb98acbefff" xsi:type="Assignment" />
+    <relationship identifier="id-906ff6c00cce4a389d7c02c541a49522" source="id-5f7aebddd3ad4a0593301978fca34bab" target="id-56a4ef970d314200bc4e95d8ea928093" xsi:type="Serving" />
+    <relationship identifier="id-696a146fe7a44bdd88efd1608dd5df47" source="id-5f7aebddd3ad4a0593301978fca34bab" target="id-eb6681ab4dd94ce3996ade5875bdf3ef" xsi:type="Serving" />
+    <relationship identifier="id-99890b62ab614616971459f19ef22402" source="id-8c910863999445c0b2afceb98acbefff" target="id-f4676bc1d45f43e89921d3e0303037b1" xsi:type="Flow" />
+    <relationship identifier="id-ea7c8a97872a444dbea31e97b5a1d422" source="id-f4676bc1d45f43e89921d3e0303037b1" target="id-8c910863999445c0b2afceb98acbefff" xsi:type="Flow" />
+    <relationship identifier="id-7aa6c18eab5943e7ae0816a82cec4e51" source="id-86d6a2f695b74347a264354315c8656f" target="id-5f7aebddd3ad4a0593301978fca34bab" xsi:type="Assignment" />
+    <relationship identifier="id-7adc30f47d424be187ad7fb51fa8aa26" source="id-ca35f8df80974169b04c1ffd58c12493" target="id-f4676bc1d45f43e89921d3e0303037b1" xsi:type="Assignment" />
+    <relationship identifier="id-eff762786a4b434eb1ed3dd4919029cb" source="id-86d6a2f695b74347a264354315c8656f" target="id-15b84bcdf6374633b8225b636f14f140" xsi:type="Assignment" />
+    <relationship identifier="id-2fe6cb0e31bd45eb864c7535e83b4bb1" source="id-3bc7d428ccea48739c4d442f9f2364e7" target="id-6bb84a70a70c4899963d5370b82d42af" xsi:type="Assignment" />
+    <relationship identifier="id-eafe2f0467a1431e901f1d13b97e4520" source="id-3bc7d428ccea48739c4d442f9f2364e7" target="id-eb2a8dd22fad4020b70d683b9adf85bc" xsi:type="Assignment" />
+    <relationship identifier="id-0eea1d6636e74768bb3c6dab3f89c637" source="id-3bc7d428ccea48739c4d442f9f2364e7" target="id-94aed85cd04d4960b53f9db553d91e1c" xsi:type="Assignment" />
+    <relationship identifier="id-3ffcda1623f6414d8d809df41bf4da82" source="id-3bc7d428ccea48739c4d442f9f2364e7" target="id-d4ae5cd23a3f4c04b5778446859595ab" xsi:type="Assignment" />
+    <relationship identifier="id-b8b461839ac14b09877660b5c0c957d3" source="id-ca35f8df80974169b04c1ffd58c12493" target="id-5fb09df777514d79afbec30bf3a49c72" xsi:type="Assignment" />
+    <relationship identifier="id-14ac215f81554bccb60dd834079eee55" source="id-ca35f8df80974169b04c1ffd58c12493" target="id-ec198d6b44094aea97ee9bb93659c30d" xsi:type="Assignment" />
+    <relationship identifier="id-f595dcb5bcf94d3e82371435f0a7edaf" source="id-1a7757e999c54d6085462db7df22a296" target="id-eb2a8dd22fad4020b70d683b9adf85bc" xsi:type="Flow">
+      <name xml:lang="es">Inquiry</name>
+    </relationship>
+    <relationship identifier="id-b35f3d1831e64f798ebe5fba8cbe9f34" source="id-eb2a8dd22fad4020b70d683b9adf85bc" target="id-1a7757e999c54d6085462db7df22a296" xsi:type="Flow">
+      <name xml:lang="es">Contract</name>
+    </relationship>
+    <relationship identifier="id-4bb031dc79024a6eb809db3c2a9de992" source="id-1a7757e999c54d6085462db7df22a296" target="id-d4ae5cd23a3f4c04b5778446859595ab" xsi:type="Flow">
+      <name xml:lang="es">Order</name>
+    </relationship>
+    <relationship identifier="id-5e030eac9d3d4341a4a07a7dd9947f83" source="id-d4ae5cd23a3f4c04b5778446859595ab" target="id-1a7757e999c54d6085462db7df22a296" xsi:type="Flow">
+      <name xml:lang="es">Offer</name>
+    </relationship>
+    <relationship identifier="id-66c6765e590b4e7ebc371e58cf171fdc" source="id-d4ae5cd23a3f4c04b5778446859595ab" target="id-1a7757e999c54d6085462db7df22a296" xsi:type="Flow">
+      <name xml:lang="es">Order Info</name>
+    </relationship>
+    <relationship identifier="id-eca59d66cde04c79b993f01a19723007" source="id-d4ae5cd23a3f4c04b5778446859595ab" target="id-1a7757e999c54d6085462db7df22a296" xsi:type="Flow">
+      <name xml:lang="es">Invoice</name>
+    </relationship>
+    <relationship identifier="id-e81da98bf225425d88569aeb05ee2f25" source="id-d4ae5cd23a3f4c04b5778446859595ab" target="id-eb2a8dd22fad4020b70d683b9adf85bc" xsi:type="Flow">
+      <name xml:lang="es">Cust. Exposure Req.</name>
+    </relationship>
+    <relationship identifier="id-35b554c3967343c8ad3256f6f128db1e" source="id-eb2a8dd22fad4020b70d683b9adf85bc" target="id-d4ae5cd23a3f4c04b5778446859595ab" xsi:type="Flow">
+      <name xml:lang="es">Order Assessment</name>
+    </relationship>
+    <relationship identifier="id-c4ed64b53e3f46d098ef73b1e6e581fc" source="id-d4ae5cd23a3f4c04b5778446859595ab" target="id-ec198d6b44094aea97ee9bb93659c30d" xsi:type="Flow">
+      <name xml:lang="es">Aggregate Order</name>
+    </relationship>
+    <relationship identifier="id-ff096bd70c66467a9932402893dac1b7" source="id-ec198d6b44094aea97ee9bb93659c30d" target="id-d4ae5cd23a3f4c04b5778446859595ab" xsi:type="Flow">
+      <name xml:lang="es">Aggregate Order Info</name>
+    </relationship>
+    <relationship identifier="id-fc28e7aaa8814b3ca8a199e3e59f7cc1" source="id-eb2a8dd22fad4020b70d683b9adf85bc" target="id-15b84bcdf6374633b8225b636f14f140" xsi:type="Flow">
+      <name xml:lang="es">Customer Credit Analysis Request</name>
+    </relationship>
+    <relationship identifier="id-def095d2db5a421db8128235714397f9" source="id-15b84bcdf6374633b8225b636f14f140" target="id-eb2a8dd22fad4020b70d683b9adf85bc" xsi:type="Flow">
+      <name xml:lang="es">Customer Credit Assessment</name>
+    </relationship>
+    <relationship identifier="id-46552ee6a0794c8880f5d3da74a0c89a" source="id-d4ae5cd23a3f4c04b5778446859595ab" target="id-6bb84a70a70c4899963d5370b82d42af" xsi:type="Flow">
+      <name xml:lang="es">Invoice</name>
+    </relationship>
+    <relationship identifier="id-59364b03590d4e65beb4a8adf80f3dd0" source="id-d4ae5cd23a3f4c04b5778446859595ab" target="id-94aed85cd04d4960b53f9db553d91e1c" xsi:type="Flow">
+      <name xml:lang="es">Shipping Order</name>
+    </relationship>
+    <relationship identifier="id-aeb98da82ca84aa1850ad53e48b04c63" source="id-94aed85cd04d4960b53f9db553d91e1c" target="id-d4ae5cd23a3f4c04b5778446859595ab" xsi:type="Flow">
+      <name xml:lang="es">GDN</name>
+    </relationship>
+    <relationship identifier="id-5285a85c637b4248b5f26de5cbaa0690" source="id-94aed85cd04d4960b53f9db553d91e1c" target="id-1a7757e999c54d6085462db7df22a296" xsi:type="Flow">
+      <name xml:lang="es">Delivery Notification</name>
+    </relationship>
+    <relationship identifier="id-8c023a9ee9704765876cd47005b454e9" source="id-1a7757e999c54d6085462db7df22a296" target="id-94aed85cd04d4960b53f9db553d91e1c" xsi:type="Flow">
+      <name xml:lang="es">Delivery Confirmation</name>
+    </relationship>
+    <relationship identifier="id-017b10c34d5747078797cb271805ea1a" source="id-ec198d6b44094aea97ee9bb93659c30d" target="id-a6992b23c09c44dba47e8e06ad7655c5" xsi:type="Flow">
+      <name xml:lang="es">Shipping Order</name>
+    </relationship>
+    <relationship identifier="id-a54cb72d96ed4ed185541b210e4643d4" source="id-a6992b23c09c44dba47e8e06ad7655c5" target="id-ec198d6b44094aea97ee9bb93659c30d" xsi:type="Flow">
+      <name xml:lang="es">GDN</name>
+    </relationship>
+    <relationship identifier="id-c3f3310108d0446e828a199e8c1e1287" source="id-ec198d6b44094aea97ee9bb93659c30d" target="id-bb08ebde1b25412bb52d9e4d35afa404" xsi:type="Flow">
+      <name xml:lang="es">Production Order</name>
+    </relationship>
+    <relationship identifier="id-40c9de0556634b378770e2d0e82e6321" source="id-bb08ebde1b25412bb52d9e4d35afa404" target="id-a6992b23c09c44dba47e8e06ad7655c5" xsi:type="Flow">
+      <name xml:lang="es">Final Products</name>
+    </relationship>
+    <relationship identifier="id-1a29fe0e1b4c4331877702f33268999d" source="id-5fb09df777514d79afbec30bf3a49c72" target="id-bb08ebde1b25412bb52d9e4d35afa404" xsi:type="Flow">
+      <name xml:lang="es">Raw Materials</name>
+    </relationship>
+    <relationship identifier="id-4c8fd7a27e75437db169d1e84a083ffc" source="id-c728f7f622be468380062354ffbf4f57" target="id-df71ee7baba64cfbb35bcd00ed36040c" xsi:type="Composition" />
+    <relationship identifier="id-e6fb41e9b92c4c519a30cd42c432dc08" source="id-c728f7f622be468380062354ffbf4f57" target="id-a9c72e1cb5344e3ab7a8a7bc8271776d" xsi:type="Composition" />
+    <relationship identifier="id-ff14d959f7d44dd0962777a0deaab52b" source="id-c728f7f622be468380062354ffbf4f57" target="id-927db0f85d244a08b92e4925eb053d2b" xsi:type="Composition" />
+    <relationship identifier="id-43eccc3c162e4e89a85c0da3d7140a5d" source="id-c728f7f622be468380062354ffbf4f57" target="id-2eec1a4a343142c09574a74d773e2224" xsi:type="Composition" />
+    <relationship identifier="id-7cf01db640a545c28862f6bd64dfe7d4" source="id-8b75218115db49b9aecd0501d04d5545" target="id-c728f7f622be468380062354ffbf4f57" xsi:type="Composition" />
+    <relationship identifier="id-a95c505e2e6a4d33897292a5ac05cefe" source="id-8b75218115db49b9aecd0501d04d5545" target="id-5538d8de4e6c4918a62221922988c957" xsi:type="Composition" />
+    <relationship identifier="id-a5ca972c87a1493c969ab24a5404318f" source="id-5538d8de4e6c4918a62221922988c957" target="id-c728f7f622be468380062354ffbf4f57" xsi:type="Flow" />
+    <relationship identifier="id-2523d00aed2d4d008634b25bde995ecb" source="id-c728f7f622be468380062354ffbf4f57" target="id-5538d8de4e6c4918a62221922988c957" xsi:type="Flow" />
+    <relationship identifier="id-f22939f7189241ba95869a943b8cd0bb" source="id-8b75218115db49b9aecd0501d04d5545" target="id-68903f066cfc4959a4e940405e47f6cd" xsi:type="Composition" />
+    <relationship identifier="id-fcf8aded662049e0b93b0d62962f2f21" source="id-8b75218115db49b9aecd0501d04d5545" target="id-970722b900b14871becf437967275425" xsi:type="Composition" />
+    <relationship identifier="id-b090dec397394ef681f15c3f519e817b" source="id-8b75218115db49b9aecd0501d04d5545" target="id-132442dad80345129362408c87cdde9b" xsi:type="Composition" />
+    <relationship identifier="id-6422d873eda848ba91f09508ef4f72d8" source="id-8b75218115db49b9aecd0501d04d5545" target="id-641d335281ca4b53932f250e695f1f94" xsi:type="Composition" />
+    <relationship identifier="id-6f0221f88d5d48cf94f91a98cf8bfec1" source="id-93c74e2f4b8b4b0491164e6d79c445d6" target="id-9d0751d373ec482b925d0f28f04f6608" xsi:type="Composition" />
+    <relationship identifier="id-e4e24864e5164dfc95b8cc0ea97edbac" source="id-93c74e2f4b8b4b0491164e6d79c445d6" target="id-021e6ea0d09f433f92532777a5980497" xsi:type="Composition" />
+    <relationship identifier="id-05c70459dd8c4b809d4b5a8be8e6546f" source="id-93c74e2f4b8b4b0491164e6d79c445d6" target="id-51d42a1da36a42c2811e84ff8952cb58" xsi:type="Composition" />
+    <relationship identifier="id-b1a7b166888f45d3bf4db9f7015c5b2a" source="id-93c74e2f4b8b4b0491164e6d79c445d6" target="id-3dfec7838acb47f588677d6e8f948fd9" xsi:type="Composition" />
+    <relationship identifier="id-3a90dbb3cd9a405eb636ff541425b895" source="id-93c74e2f4b8b4b0491164e6d79c445d6" target="id-09b37e64a61d4c4183f49930d1237509" xsi:type="Composition" />
+    <relationship identifier="id-7cdcdb4b40a242a9805c7befbbc484d8" source="id-26586078852645d59ea8b14781701c65" target="id-3eb0685faebf42cfa81567c6a4e7db24" xsi:type="Composition" />
+    <relationship identifier="id-855abfcab77b4399b9124ede0c28f1c1" source="id-132442dad80345129362408c87cdde9b" target="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Flow" />
+    <relationship identifier="id-15eaf22bbd514661a6986b679bf7bb5a" source="id-b67b02752ebc4b929c9a9fc76211cff9" target="id-132442dad80345129362408c87cdde9b" xsi:type="Flow" />
+    <relationship identifier="id-33409723619341ddac60e2901c77a9a2" source="id-641d335281ca4b53932f250e695f1f94" target="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Flow" />
+    <relationship identifier="id-3cc58aba3d844d8783f78300e809ac35" source="id-b67b02752ebc4b929c9a9fc76211cff9" target="id-641d335281ca4b53932f250e695f1f94" xsi:type="Flow" />
+    <relationship identifier="id-9b2dc0367c094304acfaabf7f2f0b125" source="id-970722b900b14871becf437967275425" target="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Flow" />
+    <relationship identifier="id-e3aee34bae8247a99db2b29f555a9705" source="id-b67b02752ebc4b929c9a9fc76211cff9" target="id-970722b900b14871becf437967275425" xsi:type="Flow" />
+    <relationship identifier="id-ff325924b75446a4b25aa54d26c46f14" source="id-9d0751d373ec482b925d0f28f04f6608" target="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Flow" />
+    <relationship identifier="id-35164ebce06748cebc3847aa49ac6dae" source="id-b67b02752ebc4b929c9a9fc76211cff9" target="id-9d0751d373ec482b925d0f28f04f6608" xsi:type="Flow" />
+    <relationship identifier="id-27978db60c43457381ac9ed8885ccf91" source="id-021e6ea0d09f433f92532777a5980497" target="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Flow" />
+    <relationship identifier="id-afac10b2330b4bc8be3444b79771b569" source="id-b67b02752ebc4b929c9a9fc76211cff9" target="id-021e6ea0d09f433f92532777a5980497" xsi:type="Flow" />
+    <relationship identifier="id-7482a60e92cc4f4a8de0d8aca202cd2a" source="id-b67b02752ebc4b929c9a9fc76211cff9" target="id-09b37e64a61d4c4183f49930d1237509" xsi:type="Flow" />
+    <relationship identifier="id-669d682920734511accefa5b2cb7dd1f" source="id-09b37e64a61d4c4183f49930d1237509" target="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Flow" />
+    <relationship identifier="id-9701ef25128c4149b850331677749aa1" source="id-b67b02752ebc4b929c9a9fc76211cff9" target="id-3dfec7838acb47f588677d6e8f948fd9" xsi:type="Flow" />
+    <relationship identifier="id-8b7fdcbb1fb446b6a168bc53550a2842" source="id-3dfec7838acb47f588677d6e8f948fd9" target="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Flow" />
+    <relationship identifier="id-eb71dae724ab4a6a9fad0e61d194eb26" source="id-b67b02752ebc4b929c9a9fc76211cff9" target="id-51d42a1da36a42c2811e84ff8952cb58" xsi:type="Flow" />
+    <relationship identifier="id-ebebf195ec63472980382dab9e91ddac" source="id-51d42a1da36a42c2811e84ff8952cb58" target="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Flow" />
+    <relationship identifier="id-44f95fe75c464b19a14a81609cd421db" source="id-b67b02752ebc4b929c9a9fc76211cff9" target="id-3eb0685faebf42cfa81567c6a4e7db24" xsi:type="Flow" />
+    <relationship identifier="id-07a1defae2014e9d855c59525c19c7b7" source="id-3eb0685faebf42cfa81567c6a4e7db24" target="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Flow" />
+    <relationship identifier="id-9a48df866be44d569b3ad2db9fb24086" source="id-b67b02752ebc4b929c9a9fc76211cff9" target="id-68903f066cfc4959a4e940405e47f6cd" xsi:type="Flow" />
+    <relationship identifier="id-84d40daec2984878ba7febd33358735a" source="id-68903f066cfc4959a4e940405e47f6cd" target="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Flow" />
+    <relationship identifier="id-1cb615feba4d41df9c417602872a99ed" source="id-b67b02752ebc4b929c9a9fc76211cff9" target="id-c728f7f622be468380062354ffbf4f57" xsi:type="Flow" />
+    <relationship identifier="id-9a3a3d96c2344514b644e1fdb8cdb8c7" source="id-c728f7f622be468380062354ffbf4f57" target="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Flow" />
+    <relationship identifier="id-e6e261c583274041b176b41f25ceb8ce" source="id-094df2608dbf49078615591a945c3681" target="id-772a5d3d408142a28ab040048e09e7ff" xsi:type="Realization" />
+    <relationship identifier="id-fc55fad85ad34c889c90180ca5d0dda8" source="id-b0541156f9194546bd0922c13349649a" target="id-094df2608dbf49078615591a945c3681" xsi:type="Assignment" />
+    <relationship identifier="id-7f3129c6dcf24ccc9aff60bcc4c592d0" source="id-b0541156f9194546bd0922c13349649a" target="id-4196a1f9d7464198aad03a7a67bfc82e" xsi:type="Composition" />
+    <relationship identifier="id-34ce1e3219e64c8087d5076fe6ec0e0b" source="id-b0541156f9194546bd0922c13349649a" target="id-7eb87af87eb349d9b8a5a8b5cbad8856" xsi:type="Composition" />
+    <relationship identifier="id-412391d8896349879b8c4b54ce5757dd" source="id-9d76a90f5163422494119c99f6a908f3" target="id-6ace217c8c624d229ee2cc11528d52e4" xsi:type="Realization" />
+    <relationship identifier="id-e092d643c58a4c84a0ed9793533a7547" source="id-9d76a90f5163422494119c99f6a908f3" target="id-79c6674039c14444a51dc8f5c7491b23" xsi:type="Realization" />
+    <relationship identifier="id-166fcba5acf5471a8828202da41fa48c" source="id-9d76a90f5163422494119c99f6a908f3" target="id-40f1e7bdf4c74241b1ac5763b3aa9d50" xsi:type="Realization" />
+    <relationship identifier="id-2d92386db079451180d64d31f71f9c60" source="id-9d76a90f5163422494119c99f6a908f3" target="id-a1337fb63ca144ad9473d94406ab187e" xsi:type="Composition" />
+    <relationship identifier="id-445880943583432fa58216cbf99d4442" source="id-9d76a90f5163422494119c99f6a908f3" target="id-f0b5bad31d9246ba8689143d271f6c38" xsi:type="Composition" />
+    <relationship identifier="id-9ed2457c1a9841aa8b16d241a189896e" source="id-7bd8507070fc42b2802ffc882e48484e" target="id-b0541156f9194546bd0922c13349649a" xsi:type="Association" />
+    <relationship identifier="id-0f71872a317d4921acd3753b037fa819" source="id-7bd8507070fc42b2802ffc882e48484e" target="id-9d76a90f5163422494119c99f6a908f3" xsi:type="Association" />
+    <relationship identifier="id-701d86f03871434fb57f5c3c212040de" source="id-a1337fb63ca144ad9473d94406ab187e" target="id-7eb87af87eb349d9b8a5a8b5cbad8856" xsi:type="Composition" />
+    <relationship identifier="id-c7b848b67db84c40bb4e52a025263c91" source="id-f0b5bad31d9246ba8689143d271f6c38" target="id-7eb87af87eb349d9b8a5a8b5cbad8856" xsi:type="Composition" />
+    <relationship identifier="id-3f3f2c435d0543ef8da0f650a4bc8d93" source="id-a1337fb63ca144ad9473d94406ab187e" target="id-2f548011437a41048be837f74c3f4d00" xsi:type="Composition" />
+    <relationship identifier="id-5bacbca553ff43f88e881b7997d3d766" source="id-f0b5bad31d9246ba8689143d271f6c38" target="id-2f548011437a41048be837f74c3f4d00" xsi:type="Composition" />
+    <relationship identifier="id-595be39534aa489bb62d5a3afd47940b" source="id-a1337fb63ca144ad9473d94406ab187e" target="id-0b84596d01f04499b880d15e58879759" xsi:type="Composition" />
+    <relationship identifier="id-5dc81e5b1f474fd6a4549f8017b1e3cd" source="id-f0b5bad31d9246ba8689143d271f6c38" target="id-69f1b9c8a59146a8938218dc363b3895" xsi:type="Composition" />
+    <relationship identifier="id-78a7fece31a74acbb9e47151730434e7" source="id-86d6a2f695b74347a264354315c8656f" target="id-23b94c08d0494535bd9804b94923f83e" xsi:type="Composition" />
+    <relationship identifier="id-ff3d80c6edd54820b87ac51fee9726f8" source="id-86d6a2f695b74347a264354315c8656f" target="id-1ba327b721494627b45b68e6ab88ce73" xsi:type="Assignment" />
+    <relationship identifier="id-87dc078893904a5f8e1628e083aae26e" source="id-eb2a8dd22fad4020b70d683b9adf85bc" target="id-1ba327b721494627b45b68e6ab88ce73" xsi:type="Flow">
+      <name xml:lang="es">New Customer Assessment Request</name>
+    </relationship>
+    <relationship identifier="id-d0b777594fbb4028be16bd38bac622d3" source="id-1ba327b721494627b45b68e6ab88ce73" target="id-eb2a8dd22fad4020b70d683b9adf85bc" xsi:type="Flow">
+      <name xml:lang="es">New Customer Approved</name>
+    </relationship>
+    <relationship identifier="id-7d7f3fce2734465890ba509b7eec364c" source="id-d4ae5cd23a3f4c04b5778446859595ab" target="id-ec198d6b44094aea97ee9bb93659c30d" xsi:type="Flow">
+      <name xml:lang="es">Customer Order</name>
+    </relationship>
+    <relationship identifier="id-00a2122c13fa4a5380523eaa404c8894" source="id-5f7aebddd3ad4a0593301978fca34bab" target="id-73d6be570bd344aeb933d06b9566af35" xsi:type="Serving" />
+    <relationship identifier="id-776b3dbb68a64026ae7e78f71246fda9" source="id-8108cbbc4ed64abbbe5b87014468f35b" target="id-73d6be570bd344aeb933d06b9566af35" xsi:type="Serving" />
+    <relationship identifier="id-b0dbd0952d7e4c7a9db21298a3cd27af" source="id-590b2196df43475cb4e2cd018686ea66" target="id-633f46a9f9f84bbda07115037faf71eb" xsi:type="Realization" />
+    <relationship identifier="id-3c157187e57042c983f84b01a9348cde" source="id-eb6681ab4dd94ce3996ade5875bdf3ef" target="id-590b2196df43475cb4e2cd018686ea66" xsi:type="Flow" />
+    <relationship identifier="id-3ca88c32f00441349bd9aca0dd67f7c2" source="id-322294a1d3b441b2a55c57b8dca6e7ff" target="id-590b2196df43475cb4e2cd018686ea66" xsi:type="Flow" />
+    <relationship identifier="id-4abc7f162f9042f99a1ec563b8696d4f" source="id-eb6681ab4dd94ce3996ade5875bdf3ef" target="id-322294a1d3b441b2a55c57b8dca6e7ff" xsi:type="Serving" />
+    <relationship identifier="id-61ebdc87de474e20a879a30a1c99fc82" source="id-4e06ee45db904a88aa46e9dce611528e" target="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Flow" />
+    <relationship identifier="id-9984fc4756e9471db662ba12b8aa4d83" source="id-b67b02752ebc4b929c9a9fc76211cff9" target="id-4e06ee45db904a88aa46e9dce611528e" xsi:type="Flow" />
+    <relationship identifier="id-8f2a9b3e59a347b682191c6cb2cd6971" source="id-e26375257d8440228f37158ecf5b8524" target="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Flow" />
+    <relationship identifier="id-a70f6ec37cf34a3c88adf7404a93aa5b" source="id-b67b02752ebc4b929c9a9fc76211cff9" target="id-e26375257d8440228f37158ecf5b8524" xsi:type="Flow" />
+    <relationship identifier="id-58e0c880b3db4f58bec1bdde212dc88a" source="id-4e06ee45db904a88aa46e9dce611528e" target="id-56a4ef970d314200bc4e95d8ea928093" xsi:type="Serving" />
+    <relationship identifier="id-baad7774d92d405e8f261b045ebd1e10" source="id-4e06ee45db904a88aa46e9dce611528e" target="id-8108cbbc4ed64abbbe5b87014468f35b" xsi:type="Serving" />
+    <relationship identifier="id-c4661a6ddd404053a3a448dfa9a1add1" source="id-4e06ee45db904a88aa46e9dce611528e" target="id-eb6681ab4dd94ce3996ade5875bdf3ef" xsi:type="Serving" />
+    <relationship identifier="id-0c490d09ad5e470d8e1f2fd8e1357ffe" source="id-4e06ee45db904a88aa46e9dce611528e" target="id-5f7aebddd3ad4a0593301978fca34bab" xsi:type="Serving" />
+    <relationship identifier="id-40a93d8fc0674a83a55543c7d366f9de" source="id-4e06ee45db904a88aa46e9dce611528e" target="id-322294a1d3b441b2a55c57b8dca6e7ff" xsi:type="Serving" />
+    <relationship identifier="id-3e2d1f927d6f4f7ba931c5cfbb8e6569" source="id-c728f7f622be468380062354ffbf4f57" target="id-322294a1d3b441b2a55c57b8dca6e7ff" xsi:type="Serving" />
+    <relationship identifier="id-1cdecf4d901346dc92de35811d271b5f" source="id-e26375257d8440228f37158ecf5b8524" target="id-590b2196df43475cb4e2cd018686ea66" xsi:type="Serving" />
+    <relationship identifier="id-76fd4032523f4952837124c227ea1b4e" source="id-86d6a2f695b74347a264354315c8656f" target="id-590b2196df43475cb4e2cd018686ea66" xsi:type="Assignment" />
+    <relationship identifier="id-a8ef868842644973850d7f8f8570bdd5" source="id-ca35f8df80974169b04c1ffd58c12493" target="id-322294a1d3b441b2a55c57b8dca6e7ff" xsi:type="Assignment" />
+    <relationship identifier="id-021c6830e7cc4b59aa81ddf73e16ad39" source="id-26586078852645d59ea8b14781701c65" target="id-4e06ee45db904a88aa46e9dce611528e" xsi:type="Composition" />
+    <relationship identifier="id-b3c7e6dd03204ea4811126d8d72dc929" source="id-26586078852645d59ea8b14781701c65" target="id-e26375257d8440228f37158ecf5b8524" xsi:type="Composition" />
+    <relationship identifier="id-b0e1f724270049b8ab6861a45b2a9d3a" source="id-fbc7c240895b4e0397b9aea45e0618bf" target="id-4d7f4fc0971947f787ba6b4fa2ff3fa0" xsi:type="Aggregation" />
+    <relationship identifier="id-b6fb2f69c7b84d36a9d7d44488f5dff3" source="id-fbc7c240895b4e0397b9aea45e0618bf" target="id-4cf5ebcb7c0b4c01bfb2c6934504ba8f" xsi:type="Aggregation" />
+    <relationship identifier="id-a42603dd1d294eedab1ca39175719926" source="id-4d7f4fc0971947f787ba6b4fa2ff3fa0" target="id-2f8dd2120d55460896baf324b937dfd6" xsi:type="Realization" />
+    <relationship identifier="id-f666ddf925cb4a699663144ace30837f" source="id-4d7f4fc0971947f787ba6b4fa2ff3fa0" target="id-8e83c502c9924312923992e8b255bff1" xsi:type="Realization" />
+    <relationship identifier="id-62bec07ee1c24eea904e7bcd21dfedfc" source="id-4cf5ebcb7c0b4c01bfb2c6934504ba8f" target="id-d81bb5d2f5274f239d10b8a210a2fa8b" xsi:type="Realization" />
+    <relationship identifier="id-c9f7575d9f0d454faf830c50662e129d" source="id-4cf5ebcb7c0b4c01bfb2c6934504ba8f" target="id-e429c90e3c69458f9131f11c48669677" xsi:type="Realization" />
+    <relationship identifier="id-3a7a20f9ddee4102aa2a1009dda0f8d4" source="id-58761ca77a6d49818b06fd0021959839" target="id-be22e5fb2b804f32b1087966af591ec4" xsi:type="Triggering" />
+    <relationship identifier="id-1a34c59912404e6ba82f8454bdaf6524" source="id-be22e5fb2b804f32b1087966af591ec4" target="id-faeb172be6704b9d992fe8646d3028f0" xsi:type="Triggering" />
+    <relationship identifier="id-dca3f4be1a224856a5a9bdce91e6e892" source="id-2f8dd2120d55460896baf324b937dfd6" target="id-322294a1d3b441b2a55c57b8dca6e7ff" xsi:type="Realization" />
+    <relationship identifier="id-601b1f6d053448549c198ec1264de387" source="id-2f8dd2120d55460896baf324b937dfd6" target="id-16a56de036194eb79b44068f44ee244d" xsi:type="Realization" />
+    <relationship identifier="id-920e152199a945a3a39f2a6baf73d5ee" source="id-2f8dd2120d55460896baf324b937dfd6" target="id-8108cbbc4ed64abbbe5b87014468f35b" xsi:type="Realization" />
+    <relationship identifier="id-e9ca401699e64d1ab329ab087245094e" source="id-8e83c502c9924312923992e8b255bff1" target="id-4e06ee45db904a88aa46e9dce611528e" xsi:type="Realization" />
+    <relationship identifier="id-1adb0aeeade143828ceb938596c1c7e1" source="id-d81bb5d2f5274f239d10b8a210a2fa8b" target="id-590b2196df43475cb4e2cd018686ea66" xsi:type="Realization" />
+    <relationship identifier="id-c976a84c39b64f528e354ab055af02c8" source="id-d81bb5d2f5274f239d10b8a210a2fa8b" target="id-633f46a9f9f84bbda07115037faf71eb" xsi:type="Realization" />
+    <relationship identifier="id-67444b25581244038c95eea3e02a0e32" source="id-e429c90e3c69458f9131f11c48669677" target="id-e26375257d8440228f37158ecf5b8524" xsi:type="Realization" />
+    <relationship identifier="id-11c12e1b44674be8a92ab3a1966d0dfa" source="id-be22e5fb2b804f32b1087966af591ec4" target="id-4e06ee45db904a88aa46e9dce611528e" xsi:type="Aggregation" />
+    <relationship identifier="id-4acfc130f7c6410abd76bb415ab5eac8" source="id-be22e5fb2b804f32b1087966af591ec4" target="id-8108cbbc4ed64abbbe5b87014468f35b" xsi:type="Aggregation" />
+    <relationship identifier="id-37c41ebe851b4039a5c4a39602348b1e" source="id-be22e5fb2b804f32b1087966af591ec4" target="id-16a56de036194eb79b44068f44ee244d" xsi:type="Aggregation" />
+    <relationship identifier="id-cdf011fb0eab4d9bb00ffc06d99b9596" source="id-be22e5fb2b804f32b1087966af591ec4" target="id-322294a1d3b441b2a55c57b8dca6e7ff" xsi:type="Aggregation" />
+    <relationship identifier="id-81d5cfc6f19b4154b4873315635856b2" source="id-faeb172be6704b9d992fe8646d3028f0" target="id-590b2196df43475cb4e2cd018686ea66" xsi:type="Aggregation" />
+    <relationship identifier="id-a12883009a84471f8b0a29ab1bcd1c1e" source="id-faeb172be6704b9d992fe8646d3028f0" target="id-633f46a9f9f84bbda07115037faf71eb" xsi:type="Aggregation" />
+    <relationship identifier="id-e474ee3e3cb34846930f6d40e9ff420b" source="id-faeb172be6704b9d992fe8646d3028f0" target="id-e26375257d8440228f37158ecf5b8524" xsi:type="Aggregation" />
+    <relationship identifier="id-d45cb8e279204268b0ca24d0525501e6" source="id-6ce3b2f185874049ad30f4b5d7a1491d" target="id-16a56de036194eb79b44068f44ee244d" xsi:type="Triggering" />
+    <relationship identifier="id-77780f3d08b54989978885c4044a2752" source="id-16a56de036194eb79b44068f44ee244d" target="id-b0f8301b5a2744279cb027be12751c25" xsi:type="Triggering" />
+    <relationship identifier="id-f388e19e59cb4d7bbb6fad4581eeb779" source="id-b0f8301b5a2744279cb027be12751c25" target="id-c4b62300152b4eab912ff382a166ce9f" xsi:type="Triggering" />
+    <relationship identifier="id-0b0135218f6e4ecb86c1ae2b90c30f56" source="id-c4b62300152b4eab912ff382a166ce9f" target="id-66ed398ab28e442ea5516dd44cdc0a49" xsi:type="Triggering" />
+    <relationship identifier="id-7f22df0afd51491d92d3a3e2b60078b3" source="id-66ed398ab28e442ea5516dd44cdc0a49" target="id-2372f409993a4d7c943255a5277337b1" xsi:type="Triggering" />
+    <relationship identifier="id-1cd2bf284eb04a2c944dec5c9df1c7d3" source="id-56a4ef970d314200bc4e95d8ea928093" target="id-16a56de036194eb79b44068f44ee244d" xsi:type="Composition" />
+    <relationship identifier="id-321a08a5219c4a008ad0a979fb0e322e" source="id-56a4ef970d314200bc4e95d8ea928093" target="id-b0f8301b5a2744279cb027be12751c25" xsi:type="Composition" />
+    <relationship identifier="id-19d1e371a99c4e68b5215de32b5a345e" source="id-56a4ef970d314200bc4e95d8ea928093" target="id-2372f409993a4d7c943255a5277337b1" xsi:type="Composition" />
+    <relationship identifier="id-f557926f05344ff18551e8b4978332e3" source="id-56a4ef970d314200bc4e95d8ea928093" target="id-6ce3b2f185874049ad30f4b5d7a1491d" xsi:type="Composition" />
+    <relationship identifier="id-702d6863ed7f46ada5e5cc74fe18532a" source="id-56a4ef970d314200bc4e95d8ea928093" target="id-66ed398ab28e442ea5516dd44cdc0a49" xsi:type="Composition" />
+    <relationship identifier="id-9516dee9eb5b4e61890deb7c85343e19" source="id-56a4ef970d314200bc4e95d8ea928093" target="id-c4b62300152b4eab912ff382a166ce9f" xsi:type="Composition" />
+    <relationship identifier="id-a4a42b824a5b4a5c80af81efaecd1f8d" source="id-bbd25ba605ba4eafaa1ab945552f0449" target="id-56a4ef970d314200bc4e95d8ea928093" xsi:type="Triggering" />
+    <relationship identifier="id-4108ed11a3b745c195ae42ea4e5874c2" source="id-8108cbbc4ed64abbbe5b87014468f35b" target="id-16a56de036194eb79b44068f44ee244d" xsi:type="Serving" />
+    <relationship identifier="id-f171221fa5d748fbbb70b55e74865a22" source="id-86d6a2f695b74347a264354315c8656f" target="id-8108cbbc4ed64abbbe5b87014468f35b" xsi:type="Assignment" />
+    <relationship identifier="id-49b9afec4b8c47c9983c215c1266b051" source="id-5f7aebddd3ad4a0593301978fca34bab" target="id-b0f8301b5a2744279cb027be12751c25" xsi:type="Serving" />
+    <relationship identifier="id-8ad312451dd041db8dc813902ff0de4f" source="id-16a56de036194eb79b44068f44ee244d" target="id-b184c5661a354a80a26061333635c927" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-7440ad3b9c58469db7c876199c9cfb59" source="id-b0f8301b5a2744279cb027be12751c25" target="id-b56b5c461fc94c06b00ed6d33955fcb2" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-13866b172b4646acad8eecb024a962cb" source="id-c4b62300152b4eab912ff382a166ce9f" target="id-2b87582d36d143db98c8e258b24655f1" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-839b8489c8be4f9b8c112979ed16c902" source="id-c4b62300152b4eab912ff382a166ce9f" target="id-b184c5661a354a80a26061333635c927" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-678b5212401e4f29b871752259798af5" source="id-66ed398ab28e442ea5516dd44cdc0a49" target="id-b184c5661a354a80a26061333635c927" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-02b422a2cf694522ada32c1e044d3e73" source="id-2372f409993a4d7c943255a5277337b1" target="id-0bed0f0876c6428fa25879de80d47208" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-71ae997cd5d14ebb8e8f99cb8e23df0d" source="id-51c3a5a5d0c343df91c73e182a373148" target="id-0bed0f0876c6428fa25879de80d47208" xsi:type="Realization" />
+    <relationship identifier="id-0723603c90374bc2b94bb7865d59e89d" source="id-3e0c53acd20e49d491f78cf0d33475d6" target="id-6ce3b2f185874049ad30f4b5d7a1491d" xsi:type="Serving" />
+    <relationship identifier="id-9acacc74a46e4d8f90a07de7f6c40295" source="id-3e0c53acd20e49d491f78cf0d33475d6" target="id-16a56de036194eb79b44068f44ee244d" xsi:type="Serving" />
+    <relationship identifier="id-4dacd8a214d044b5aaf9d1f1b152f6c3" source="id-3e0c53acd20e49d491f78cf0d33475d6" target="id-c4b62300152b4eab912ff382a166ce9f" xsi:type="Serving" />
+    <relationship identifier="id-d2657cf7dbd3498bafce917d4b08cfd0" source="id-deab2ec93baa49a28e95cb01ae59f7c3" target="id-b0f8301b5a2744279cb027be12751c25" xsi:type="Serving" />
+    <relationship identifier="id-6068459dcf664ad5a7b0d37937524430" source="id-0d58563f7c7647b8a9eb8d050ec6034b" target="id-66ed398ab28e442ea5516dd44cdc0a49" xsi:type="Serving" />
+    <relationship identifier="id-bda70888878c4491b39b4af4ee18f458" source="id-eed49dfc6a754e3fbbcff474c2ee1b8d" target="id-2372f409993a4d7c943255a5277337b1" xsi:type="Serving" />
+    <relationship identifier="id-2f0d63ae8ea84153b6062fdd0dd312ba" source="id-4e06ee45db904a88aa46e9dce611528e" target="id-3e0c53acd20e49d491f78cf0d33475d6" xsi:type="Realization" />
+    <relationship identifier="id-e03267e87a984283a7ab52ca7a5d9a8c" source="id-4e06ee45db904a88aa46e9dce611528e" target="id-deab2ec93baa49a28e95cb01ae59f7c3" xsi:type="Realization" />
+    <relationship identifier="id-d274fbfebd7a44e6b7b0c4fd7fd4df14" source="id-4e06ee45db904a88aa46e9dce611528e" target="id-0d58563f7c7647b8a9eb8d050ec6034b" xsi:type="Realization" />
+    <relationship identifier="id-8ca6a7dfae9d4e619287374aea2c4126" source="id-4e06ee45db904a88aa46e9dce611528e" target="id-eed49dfc6a754e3fbbcff474c2ee1b8d" xsi:type="Realization" />
+    <relationship identifier="id-9e76c169badb45cf9ef8550ac376cf63" source="id-d17a14d6490b493590904eee8473936c" target="id-3a3aa1f975794029b3d192f1dcefc361" xsi:type="Triggering" />
+    <relationship identifier="id-91d310907d1f45ea83ab0bd401f3f8da" source="id-3a3aa1f975794029b3d192f1dcefc361" target="id-9331a6d1c1f54746841c1c6908d8b9e8" xsi:type="Triggering" />
+    <relationship identifier="id-9c279ee6164144a7a4e86c85da5f415e" source="id-eb6681ab4dd94ce3996ade5875bdf3ef" target="id-d17a14d6490b493590904eee8473936c" xsi:type="Composition" />
+    <relationship identifier="id-2313163af2504bcf97334f5e667739be" source="id-eb6681ab4dd94ce3996ade5875bdf3ef" target="id-9331a6d1c1f54746841c1c6908d8b9e8" xsi:type="Composition" />
+    <relationship identifier="id-a7c3d87124b84e81baafbe77a112a5d5" source="id-eb6681ab4dd94ce3996ade5875bdf3ef" target="id-3a3aa1f975794029b3d192f1dcefc361" xsi:type="Composition" />
+    <relationship identifier="id-d400f395329743d6a210542f0a7d07a6" source="id-c578fa3dcee04225a0144fa71920eeb6" target="id-eb6681ab4dd94ce3996ade5875bdf3ef" xsi:type="Triggering" />
+    <relationship identifier="id-359fe6f134a24f009c18dc19b1432e82" source="id-9331a6d1c1f54746841c1c6908d8b9e8" target="id-6191979d2f304476ab02f638d4ece684" xsi:type="Triggering" />
+    <relationship identifier="id-ea02ec226e9e44eabc67e3de952542ad" source="id-6191979d2f304476ab02f638d4ece684" target="id-590b2196df43475cb4e2cd018686ea66" xsi:type="Triggering" />
+    <relationship identifier="id-5f77215fb5c94ff89c5c29f09aeb4cd2" source="id-d17a14d6490b493590904eee8473936c" target="id-86a95bbd46c448b4ad517306a911c2e9" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-21ccfc64299947cf84608184faa689b8" source="id-d17a14d6490b493590904eee8473936c" target="id-d527ba03811741ebb7569d1b04442a25" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-d4c54ab4367246f1b8911ebd052c73c3" source="id-d17a14d6490b493590904eee8473936c" target="id-b184c5661a354a80a26061333635c927" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-9f6bf9cce0914a0c90e8aed50db56eb6" source="id-3a3aa1f975794029b3d192f1dcefc361" target="id-260c70cf6aad4a17b0d321e5674b57c4" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-f7564b50863d46339f8ecdde808e9711" source="id-3a3aa1f975794029b3d192f1dcefc361" target="id-b184c5661a354a80a26061333635c927" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-4cf36345fa4849de86160e994cf9a29f" source="id-9331a6d1c1f54746841c1c6908d8b9e8" target="id-5f42eca753994b2eb284dd75b26a7cb2" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-a5b4193a7da54c0882e995bc050cdc32" source="id-9331a6d1c1f54746841c1c6908d8b9e8" target="id-d527ba03811741ebb7569d1b04442a25" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-fe7b3c77e211485ebee8f59032c1da09" source="id-65db965489624a89893068173a39cf59" target="id-3a3aa1f975794029b3d192f1dcefc361" xsi:type="Serving" />
+    <relationship identifier="id-f3a7d86ac3a14acfa7c8d670c69e43bf" source="id-815c2b316d7848279b068a86a0a2ddea" target="id-d17a14d6490b493590904eee8473936c" xsi:type="Serving" />
+    <relationship identifier="id-61e2ba8b92744d6697758aa50794d893" source="id-815c2b316d7848279b068a86a0a2ddea" target="id-9331a6d1c1f54746841c1c6908d8b9e8" xsi:type="Serving" />
+    <relationship identifier="id-0445695e9fec438e9a5ef43857ccb243" source="id-4e06ee45db904a88aa46e9dce611528e" target="id-815c2b316d7848279b068a86a0a2ddea" xsi:type="Realization" />
+    <relationship identifier="id-d0a04647b05b48adb59e216cbbc5b46f" source="id-4e06ee45db904a88aa46e9dce611528e" target="id-65db965489624a89893068173a39cf59" xsi:type="Realization" />
+    <relationship identifier="id-a268ca16d2f74427a688fc6d65599df2" source="id-c9eb53d707564096a8727df622f078bb" target="id-4e06ee45db904a88aa46e9dce611528e" xsi:type="Serving" />
+    <relationship identifier="id-6e1154ae7e1b42f8a587d4207ff79bad" source="id-b8ba463d96e7480e8099014269c938e8" target="id-3eb0685faebf42cfa81567c6a4e7db24" xsi:type="Aggregation" />
+    <relationship identifier="id-95dccab6d18e4a35a29bf5f251eb16cc" source="id-b8ba463d96e7480e8099014269c938e8" target="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Aggregation" />
+    <relationship identifier="id-0fb8c568ca7b465184f2d76486832e0b" source="id-b8ba463d96e7480e8099014269c938e8" target="id-c9eb53d707564096a8727df622f078bb" xsi:type="Realization" />
+    <relationship identifier="id-65ef28d914c74e039bb9a406b2ac91b1" source="id-f7bd6d6664424100b329cb8b0ed40510" target="id-a9bbb7a79a9b4d568f6f66917f0b40d1" xsi:type="Triggering" />
+    <relationship identifier="id-349e31e3a0204dee93eaeec603f58486" source="id-590b2196df43475cb4e2cd018686ea66" target="id-f7bd6d6664424100b329cb8b0ed40510" xsi:type="Composition" />
+    <relationship identifier="id-af85fc5501bc45d2b998787ea035996d" source="id-590b2196df43475cb4e2cd018686ea66" target="id-a9bbb7a79a9b4d568f6f66917f0b40d1" xsi:type="Composition" />
+    <relationship identifier="id-1f0d849706644335bfb100282c445c7f" source="id-1cd9ba40fb81440b89ca6b9b81264bf4" target="id-590b2196df43475cb4e2cd018686ea66" xsi:type="Serving" />
+    <relationship identifier="id-10298aab69d64ad8a69e63cf794357c5" source="id-e26375257d8440228f37158ecf5b8524" target="id-1cd9ba40fb81440b89ca6b9b81264bf4" xsi:type="Realization" />
+    <relationship identifier="id-82012bdf7ac544d9822b2546c3b861ca" source="id-c521cb12763d4ab3993c3c45b66dc5d4" target="id-e26375257d8440228f37158ecf5b8524" xsi:type="Serving" />
+    <relationship identifier="id-4a8d31f88d574a9089e90deee7ff98c9" source="id-4c50a5c4b84a49128b53481ac94f3430" target="id-c521cb12763d4ab3993c3c45b66dc5d4" xsi:type="Realization" />
+    <relationship identifier="id-67d03a22a57c4b9ca3536f514a2511a0" source="id-4c50a5c4b84a49128b53481ac94f3430" target="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Aggregation" />
+    <relationship identifier="id-ee27f10dc39d47598d4911480a093e90" source="id-4c50a5c4b84a49128b53481ac94f3430" target="id-4e06ee45db904a88aa46e9dce611528e" xsi:type="Aggregation" />
+    <relationship identifier="id-4d3664323e0548c5b2581f6f082dbc24" source="id-458d93fe1e2f4c51a43bae8e26b96aa4" target="id-cef7496ae5d84bfa8b4de2882dbbb248" xsi:type="Triggering" />
+    <relationship identifier="id-f0d55a3a939041ef8bcefb5254a0c77e" source="id-cef7496ae5d84bfa8b4de2882dbbb248" target="id-26bb007b0934471f9c05d188e9589372" xsi:type="Triggering" />
+    <relationship identifier="id-e72a2f5f97524207bd87ddc2d36996a5" source="id-26bb007b0934471f9c05d188e9589372" target="id-c4d0ce61237a4b03a3f27f9d1b009e55" xsi:type="Triggering" />
+    <relationship identifier="id-1bb0d928e2764f88ae2a80a6b2373a31" source="id-322294a1d3b441b2a55c57b8dca6e7ff" target="id-458d93fe1e2f4c51a43bae8e26b96aa4" xsi:type="Composition" />
+    <relationship identifier="id-418908fd95334c31ae1ee2304121ba62" source="id-322294a1d3b441b2a55c57b8dca6e7ff" target="id-cef7496ae5d84bfa8b4de2882dbbb248" xsi:type="Composition" />
+    <relationship identifier="id-343934eb45394fa7bc381bfefc4d056d" source="id-322294a1d3b441b2a55c57b8dca6e7ff" target="id-26bb007b0934471f9c05d188e9589372" xsi:type="Composition" />
+    <relationship identifier="id-b3ac721f02534bf1b3ed9775aeac303e" source="id-322294a1d3b441b2a55c57b8dca6e7ff" target="id-c4d0ce61237a4b03a3f27f9d1b009e55" xsi:type="Composition" />
+    <relationship identifier="id-937bbcf4bfaf45a498c651052fd04b47" source="id-8fa16f9c69894e46ba236ae0230911bc" target="id-322294a1d3b441b2a55c57b8dca6e7ff" xsi:type="Triggering" />
+    <relationship identifier="id-910409c3681c46ec8fcf2be89b91c5ca" source="id-c4d0ce61237a4b03a3f27f9d1b009e55" target="id-6191979d2f304476ab02f638d4ece684" xsi:type="Triggering" />
+    <relationship identifier="id-fc4152c18e8141b9808ff58527e8fb0e" source="id-458d93fe1e2f4c51a43bae8e26b96aa4" target="id-17b8b5467ec44bb3be416b7d71bd2a07" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-56dcf3e0644c40dfa2e34e43094b5f79" source="id-458d93fe1e2f4c51a43bae8e26b96aa4" target="id-b1b2c63ef02c42eb88310f21fe662e87" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-3be81b3c59e54b4796ac2eb5caabb242" source="id-cef7496ae5d84bfa8b4de2882dbbb248" target="id-86819b7c2aef41b2b13dc893c50ea3ec" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-50568a62ff514fd9aabad89e255830ed" source="id-cef7496ae5d84bfa8b4de2882dbbb248" target="id-b1b2c63ef02c42eb88310f21fe662e87" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-4a1f0e7f101248ec9e553b8b6690cd60" source="id-26bb007b0934471f9c05d188e9589372" target="id-b1b2c63ef02c42eb88310f21fe662e87" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-646eb2e3201c49f38c068d2f54c8097b" source="id-c4d0ce61237a4b03a3f27f9d1b009e55" target="id-b1b2c63ef02c42eb88310f21fe662e87" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-4cce7fe2273e4cbfa269d34993272379" source="id-26bb007b0934471f9c05d188e9589372" target="id-201410bdce59449d817eda936fc5ef57" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-16a3c76c26154a59939c26b16ea0ee47" source="id-26bb007b0934471f9c05d188e9589372" target="id-8d9a138abbbd49248dda77330d209ac2" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-830d0d07355a40b18354ca1be8f60e20" source="id-cfa3f50f73694f23a2ef50c482a320b9" target="id-c4d0ce61237a4b03a3f27f9d1b009e55" xsi:type="Serving" />
+    <relationship identifier="id-f96548e2bd6d4f508502d5f1dcb11b51" source="id-c1d7e78cb9a8486cb0365b0c3eafdbd9" target="id-26bb007b0934471f9c05d188e9589372" xsi:type="Serving" />
+    <relationship identifier="id-f6b2077e6187458280a345de367c7af1" source="id-06fe133456074678b8f6a19e6aa5906b" target="id-cef7496ae5d84bfa8b4de2882dbbb248" xsi:type="Serving" />
+    <relationship identifier="id-09c9d7ae76044d66b5b9a408aa6154a0" source="id-cb9b699fb1fc478c8a8f436b20038f0f" target="id-458d93fe1e2f4c51a43bae8e26b96aa4" xsi:type="Serving" />
+    <relationship identifier="id-8da91a3bad204d0dac78fdd9c4444bf2" source="id-cfa3f50f73694f23a2ef50c482a320b9" target="id-cef7496ae5d84bfa8b4de2882dbbb248" xsi:type="Serving" />
+    <relationship identifier="id-e2b70f6020004bd08a615b2d4e2b5fd0" source="id-c728f7f622be468380062354ffbf4f57" target="id-cb9b699fb1fc478c8a8f436b20038f0f" xsi:type="Realization" />
+    <relationship identifier="id-6bb180a4e44c4ca4b34b1fe8176c124a" source="id-c728f7f622be468380062354ffbf4f57" target="id-06fe133456074678b8f6a19e6aa5906b" xsi:type="Realization" />
+    <relationship identifier="id-bf60141d36f64c88b276fa4e759e2cf7" source="id-4e06ee45db904a88aa46e9dce611528e" target="id-cfa3f50f73694f23a2ef50c482a320b9" xsi:type="Realization" />
+    <relationship identifier="id-e16526d578e447fc82921dc99dec9332" source="id-b67b02752ebc4b929c9a9fc76211cff9" target="id-c1d7e78cb9a8486cb0365b0c3eafdbd9" xsi:type="Realization" />
+    <relationship identifier="id-53953760b2a44842adf5d843032c638a" source="id-877622cb13a744b1baa7d9e94576aa25" target="id-f11c2b0d08c44572995ce0a180edc174" xsi:type="Aggregation" />
+    <relationship identifier="id-43d49ff09883433d9e841aab36a0c9c2" source="id-f31166117d504940a2268fb1dcb0bbc7" target="id-d676a607a130483a961a4a1de0179094" xsi:type="Association" />
+    <relationship identifier="id-7a139d573c7c4a9e8e7ee3c1e4f0da15" source="id-8939bfb16933425c952bd4ca553d90e2" target="id-877622cb13a744b1baa7d9e94576aa25" xsi:type="Association" />
+    <relationship identifier="id-d47baa395fed460db6421a2aded17de2" source="id-d676a607a130483a961a4a1de0179094" target="id-3fe71c490fc64bf3bb22c73bff890b38" xsi:type="Association" />
+    <relationship identifier="id-382214250efd4231a02756416f05fcec" source="id-877622cb13a744b1baa7d9e94576aa25" target="id-3fe71c490fc64bf3bb22c73bff890b38" xsi:type="Association" />
+    <relationship identifier="id-c270926850164f48b17d088aeb65730c" source="id-8939bfb16933425c952bd4ca553d90e2" target="id-3fe71c490fc64bf3bb22c73bff890b38" xsi:type="Association" />
+    <relationship identifier="id-0392078f67334640b8dfed5f54dd9c78" source="id-f31166117d504940a2268fb1dcb0bbc7" target="id-3fe71c490fc64bf3bb22c73bff890b38" xsi:type="Association" />
+    <relationship identifier="id-3d55bc711a11449592ef575f1bac55f9" source="id-3fe71c490fc64bf3bb22c73bff890b38" target="id-58df809904fa4baf8b5b7c28c53d20b0" xsi:type="Association" />
+    <relationship identifier="id-d0fc1d4dc3864dfb8336c6a37a243d47" source="id-f11c2b0d08c44572995ce0a180edc174" target="id-58df809904fa4baf8b5b7c28c53d20b0" xsi:type="Association" />
+    <relationship identifier="id-fc89fbdf1b2e4d8884dbcca370d01424" source="id-4aee877b6bfd42619217ccb2547b68ba" target="id-58df809904fa4baf8b5b7c28c53d20b0" xsi:type="Influence" />
+    <relationship identifier="id-a32f1e7d20d848c0b265b46c8f372f24" source="id-3fd6818a449e46559476e24456f63196" target="id-58df809904fa4baf8b5b7c28c53d20b0" xsi:type="Influence" />
+    <relationship identifier="id-c2a8d9d9318d41549037025d71599ee7" source="id-5f2f67e939914b59905c8b33282320ef" target="id-5360e04f3f2b4d858aaaf6229e79b09a" xsi:type="Flow" />
+    <relationship identifier="id-d22a15e338ce4844866d59025d1bd167" source="id-ffae0a20ba5a4960b55d50ff0b15dd68" target="id-5360e04f3f2b4d858aaaf6229e79b09a" xsi:type="Flow" />
+    <relationship identifier="id-e37063f05fff44f5a6c39c4a5b54dc07" source="id-dfc0afa8475c4f559f13403e85a7f08e" target="id-5f2f67e939914b59905c8b33282320ef" xsi:type="Composition" />
+    <relationship identifier="id-a58fbc2d3df14bcca8aa115deaa97953" source="id-dfc0afa8475c4f559f13403e85a7f08e" target="id-ffae0a20ba5a4960b55d50ff0b15dd68" xsi:type="Composition" />
+    <relationship identifier="id-4f1372ca7501479fb4f27c842faba7ac" source="id-dfc0afa8475c4f559f13403e85a7f08e" target="id-5360e04f3f2b4d858aaaf6229e79b09a" xsi:type="Composition" />
+    <relationship identifier="id-c8a8d78b65a84ccbb6dfbfafb7b1d8d2" source="id-5f2f67e939914b59905c8b33282320ef" target="id-ffae0a20ba5a4960b55d50ff0b15dd68" xsi:type="Flow" />
+    <relationship identifier="id-646d97276df34c37b377c908186bd107" source="id-185e92e049434c4f954cc9b68957879f" target="id-53efc358b55540f0a4d75652777c457d" xsi:type="Triggering" />
+    <relationship identifier="id-3c25d67261064ea28e199fe9a0b85f85" source="id-53efc358b55540f0a4d75652777c457d" target="id-0c7864041e1546d38b8f0cef3bb638ab" xsi:type="Triggering" />
+    <relationship identifier="id-dcd4c81485474c4a8a58d0bc320d56fe" source="id-0c7864041e1546d38b8f0cef3bb638ab" target="id-dfc0afa8475c4f559f13403e85a7f08e" xsi:type="Triggering" />
+    <relationship identifier="id-a74df18bcb2747a4a9e879dcb6b0820e" source="id-0c7864041e1546d38b8f0cef3bb638ab" target="id-b0f8301b5a2744279cb027be12751c25" xsi:type="Triggering" />
+    <relationship identifier="id-404aaef8afbd4c8cac91b3e7ce7e87fe" source="id-b0f8301b5a2744279cb027be12751c25" target="id-72b88e880fe74bc1b6c30caa12640289" xsi:type="Triggering" />
+    <relationship identifier="id-d416fcebaa42472d9eb4fbcbd17d6a56" source="id-dfc0afa8475c4f559f13403e85a7f08e" target="id-72b88e880fe74bc1b6c30caa12640289" xsi:type="Triggering" />
+    <relationship identifier="id-17e42d417d1f4e609a0b754630811877" source="id-72b88e880fe74bc1b6c30caa12640289" target="id-2ec461c4dfd9428985b462c120b0fb79" xsi:type="Triggering" />
+    <relationship identifier="id-f2cd0f5cead94ed68cd27bf318a265a5" source="id-2ec461c4dfd9428985b462c120b0fb79" target="id-66ed398ab28e442ea5516dd44cdc0a49" xsi:type="Triggering" />
+    <relationship identifier="id-ad1e7e9f59954f18bf4803a1a0027669" source="id-66ed398ab28e442ea5516dd44cdc0a49" target="id-1ddb1228062a4a1997ec7e977f7f4e3d" xsi:type="Triggering" />
+    <relationship identifier="id-f6989aa63ab24e2bb69cb321699de3af" source="id-d15443baa07a4291a075f402917fe007" target="id-53efc358b55540f0a4d75652777c457d" xsi:type="Assignment" />
+    <relationship identifier="id-1d71a1527dbe4fb5b8a2eb3365ace3b0" source="id-e0af5fde22f148fd830c3b8f62c44038" target="id-b0f8301b5a2744279cb027be12751c25" xsi:type="Assignment" />
+    <relationship identifier="id-3cb2acbc8d374c47879d879a27ec69e6" source="id-569bfe90e09e4c4ea87799bb9cf23274" target="id-dfc0afa8475c4f559f13403e85a7f08e" xsi:type="Assignment" />
+    <relationship identifier="id-4d22767cc0e74f62b7ea0425e51bb1b7" source="id-5af8778d34c44cac8d30b4736484ff53" target="id-66ed398ab28e442ea5516dd44cdc0a49" xsi:type="Assignment" />
+    <relationship identifier="id-106c11a71e504c6d92b950e81ce22d80" source="id-8737a76acd9c4d1fbb2a4ffc86cb2993" target="id-0cedc365b4d4417f9d2a45c1f7cd5e12" xsi:type="Aggregation" />
+    <relationship identifier="id-11442bc6e2674460b518658d8acb923d" source="id-8737a76acd9c4d1fbb2a4ffc86cb2993" target="id-946bfea9e17e42aa8f0184f2ef94b6f1" xsi:type="Aggregation" />
+    <relationship identifier="id-88dfc205b0174ee4bc449aa39843ad8a" source="id-8737a76acd9c4d1fbb2a4ffc86cb2993" target="id-1ae1d77701f5419eae23f0ce50730604" xsi:type="Aggregation" />
+    <relationship identifier="id-8c2715be52c14efb8ff1b5f37db7a5d6" source="id-8737a76acd9c4d1fbb2a4ffc86cb2993" target="id-cdda390a32864677a1dfe234de530add" xsi:type="Aggregation" />
+    <relationship identifier="id-13bca28e98274e7787dab6fbff0b7fcc" source="id-8737a76acd9c4d1fbb2a4ffc86cb2993" target="id-2ec461c4dfd9428985b462c120b0fb79" xsi:type="Assignment" />
+    <relationship identifier="id-0b96fb0d0e9941529d2f6c18b3561dec" source="id-9a865b3c106b4c5cb4800029ac3d54a7" target="id-53efc358b55540f0a4d75652777c457d" xsi:type="Serving" />
+    <relationship identifier="id-f4cf9ae4b5b04c83b7ac68e8a7499459" source="id-8dd7f9e048c54837a99fdc6dc101ff29" target="id-dfc0afa8475c4f559f13403e85a7f08e" xsi:type="Serving" />
+    <relationship identifier="id-ffce88df12ee4b758bf1850598c844b0" source="id-8dd7f9e048c54837a99fdc6dc101ff29" target="id-9a865b3c106b4c5cb4800029ac3d54a7" xsi:type="Serving" />
+    <relationship identifier="id-f33b67e9b6d6410fb7ecf59859619c44" source="id-569bfe90e09e4c4ea87799bb9cf23274" target="id-e09baac983c64a8abf359b5ead3f2b26" xsi:type="Assignment" />
+    <relationship identifier="id-e7bcaba7d8e8473e8d9274c6819e6831" source="id-3b89b7e81d7d4052affd44601b6e7a83" target="id-434f18b593744f43914399d59d52b4e2" xsi:type="Assignment" />
+    <relationship identifier="id-8383478607a84e87a7f1ce4e435c7665" source="id-ad64cacb19e34896829b2a462615fd7b" target="id-d6fd3df3ae0b4a56b96f5d22d1293f91" xsi:type="Assignment" />
+    <relationship identifier="id-592d5a0e9516450baefeb2fb60880cdf" source="id-8dd7f9e048c54837a99fdc6dc101ff29" target="id-d6fd3df3ae0b4a56b96f5d22d1293f91" xsi:type="Serving" />
+    <relationship identifier="id-56c77f2ad63746b8a4462aab26b0828a" source="id-8dd7f9e048c54837a99fdc6dc101ff29" target="id-434f18b593744f43914399d59d52b4e2" xsi:type="Serving" />
+    <relationship identifier="id-cd2051d687f246eb88bd29a38cc4d43d" source="id-434f18b593744f43914399d59d52b4e2" target="id-4b13dd7b55374db8846d4660064beefd" xsi:type="Composition" />
+    <relationship identifier="id-e4fca00046234778adc85086d0dae34c" source="id-1ddb1228062a4a1997ec7e977f7f4e3d" target="id-d6fd3df3ae0b4a56b96f5d22d1293f91" xsi:type="Triggering" />
+    <relationship identifier="id-5ef40b745ffe400cbe17fc3086b8179b" source="id-d6fd3df3ae0b4a56b96f5d22d1293f91" target="id-434f18b593744f43914399d59d52b4e2" xsi:type="Triggering" />
+    <relationship identifier="id-4dc192fea4d348b0a4011f793a5a83ba" source="id-434f18b593744f43914399d59d52b4e2" target="id-e09baac983c64a8abf359b5ead3f2b26" xsi:type="Triggering" />
+    <relationship identifier="id-d771d69f102e4b0e9f2fcb044a0a2910" source="id-e09baac983c64a8abf359b5ead3f2b26" target="id-a33fd073b4ba4e508cbe3ab2dd3ebc6a" xsi:type="Triggering" />
+    <relationship identifier="id-2b49f5e3aa1f4a33b2bf2d4da8d1ecc0" source="id-abb6ad8f13864cdd9a545391293aac2f" target="id-41f5b1884333497abc39d31394864829" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-dfcfc71085c744dbab682a888185d405" source="id-d004969cca104c28b670b1df84895480" target="id-41f5b1884333497abc39d31394864829" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-bf5d0980823b459582f7b7f2ca9ff866" source="id-d004969cca104c28b670b1df84895480" target="id-c70aca3eba1040fc8561439d8b0f4bc5" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-541d8ad87ec54da8b06ddbdb6ff32e15" source="id-7f6504f22c8341f98fbb7a8f2040fb86" target="id-c70aca3eba1040fc8561439d8b0f4bc5" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-58641959b27249948876585f234324fa" source="id-7f6504f22c8341f98fbb7a8f2040fb86" target="id-251afb2b14b44e369b91879e8be1a7b2" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-1c200b633efb4e7c849cb0b24a16d656" source="id-6bff6aab31d24eafb56cc8d19c39a349" target="id-251afb2b14b44e369b91879e8be1a7b2" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-99869d8bdfac48688f90c48d7148b4b2" source="id-6bff6aab31d24eafb56cc8d19c39a349" target="id-c5ae1afc36664d8c8b6f17c160aa6369" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-f885506aa5544949910befeb7b8102c0" source="id-d750071fabad4b9498b391c0439ad8a9" target="id-c5ae1afc36664d8c8b6f17c160aa6369" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-e0fcfbc217c14d4fafb63d2d585286a2" source="id-d750071fabad4b9498b391c0439ad8a9" target="id-2915da9943da4ffd8ce7db5f564b8560" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-19891cec3a20492d8f877fb5bae3dbb9" source="id-6bff6aab31d24eafb56cc8d19c39a349" target="id-2915da9943da4ffd8ce7db5f564b8560" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-740a7f4e522a452c948d454e0a811794" source="id-6bff6aab31d24eafb56cc8d19c39a349" target="id-76fccb108cf0417894987ca3241ac9da" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-e81b2399c4e64971be60ada42c619c0f" source="id-7f6504f22c8341f98fbb7a8f2040fb86" target="id-76fccb108cf0417894987ca3241ac9da" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-0739c23ade8a4fdf99d727faae31b258" source="id-7f6504f22c8341f98fbb7a8f2040fb86" target="id-6547822784014590b1f6ce403d11dab6" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-e9086fe91ef3456fae5053977c81b421" source="id-d004969cca104c28b670b1df84895480" target="id-6547822784014590b1f6ce403d11dab6" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-07c3811485f74e0491fb790e4fae8639" source="id-d004969cca104c28b670b1df84895480" target="id-fde9a2a74e544857bcdcd5c127214475" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-c72cba963ef54e938eaa447bc2a20577" source="id-abb6ad8f13864cdd9a545391293aac2f" target="id-fde9a2a74e544857bcdcd5c127214475" xsi:type="Access" accessType="Read" />
+    <relationship identifier="id-d7bd0e004f454d72a881e2390fe30424" source="id-770e063936e4428c8107dae96d3d3cc7" target="id-11ccd99fca024f548aa717079047a2d6" xsi:type="Association" />
+    <relationship identifier="id-4f58821d8da14945932926ae33866dd3" source="id-f1f36d4abf914d598a9b032762310b30" target="id-8e6db4ddae3a41c2a7fe819cb7c140db" xsi:type="Composition" />
+    <relationship identifier="id-d459706aa3654228a428fcedeb76b861" source="id-1c00d69a990445f7a53257a2b8a185b6" target="id-e127038f87cb42959f5a9be4c63ac400" xsi:type="Composition" />
+    <relationship identifier="id-2027668953494b6daf40f1f55cbc8cf5" source="id-1c00d69a990445f7a53257a2b8a185b6" target="id-770e063936e4428c8107dae96d3d3cc7" xsi:type="Realization" />
+    <relationship identifier="id-c15f7da617cc4414b798c92b65e0f219" source="id-f1f36d4abf914d598a9b032762310b30" target="id-11ccd99fca024f548aa717079047a2d6" xsi:type="Realization" />
+    <relationship identifier="id-9804e1a77131460abc8ea27bc843599e" source="id-d908916d313d4fac9b2a6cd132eaf4c6" target="id-e27c7d476c4f4facb9f78e3d7edd041d" xsi:type="Association" />
+    <relationship identifier="id-f9fdf0fb20234c39949eed2dbe14ca39" source="id-85f3e58459cf4566a8984eb0261305df" target="id-d908916d313d4fac9b2a6cd132eaf4c6" xsi:type="Realization" />
+    <relationship identifier="id-d0e38b9cc8ab452883a8e1382493b148" source="id-0b43aa7ad1e34ecfac49e9107b204ed6" target="id-e27c7d476c4f4facb9f78e3d7edd041d" xsi:type="Realization" />
+    <relationship identifier="id-f8a8cba0406c44e18de6633183662c87" source="id-85f3e58459cf4566a8984eb0261305df" target="id-de3928a8ce2d4a0c8777d3c53213e57e" xsi:type="Composition" />
+    <relationship identifier="id-05f695f581bb49a6864f1df65e5d5070" source="id-0b43aa7ad1e34ecfac49e9107b204ed6" target="id-54d1145720594f2784b21ce4e4ca0ed0" xsi:type="Composition" />
+    <relationship identifier="id-e3f67792b2554a57b680763dfdea4f2e" source="id-d3f6658ad824487fadc62b80a9709b5c" target="id-3748eb9ccc5844c8832b299b26ce3eea" xsi:type="Association" />
+    <relationship identifier="id-aab4f269e6854079a2702641a2eef4b4" source="id-20aa4381e31143b697919991db4db30b" target="id-3748eb9ccc5844c8832b299b26ce3eea" xsi:type="Realization" />
+    <relationship identifier="id-179a424cd7c742fe80ed7b2c9f2c941b" source="id-3e585eea23014b888f64de613fe21d3c" target="id-d3f6658ad824487fadc62b80a9709b5c" xsi:type="Realization" />
+    <relationship identifier="id-e1e447654c4c464f9aecbb736b45ec97" source="id-3e585eea23014b888f64de613fe21d3c" target="id-cf388ea8144942eeb6a7d23d2fc9d9e5" xsi:type="Composition" />
+    <relationship identifier="id-915dd08d40bc464dbe7cece410d8acc8" source="id-20aa4381e31143b697919991db4db30b" target="id-d40e8b39852a401db024c671bc95209d" xsi:type="Composition" />
+    <relationship identifier="id-301460d307144c8faa0bbf2d5b49910a" source="id-d3d12d7b7e494f32a29a96499f6f66b1" target="id-08c08f4c8e6a4a50b14e523530a5c14f" xsi:type="Association" />
+    <relationship identifier="id-58ab965d01fe4e05a0da156fc93f1cc1" source="id-1c00d69a990445f7a53257a2b8a185b6" target="id-f32c66917de74091bdd5a9624452f2c3" xsi:type="Composition" />
+    <relationship identifier="id-399097ed6904460685975ae337897d43" source="id-f1f36d4abf914d598a9b032762310b30" target="id-89f4b36253eb49fcbf5f75119cf5ff24" xsi:type="Composition" />
+    <relationship identifier="id-0809459150ae416a80b97004e2c1918d" source="id-f1f36d4abf914d598a9b032762310b30" target="id-08c08f4c8e6a4a50b14e523530a5c14f" xsi:type="Realization" />
+    <relationship identifier="id-653a6be49b1f4b3e80dc7899b44bf46e" source="id-1c00d69a990445f7a53257a2b8a185b6" target="id-d3d12d7b7e494f32a29a96499f6f66b1" xsi:type="Realization" />
+  </relationships>
+  <organizations>
+    <item>
+      <label xml:lang="es">Strategy</label>
+      <item>
+        <label xml:lang="es">Value Stream</label>
+        <item>
+          <label xml:lang="es">Produce Steel Products</label>
+          <item identifierRef="id-fc034ab99bfa4b9e9ae7f51fa8de905f" />
+          <item identifierRef="id-c93b9d430cd2423b95c52c610e12f720" />
+          <item identifierRef="id-281d523a5a0e45e686b8d9c6726a5be9" />
+          <item identifierRef="id-051bc17974ef4cedb0424a31e975d727" />
+          <item identifierRef="id-53228d509e7c444dbf57f5dd19df3484" />
+        </item>
+        <item identifierRef="id-1e3683a995704e0bb1abe93aeba4d203" />
+      </item>
+    </item>
+    <item>
+      <label xml:lang="es">Business</label>
+      <item>
+        <label xml:lang="es">Business_Actors</label>
+        <item>
+          <label xml:lang="es">Business Units</label>
+          <item identifierRef="id-70e443457ba447cf9f7be64c0a2e0ad1" />
+          <item identifierRef="id-b50ea84ae74845f3b8001028c0558e90" />
+          <item identifierRef="id-5987ea5989b34bb3b7b3b7df0c5d7596" />
+          <item identifierRef="id-3bc7d428ccea48739c4d442f9f2364e7" />
+          <item identifierRef="id-ca27484ed8934cd2bb57cec774298909" />
+          <item identifierRef="id-f96b2f70a48e42bb83646b89292b1286" />
+          <item identifierRef="id-65c1620fd1284553b20818224030a84d" />
+          <item identifierRef="id-628c9b29c1254f3c8d0aea92d13e5d65" />
+          <item identifierRef="id-86d6a2f695b74347a264354315c8656f" />
+          <item identifierRef="id-b6d4eb2c1e184d33897f7862f6317033" />
+          <item identifierRef="id-eee6f468492e48efb54f44db721f75aa" />
+          <item identifierRef="id-dae853c3fdda4da9a99c066d144cc617" />
+          <item identifierRef="id-761d6b44b0084191bb0574b9b2c4e949" />
+          <item identifierRef="id-ca35f8df80974169b04c1ffd58c12493" />
+          <item identifierRef="id-2bcc0251b630425ea4c325246a35f5b8" />
+          <item identifierRef="id-6118370573ec480e85a1d4b2eed6eacd" />
+          <item identifierRef="id-23b94c08d0494535bd9804b94923f83e" />
+        </item>
+        <item>
+          <label xml:lang="es">Actors</label>
+          <item identifierRef="id-1a7757e999c54d6085462db7df22a296" />
+          <item identifierRef="id-d95e1aa70fcd4c8bba40177204ebca8d" />
+          <item identifierRef="id-50fbcd5489444693bcbc3efe86d1df80" />
+        </item>
+      </item>
+      <item>
+        <label xml:lang="es">Business Functions</label>
+        <item>
+          <label xml:lang="es">ArchiMetal Operations</label>
+          <item identifierRef="id-a6992b23c09c44dba47e8e06ad7655c5" />
+          <item identifierRef="id-bb08ebde1b25412bb52d9e4d35afa404" />
+          <item identifierRef="id-9341d876214745edb68cdc91b7b8ffe7" />
+          <item identifierRef="id-ec198d6b44094aea97ee9bb93659c30d" />
+          <item identifierRef="id-04e04b7fccd14a7a88229604fccc7a86" />
+        </item>
+        <item>
+          <label xml:lang="es">DC Benelux</label>
+          <item identifierRef="id-eb2a8dd22fad4020b70d683b9adf85bc" />
+          <item identifierRef="id-d4ae5cd23a3f4c04b5778446859595ab" />
+          <item identifierRef="id-6bb84a70a70c4899963d5370b82d42af" />
+          <item identifierRef="id-94aed85cd04d4960b53f9db553d91e1c" />
+        </item>
+        <item>
+          <label xml:lang="es">HQ</label>
+          <item identifierRef="id-15b84bcdf6374633b8225b636f14f140" />
+          <item identifierRef="id-1ba327b721494627b45b68e6ab88ce73" />
+        </item>
+        <item>
+          <label xml:lang="es">ArchiBuilder</label>
+          <item identifierRef="id-abb6ad8f13864cdd9a545391293aac2f" />
+          <item identifierRef="id-6bff6aab31d24eafb56cc8d19c39a349" />
+          <item identifierRef="id-7f6504f22c8341f98fbb7a8f2040fb86" />
+          <item identifierRef="id-d004969cca104c28b670b1df84895480" />
+          <item identifierRef="id-d750071fabad4b9498b391c0439ad8a9" />
+        </item>
+        <item identifierRef="id-c35cc8ce1a73415080bf804d76727b72" />
+        <item identifierRef="id-5fb09df777514d79afbec30bf3a49c72" />
+      </item>
+      <item>
+        <label xml:lang="es">Business Service</label>
+        <item>
+          <label xml:lang="es">External</label>
+          <item identifierRef="id-d02d8886a7934dc898143a97a8376606" />
+          <item identifierRef="id-73d6be570bd344aeb933d06b9566af35" />
+          <item identifierRef="id-cbc5896e78284e23b5bbca5e9a15dc76" />
+          <item identifierRef="id-633f46a9f9f84bbda07115037faf71eb" />
+          <item identifierRef="id-c160bb04a89643a880d79a2dce37bd38" />
+        </item>
+        <item>
+          <label xml:lang="es">Internal</label>
+          <item identifierRef="id-5f7aebddd3ad4a0593301978fca34bab" />
+          <item identifierRef="id-8108cbbc4ed64abbbe5b87014468f35b" />
+        </item>
+        <item identifierRef="id-e73fde26e4094a1c9f97edfb48139287" />
+      </item>
+      <item>
+        <label xml:lang="es">Business Object</label>
+        <item>
+          <label xml:lang="es">Customer Information</label>
+          <item identifierRef="id-d970cdcf5ac247698017f1e9732e2a07" />
+          <item identifierRef="id-b42e8f45867b487ca2ccd136ebfafde7" />
+          <item identifierRef="id-b56b5c461fc94c06b00ed6d33955fcb2" />
+          <item identifierRef="id-e59bb5647dc6486c8ea1d08b67c19bc1" />
+          <item identifierRef="id-0bed0f0876c6428fa25879de80d47208" />
+          <item identifierRef="id-fde9a2a74e544857bcdcd5c127214475" />
+          <item identifierRef="id-260c70cf6aad4a17b0d321e5674b57c4" />
+        </item>
+        <item>
+          <label xml:lang="es">Sales Pipeline</label>
+          <item identifierRef="id-17ef9d3c310b4a5aa7463cd6d85db619" />
+          <item identifierRef="id-d1edd2e27b3c48f0b4753883ba9ef65f" />
+          <item identifierRef="id-3c646c52bc8e45cfafa3b767bb3af35f" />
+          <item identifierRef="id-389fa5299bd54976a7e31306656cbb42" />
+        </item>
+        <item>
+          <label xml:lang="es">Register Order</label>
+          <item identifierRef="id-86a95bbd46c448b4ad517306a911c2e9" />
+          <item identifierRef="id-d527ba03811741ebb7569d1b04442a25" />
+          <item identifierRef="id-5f42eca753994b2eb284dd75b26a7cb2" />
+        </item>
+        <item>
+          <label xml:lang="es">Process Customer Order</label>
+          <item identifierRef="id-17b8b5467ec44bb3be416b7d71bd2a07" />
+          <item identifierRef="id-86819b7c2aef41b2b13dc893c50ea3ec" />
+          <item identifierRef="id-b1b2c63ef02c42eb88310f21fe662e87" />
+          <item identifierRef="id-201410bdce59449d817eda936fc5ef57" />
+          <item identifierRef="id-8d9a138abbbd49248dda77330d209ac2" />
+        </item>
+        <item>
+          <label xml:lang="es">ArchiBuilder</label>
+          <item identifierRef="id-6547822784014590b1f6ce403d11dab6" />
+          <item identifierRef="id-76fccb108cf0417894987ca3241ac9da" />
+          <item identifierRef="id-2915da9943da4ffd8ce7db5f564b8560" />
+          <item identifierRef="id-41f5b1884333497abc39d31394864829" />
+          <item identifierRef="id-c70aca3eba1040fc8561439d8b0f4bc5" />
+          <item identifierRef="id-251afb2b14b44e369b91879e8be1a7b2" />
+          <item identifierRef="id-c5ae1afc36664d8c8b6f17c160aa6369" />
+        </item>
+        <item>
+          <label xml:lang="es">ERP-to-MES</label>
+          <item identifierRef="id-770e063936e4428c8107dae96d3d3cc7" />
+          <item identifierRef="id-11ccd99fca024f548aa717079047a2d6" />
+          <item identifierRef="id-d908916d313d4fac9b2a6cd132eaf4c6" />
+          <item identifierRef="id-e27c7d476c4f4facb9f78e3d7edd041d" />
+          <item identifierRef="id-d3f6658ad824487fadc62b80a9709b5c" />
+          <item identifierRef="id-3748eb9ccc5844c8832b299b26ce3eea" />
+          <item identifierRef="id-d3d12d7b7e494f32a29a96499f6f66b1" />
+          <item identifierRef="id-08c08f4c8e6a4a50b14e523530a5c14f" />
+        </item>
+        <item identifierRef="id-c8586b2db2314b17852d6e100b1c633f" />
+        <item identifierRef="id-b184c5661a354a80a26061333635c927" />
+        <item identifierRef="id-2b87582d36d143db98c8e258b24655f1" />
+      </item>
+      <item>
+        <label xml:lang="es">Business Process</label>
+        <item>
+          <label xml:lang="es">Develop Contract</label>
+          <item identifierRef="id-16a56de036194eb79b44068f44ee244d" />
+          <item identifierRef="id-6ce3b2f185874049ad30f4b5d7a1491d" />
+          <item identifierRef="id-b0f8301b5a2744279cb027be12751c25" />
+          <item identifierRef="id-c4b62300152b4eab912ff382a166ce9f" />
+          <item identifierRef="id-66ed398ab28e442ea5516dd44cdc0a49" />
+          <item identifierRef="id-2372f409993a4d7c943255a5277337b1" />
+        </item>
+        <item>
+          <label xml:lang="es">Register Order</label>
+          <item identifierRef="id-d17a14d6490b493590904eee8473936c" />
+          <item identifierRef="id-3a3aa1f975794029b3d192f1dcefc361" />
+          <item identifierRef="id-9331a6d1c1f54746841c1c6908d8b9e8" />
+        </item>
+        <item>
+          <label xml:lang="es">Track Customer Order</label>
+          <item identifierRef="id-f7bd6d6664424100b329cb8b0ed40510" />
+          <item identifierRef="id-a9bbb7a79a9b4d568f6f66917f0b40d1" />
+        </item>
+        <item>
+          <label xml:lang="es">Process Customer Order</label>
+          <item identifierRef="id-458d93fe1e2f4c51a43bae8e26b96aa4" />
+          <item identifierRef="id-cef7496ae5d84bfa8b4de2882dbbb248" />
+          <item identifierRef="id-26bb007b0934471f9c05d188e9589372" />
+          <item identifierRef="id-c4d0ce61237a4b03a3f27f9d1b009e55" />
+        </item>
+        <item>
+          <label xml:lang="es">Convert Order to Contract</label>
+          <item>
+            <label xml:lang="es">Plan Order</label>
+            <item identifierRef="id-5f2f67e939914b59905c8b33282320ef" />
+            <item identifierRef="id-5360e04f3f2b4d858aaaf6229e79b09a" />
+            <item identifierRef="id-ffae0a20ba5a4960b55d50ff0b15dd68" />
+          </item>
+          <item identifierRef="id-53efc358b55540f0a4d75652777c457d" />
+          <item identifierRef="id-dfc0afa8475c4f559f13403e85a7f08e" />
+          <item identifierRef="id-2ec461c4dfd9428985b462c120b0fb79" />
+        </item>
+        <item>
+          <label xml:lang="es">Fulfill Order</label>
+          <item>
+            <label xml:lang="es">Activate Delivery Schedule</label>
+            <item identifierRef="id-4b13dd7b55374db8846d4660064beefd" />
+          </item>
+          <item identifierRef="id-d6fd3df3ae0b4a56b96f5d22d1293f91" />
+          <item identifierRef="id-434f18b593744f43914399d59d52b4e2" />
+          <item identifierRef="id-e09baac983c64a8abf359b5ead3f2b26" />
+          <item identifierRef="id-a33fd073b4ba4e508cbe3ab2dd3ebc6a" />
+        </item>
+        <item identifierRef="id-56a4ef970d314200bc4e95d8ea928093" />
+        <item identifierRef="id-eb6681ab4dd94ce3996ade5875bdf3ef" />
+        <item identifierRef="id-b7900be563de46529b9fc8d1975b2b37" />
+        <item identifierRef="id-103caa122d7e4d63a5b6479756634453" />
+        <item identifierRef="id-8584078cf77640869fc4b4ff7a60d00d" />
+        <item identifierRef="id-8c910863999445c0b2afceb98acbefff" />
+        <item identifierRef="id-f4676bc1d45f43e89921d3e0303037b1" />
+        <item identifierRef="id-322294a1d3b441b2a55c57b8dca6e7ff" />
+        <item identifierRef="id-590b2196df43475cb4e2cd018686ea66" />
+      </item>
+      <item>
+        <label xml:lang="es">Business Event</label>
+        <item identifierRef="id-c578fa3dcee04225a0144fa71920eeb6" />
+        <item identifierRef="id-8fa16f9c69894e46ba236ae0230911bc" />
+        <item identifierRef="id-6191979d2f304476ab02f638d4ece684" />
+        <item identifierRef="id-bbd25ba605ba4eafaa1ab945552f0449" />
+        <item identifierRef="id-185e92e049434c4f954cc9b68957879f" />
+        <item identifierRef="id-1ddb1228062a4a1997ec7e977f7f4e3d" />
+      </item>
+      <item>
+        <label xml:lang="es">Business Role</label>
+        <item identifierRef="id-d15443baa07a4291a075f402917fe007" />
+        <item identifierRef="id-e0af5fde22f148fd830c3b8f62c44038" />
+        <item identifierRef="id-569bfe90e09e4c4ea87799bb9cf23274" />
+        <item identifierRef="id-5af8778d34c44cac8d30b4736484ff53" />
+        <item identifierRef="id-0cedc365b4d4417f9d2a45c1f7cd5e12" />
+        <item identifierRef="id-cdda390a32864677a1dfe234de530add" />
+        <item identifierRef="id-946bfea9e17e42aa8f0184f2ef94b6f1" />
+        <item identifierRef="id-1ae1d77701f5419eae23f0ce50730604" />
+        <item identifierRef="id-ad64cacb19e34896829b2a462615fd7b" />
+        <item identifierRef="id-3b89b7e81d7d4052affd44601b6e7a83" />
+      </item>
+      <item identifierRef="id-9d3639bc0b2c46deafc67db505ca796b" />
+      <item identifierRef="id-10b667b736514a2da297f4dea0a14645" />
+      <item identifierRef="id-51c3a5a5d0c343df91c73e182a373148" />
+      <item identifierRef="id-8737a76acd9c4d1fbb2a4ffc86cb2993" />
+    </item>
+    <item>
+      <label xml:lang="es">Application</label>
+      <item>
+        <label xml:lang="es">Application Service</label>
+        <item>
+          <label xml:lang="es">CRM</label>
+          <item identifierRef="id-ba8ce89c442d457c845d849f2ba0b8e5" />
+          <item identifierRef="id-72854cd1e4ff40a1bdf77773165e2bdc" />
+          <item identifierRef="id-226179e7cbaa4a919383bdd4e44b41dc" />
+          <item identifierRef="id-99bc4a3c85954400915f6e7433440cb0" />
+          <item identifierRef="id-e9a3e42545534d519a9221494e2afb44" />
+          <item identifierRef="id-a4e2426aa6344ff49a4d9f5a22b67ad9" />
+          <item identifierRef="id-5c6ae3c285034247837fe4118e5c76d9" />
+          <item identifierRef="id-2dbbbff37e7644338f16ac2fbf784265" />
+        </item>
+        <item>
+          <label xml:lang="es">Develop Contract</label>
+          <item identifierRef="id-3e0c53acd20e49d491f78cf0d33475d6" />
+          <item identifierRef="id-deab2ec93baa49a28e95cb01ae59f7c3" />
+          <item identifierRef="id-0d58563f7c7647b8a9eb8d050ec6034b" />
+          <item identifierRef="id-eed49dfc6a754e3fbbcff474c2ee1b8d" />
+        </item>
+        <item>
+          <label xml:lang="es">Register Order</label>
+          <item identifierRef="id-65db965489624a89893068173a39cf59" />
+          <item identifierRef="id-815c2b316d7848279b068a86a0a2ddea" />
+          <item identifierRef="id-c9eb53d707564096a8727df622f078bb" />
+        </item>
+        <item>
+          <label xml:lang="es">Track Customer Order</label>
+          <item identifierRef="id-1cd9ba40fb81440b89ca6b9b81264bf4" />
+          <item identifierRef="id-c521cb12763d4ab3993c3c45b66dc5d4" />
+        </item>
+        <item>
+          <label xml:lang="es">Process Customer Order</label>
+          <item identifierRef="id-cb9b699fb1fc478c8a8f436b20038f0f" />
+          <item identifierRef="id-06fe133456074678b8f6a19e6aa5906b" />
+          <item identifierRef="id-c1d7e78cb9a8486cb0365b0c3eafdbd9" />
+          <item identifierRef="id-cfa3f50f73694f23a2ef50c482a320b9" />
+        </item>
+        <item identifierRef="id-9a865b3c106b4c5cb4800029ac3d54a7" />
+        <item identifierRef="id-8dd7f9e048c54837a99fdc6dc101ff29" />
+      </item>
+      <item>
+        <label xml:lang="es">Application Components</label>
+        <item>
+          <label xml:lang="es">Integrated Customer-Centric Solution</label>
+          <item identifierRef="id-2a8eb6786915456d92df41a8b9349314" />
+          <item identifierRef="id-4e06ee45db904a88aa46e9dce611528e" />
+          <item identifierRef="id-c728f7f622be468380062354ffbf4f57" />
+          <item identifierRef="id-e26375257d8440228f37158ecf5b8524" />
+        </item>
+        <item>
+          <label xml:lang="es">Baseline</label>
+          <item identifierRef="id-a9c72e1cb5344e3ab7a8a7bc8271776d" />
+          <item identifierRef="id-2eec1a4a343142c09574a74d773e2224" />
+          <item identifierRef="id-927db0f85d244a08b92e4925eb053d2b" />
+          <item identifierRef="id-df71ee7baba64cfbb35bcd00ed36040c" />
+          <item identifierRef="id-68903f066cfc4959a4e940405e47f6cd" />
+          <item identifierRef="id-5538d8de4e6c4918a62221922988c957" />
+          <item identifierRef="id-132442dad80345129362408c87cdde9b" />
+          <item identifierRef="id-641d335281ca4b53932f250e695f1f94" />
+          <item identifierRef="id-970722b900b14871becf437967275425" />
+          <item identifierRef="id-9d0751d373ec482b925d0f28f04f6608" />
+          <item identifierRef="id-021e6ea0d09f433f92532777a5980497" />
+          <item identifierRef="id-51d42a1da36a42c2811e84ff8952cb58" />
+          <item identifierRef="id-3dfec7838acb47f588677d6e8f948fd9" />
+          <item identifierRef="id-09b37e64a61d4c4183f49930d1237509" />
+          <item identifierRef="id-3eb0685faebf42cfa81567c6a4e7db24" />
+        </item>
+        <item identifierRef="id-3237b47e6ecc442b87d63a2c0ff8077c" />
+        <item identifierRef="id-b67b02752ebc4b929c9a9fc76211cff9" />
+      </item>
+      <item>
+        <label xml:lang="es">ERP-to-MES</label>
+        <item identifierRef="id-1c00d69a990445f7a53257a2b8a185b6" />
+        <item identifierRef="id-f1f36d4abf914d598a9b032762310b30" />
+        <item identifierRef="id-e127038f87cb42959f5a9be4c63ac400" />
+        <item identifierRef="id-8e6db4ddae3a41c2a7fe819cb7c140db" />
+        <item identifierRef="id-85f3e58459cf4566a8984eb0261305df" />
+        <item identifierRef="id-0b43aa7ad1e34ecfac49e9107b204ed6" />
+        <item identifierRef="id-de3928a8ce2d4a0c8777d3c53213e57e" />
+        <item identifierRef="id-54d1145720594f2784b21ce4e4ca0ed0" />
+        <item identifierRef="id-3e585eea23014b888f64de613fe21d3c" />
+        <item identifierRef="id-20aa4381e31143b697919991db4db30b" />
+        <item identifierRef="id-cf388ea8144942eeb6a7d23d2fc9d9e5" />
+        <item identifierRef="id-d40e8b39852a401db024c671bc95209d" />
+        <item identifierRef="id-f32c66917de74091bdd5a9624452f2c3" />
+        <item identifierRef="id-89f4b36253eb49fcbf5f75119cf5ff24" />
+      </item>
+      <item identifierRef="id-300c7dd906cb45b4b0b8e6bb0828221f" />
+      <item identifierRef="id-b8ba463d96e7480e8099014269c938e8" />
+      <item identifierRef="id-4c50a5c4b84a49128b53481ac94f3430" />
+    </item>
+    <item>
+      <label xml:lang="es">Technology &amp; Physical</label>
+      <item>
+        <label xml:lang="es">Physical Processes</label>
+        <item>
+          <label xml:lang="es">Logistics Process</label>
+          <item identifierRef="id-868a037328914ca79d43352cdccc890f" />
+          <item identifierRef="id-330b37e7d3bf425a8da334998ed4b559" />
+        </item>
+        <item>
+          <label xml:lang="es">Physical Production Process</label>
+          <item identifierRef="id-e36661dac4014c0bb54cc138c8af5485" />
+          <item identifierRef="id-cfa53abb5fea4aac8c1ad6901b1b2470" />
+          <item identifierRef="id-493d8b255dcd4c249087ff7e85f0f16a" />
+          <item identifierRef="id-169ba8405759474db2179d246f01216d" />
+        </item>
+        <item identifierRef="id-32425a437e9b4d6e88c7ea527389db79" />
+        <item identifierRef="id-d894787e002341deb3688fbc1084e63c" />
+        <item identifierRef="id-809e6563310c4e15b7697fa525023abf" />
+      </item>
+      <item>
+        <label xml:lang="es">Steel Production</label>
+        <item>
+          <label xml:lang="es">Hot Strip Mill</label>
+          <item identifierRef="id-64e12c6aa1954c6486e01bda92a18d82" />
+          <item identifierRef="id-dc154c48f080459ca6e29d7f1edaf050" />
+          <item identifierRef="id-7d3aa9ac0b804060a502de4b8ad537fc" />
+        </item>
+        <item identifierRef="id-e79b5c486e7b472ea4db37e0d5a19efb" />
+        <item identifierRef="id-a9ed7174af0548d5b138b47fba446282" />
+        <item identifierRef="id-64e6961cbc5b4c03b984593db7d9ae8a" />
+        <item identifierRef="id-3bfc5d5eae14479aa57922a2f99ab3d6" />
+        <item identifierRef="id-143ca1ce20d2492caf819e0787d23823" />
+        <item identifierRef="id-e54ac98461364b6f89be0d7ce49996b0" />
+        <item identifierRef="id-5903ad80d51e413dab64159cdf1f6fd0" />
+        <item identifierRef="id-02c0f4e1301f46cfbf2453b11e1c6de0" />
+        <item identifierRef="id-0cc3e6f3dca340b58f7b177619936176" />
+        <item identifierRef="id-3d3294e5d139473e965cacb7ad9e4e7f" />
+        <item identifierRef="id-23d2166d570f40bdad1417d39f10373f" />
+        <item identifierRef="id-4364086f4188452084a6168dcbd7b186" />
+        <item identifierRef="id-cf389c783061458f822a388324e89b09" />
+        <item identifierRef="id-1d8b234a0add4fdca68c71514f32e981" />
+        <item identifierRef="id-9d1d0adbfe2c43cba2db422b4ca184cc" />
+        <item identifierRef="id-64a3c89d49ff447f9dab07ddcaf002ec" />
+        <item identifierRef="id-2ce4621d4a164842b29cce506cde7a68" />
+        <item identifierRef="id-131c1792801b40a49a9041661dec5ed8" />
+        <item identifierRef="id-8b9b1e49a27848f68fea836a25a610d6" />
+      </item>
+      <item>
+        <label xml:lang="es">Corp-DC</label>
+        <item identifierRef="id-40f1e7bdf4c74241b1ac5763b3aa9d50" />
+        <item identifierRef="id-79c6674039c14444a51dc8f5c7491b23" />
+        <item identifierRef="id-6ace217c8c624d229ee2cc11528d52e4" />
+        <item identifierRef="id-772a5d3d408142a28ab040048e09e7ff" />
+        <item identifierRef="id-094df2608dbf49078615591a945c3681" />
+        <item identifierRef="id-b0541156f9194546bd0922c13349649a" />
+        <item identifierRef="id-7eb87af87eb349d9b8a5a8b5cbad8856" />
+        <item identifierRef="id-4196a1f9d7464198aad03a7a67bfc82e" />
+        <item identifierRef="id-9d76a90f5163422494119c99f6a908f3" />
+        <item identifierRef="id-a1337fb63ca144ad9473d94406ab187e" />
+        <item identifierRef="id-f0b5bad31d9246ba8689143d271f6c38" />
+        <item identifierRef="id-7bd8507070fc42b2802ffc882e48484e" />
+        <item identifierRef="id-2f548011437a41048be837f74c3f4d00" />
+        <item identifierRef="id-0b84596d01f04499b880d15e58879759" />
+        <item identifierRef="id-69f1b9c8a59146a8938218dc363b3895" />
+      </item>
+    </item>
+    <item>
+      <label xml:lang="es">Motivation</label>
+      <item>
+        <label xml:lang="es">Stakeholders</label>
+        <item identifierRef="id-fcb1db6aa783410aa3856df684699fd3" />
+        <item identifierRef="id-8939bfb16933425c952bd4ca553d90e2" />
+        <item identifierRef="id-f31166117d504940a2268fb1dcb0bbc7" />
+      </item>
+      <item>
+        <label xml:lang="es">Drivers</label>
+        <item identifierRef="id-985c644ebbe343c5a32fc36353e0535d" />
+        <item identifierRef="id-41f712023d8b4f9babb41249355dfc7b" />
+        <item identifierRef="id-1008ebfba144417f8e8a58e889c3b9c6" />
+        <item identifierRef="id-3fe71c490fc64bf3bb22c73bff890b38" />
+      </item>
+      <item>
+        <label xml:lang="es">Assessment</label>
+        <item identifierRef="id-773494ddbf30427a8218ff76abbe0d5f" />
+        <item identifierRef="id-bf3da697d4314f33bcb03ae7ed84d665" />
+        <item identifierRef="id-73a045146ae94517bca67365cd206c1a" />
+        <item identifierRef="id-e929318a3ae441ba9dd96b8d4623557a" />
+        <item identifierRef="id-4c52d1762cb8468c92950f0bc509e045" />
+        <item identifierRef="id-70189a83837444a798183ae73a7bc5b2" />
+        <item identifierRef="id-26dae395ffb343dcbb3a410b88d3021d" />
+        <item identifierRef="id-db9483ab0a3b4f1eb7259e53426eee09" />
+        <item identifierRef="id-58df809904fa4baf8b5b7c28c53d20b0" />
+        <item identifierRef="id-4aee877b6bfd42619217ccb2547b68ba" />
+        <item identifierRef="id-3fd6818a449e46559476e24456f63196" />
+      </item>
+      <item>
+        <label xml:lang="es">Goals</label>
+        <item identifierRef="id-b9d676d91e5e40ebaa9338c0e87463bf" />
+        <item identifierRef="id-f19bc7ea65c94679b97db1774cb2ef34" />
+        <item identifierRef="id-d57beba0aeca4d5884d9f79cee2cacad" />
+        <item identifierRef="id-a0f64c7e0e3b43c6a9ea32a9b35e99eb" />
+        <item identifierRef="id-877622cb13a744b1baa7d9e94576aa25" />
+        <item identifierRef="id-f11c2b0d08c44572995ce0a180edc174" />
+        <item identifierRef="id-d676a607a130483a961a4a1de0179094" />
+      </item>
+      <item identifierRef="id-4b6a9ff03a9b4b1689350806c022f681" />
+      <item identifierRef="id-9960fb227da24f57b727e05fd81a7739" />
+    </item>
+    <item>
+      <label xml:lang="es">Implementation &amp; Migration</label>
+      <item identifierRef="id-fbc7c240895b4e0397b9aea45e0618bf" />
+      <item identifierRef="id-4d7f4fc0971947f787ba6b4fa2ff3fa0" />
+      <item identifierRef="id-4cf5ebcb7c0b4c01bfb2c6934504ba8f" />
+      <item identifierRef="id-2f8dd2120d55460896baf324b937dfd6" />
+      <item identifierRef="id-8e83c502c9924312923992e8b255bff1" />
+      <item identifierRef="id-d81bb5d2f5274f239d10b8a210a2fa8b" />
+      <item identifierRef="id-e429c90e3c69458f9131f11c48669677" />
+      <item identifierRef="id-58761ca77a6d49818b06fd0021959839" />
+      <item identifierRef="id-be22e5fb2b804f32b1087966af591ec4" />
+      <item identifierRef="id-faeb172be6704b9d992fe8646d3028f0" />
+    </item>
+    <item>
+      <label xml:lang="es">Other</label>
+      <item identifierRef="id-c3e80fb693bd48ebbfe756c998d7384b" />
+      <item identifierRef="id-8b75218115db49b9aecd0501d04d5545" />
+      <item identifierRef="id-93c74e2f4b8b4b0491164e6d79c445d6" />
+      <item identifierRef="id-26586078852645d59ea8b14781701c65" />
+      <item identifierRef="id-0c7864041e1546d38b8f0cef3bb638ab" />
+      <item identifierRef="id-72b88e880fe74bc1b6c30caa12640289" />
+    </item>
+    <item>
+      <label xml:lang="es">Relations</label>
+      <item identifierRef="id-41a7e9a05f634d78b0905a8377bbb636" />
+      <item identifierRef="id-bfdad74a7fac4bfe85f85ae3f89b5b8f" />
+      <item identifierRef="id-787a4cc6202d4b01a2fdc74dcfe2fd57" />
+      <item identifierRef="id-621760440b4e4f8eb1b08d0c23e5ee49" />
+      <item identifierRef="id-f42ba8a6bdc143f2984f4e4921ca2de2" />
+      <item identifierRef="id-caea252e989343969654c9a981e9e25c" />
+      <item identifierRef="id-2e44ec61777c449bbc4d01d28db2a7ef" />
+      <item identifierRef="id-90888cc5c1eb44b8ad54e7e8b392c9ea" />
+      <item identifierRef="id-1fb891470a8b42d2b0f87e92885a14e6" />
+      <item identifierRef="id-c538f1bf4f144469aa207e73bd8189c5" />
+      <item identifierRef="id-68ec6264cc3e4faf97177c0b496099bf" />
+      <item identifierRef="id-d07e45f34c934ad88f656e41c7186a08" />
+      <item identifierRef="id-f7739d8d47624648bee67824e68ccae4" />
+      <item identifierRef="id-9f43bd5578534fc5824e27a572a22cf9" />
+      <item identifierRef="id-76a6723cd0824465a7a1d77014d8b6ff" />
+      <item identifierRef="id-f3bf5f25f60e4c89b7f6b9de305ff28c" />
+      <item identifierRef="id-eb38b69298ee46dfbe0d976f84d8d262" />
+      <item identifierRef="id-6f5c6dceb0594ca8ba8be8e85214b686" />
+      <item identifierRef="id-7e623a892b494202b7fa8ea6a1a06c80" />
+      <item identifierRef="id-cd6c3aeb94cf4cefbfd3df75082d8fe7" />
+      <item identifierRef="id-77773be25be24129bd660aab1c749b7f" />
+      <item identifierRef="id-ce665fc5db4d4e3cad11c6dec73e70b4" />
+      <item identifierRef="id-7d9525874e154f8fb292970c5cda6ddb" />
+      <item identifierRef="id-9a8d56e3053a422e9009a70dc23b28f5" />
+      <item identifierRef="id-61b7abe559c64c4ea18fcba54c1ae17e" />
+      <item identifierRef="id-91cf3830343346699650c97c4962a76c" />
+      <item identifierRef="id-46390cc95d6246c08208fa25fb06aa49" />
+      <item identifierRef="id-1d368509cab740e4bcfc5fdf91b827a2" />
+      <item identifierRef="id-0eb3c88263d84399bb798d8e24afa00b" />
+      <item identifierRef="id-33cdf3f2d9e344199ba50e2ab92e4ec3" />
+      <item identifierRef="id-dee89864271043df898a92ae5b001fd7" />
+      <item identifierRef="id-aab1dbccb34f4d43b104b4a8c5f70a37" />
+      <item identifierRef="id-94ecdff105684a36bcf339a4bda8499e" />
+      <item identifierRef="id-905f8841ef2f4debbdae6ae27fec16c7" />
+      <item identifierRef="id-b38253cbaf7b48ad9cb0307b851e2ea8" />
+      <item identifierRef="id-ff4fba53c3c24676af1e7cefaef702c9" />
+      <item identifierRef="id-5345754f72ee4a339dbd8c95879a865f" />
+      <item identifierRef="id-aabd8faaeb1943cd90c517f625d3ae17" />
+      <item identifierRef="id-06e6805296004d95b46ab40f2e633b2e" />
+      <item identifierRef="id-11d4a56d51c3476aafda510d68127aeb" />
+      <item identifierRef="id-a921b99ac27d48daaa7f4257f848df46" />
+      <item identifierRef="id-f0f98883b8ad4d30af589b98c62a7098" />
+      <item identifierRef="id-04266827af764ac095b38c36d16c0ddf" />
+      <item identifierRef="id-49833304877847309113437178ce88d1" />
+      <item identifierRef="id-bed57c56146f445780694bb9c7b097e0" />
+      <item identifierRef="id-e290eaf5e13d42828c1998b01b6c9028" />
+      <item identifierRef="id-86ee34f4fdb14ac4957aa6ea6ef34e6a" />
+      <item identifierRef="id-47095985ccd84fd49165d5854bbda0af" />
+      <item identifierRef="id-6f9d014c9eeb44aba2a3f468e1f09c7d" />
+      <item identifierRef="id-ff93f89996444d5e96d293c778a769e5" />
+      <item identifierRef="id-8934907edada473fa5878d326d9a47d1" />
+      <item identifierRef="id-25649e1af41945b4b77cda1050fa9904" />
+      <item identifierRef="id-ac83455bf9384f09b5dfb7d04f8d5d4d" />
+      <item identifierRef="id-444656e2076d467c96a713b0a58a058f" />
+      <item identifierRef="id-d155f8d0a8e84fb6b20de1e991a7e56d" />
+      <item identifierRef="id-fb0e9ab738a840a69b6711d3ed7e7725" />
+      <item identifierRef="id-b9257449c58a4d5e868cc2142dd128c7" />
+      <item identifierRef="id-a5b2a14f9da845529fa6a4cc6e589e71" />
+      <item identifierRef="id-6816b6a7ed46492a87251d726ec06d7a" />
+      <item identifierRef="id-a5beea4740974139825a59c15b6d8dfa" />
+      <item identifierRef="id-b063cacf85f6455f915ba818b5dda91d" />
+      <item identifierRef="id-4657a2510445450fb2a5a8f28e4c8e33" />
+      <item identifierRef="id-8c2a1aee70be437bb9e08b17947d781d" />
+      <item identifierRef="id-2b4fc33da23c481b9f315c3b3802eb0e" />
+      <item identifierRef="id-69b7bdfe1fe947c092947aa785e55822" />
+      <item identifierRef="id-92b485ef57bb4833baa3de4f30d3cf93" />
+      <item identifierRef="id-63a47bfb8a6c4976b0cf9b05737ab7b6" />
+      <item identifierRef="id-382ff4a3c8e34fb6922341e6d713e425" />
+      <item identifierRef="id-db7373bcc3314ebbb731ef7e07d26388" />
+      <item identifierRef="id-39e52a103c804df8a13a9340ae3012db" />
+      <item identifierRef="id-73f64dea1cb446d197c2196ecb8e38e3" />
+      <item identifierRef="id-e742d45767a04a99a009bf800315f50f" />
+      <item identifierRef="id-8aa225cf93f945b790e82a0dacf6a2c0" />
+      <item identifierRef="id-e645861dcfa348e4908b38a236f7c987" />
+      <item identifierRef="id-57ef78b12639485391ba16c6f77a23a8" />
+      <item identifierRef="id-e3360c30fe79439aad031c4ab0179f73" />
+      <item identifierRef="id-77d3c7ec3c7d40b792c69a7e77fc05fc" />
+      <item identifierRef="id-059ee2d9df774b37a6cf5f3781474078" />
+      <item identifierRef="id-56006141b9f84774bf187017b6b4bbfd" />
+      <item identifierRef="id-fe5b1c1a7b7b4feb8c332646fb491054" />
+      <item identifierRef="id-ffd2cd9166134f5696a00d225c52da64" />
+      <item identifierRef="id-0348cd1eb1584e9b8c3e227e3ac1e452" />
+      <item identifierRef="id-19d3440bf3644351a243e4643a1a10d8" />
+      <item identifierRef="id-d3469f3809b4441d942adf3ef2741833" />
+      <item identifierRef="id-7669e65ab1034b6d878df79babb655a5" />
+      <item identifierRef="id-ba744d730a164cf0b0c5719100b2569c" />
+      <item identifierRef="id-7b538a04c895462c9ccf34c555b3fcbc" />
+      <item identifierRef="id-3b75b3117c164ed78c02b13d9d72f03b" />
+      <item identifierRef="id-3bda25cdcd914997bcfbce7508a2b52f" />
+      <item identifierRef="id-5e4ced2c083341aaa1d43e43cc386f59" />
+      <item identifierRef="id-29cf98286e404826813e3fd5d363faa4" />
+      <item identifierRef="id-edbfed03abca46d0b0fa9f301af49848" />
+      <item identifierRef="id-284558569ac940e1a5b0e3000096850f" />
+      <item identifierRef="id-a2a0c2f582964d98ae5e90d434018f18" />
+      <item identifierRef="id-30522f5fa02146338ce89262dba83fb5" />
+      <item identifierRef="id-02ed4c260f494d798413cd888ed9a225" />
+      <item identifierRef="id-52fd056560dc472a9e3437d3fecd4bbc" />
+      <item identifierRef="id-c2bea22fcc67491e8f94e92c284a6ffe" />
+      <item identifierRef="id-13604f57255f42d2aba9fa1285d8425f" />
+      <item identifierRef="id-8bb3d6c2686a47bea3048439d73a7961" />
+      <item identifierRef="id-6bc9b8fd5f864ec1b28f44033ab4bc34" />
+      <item identifierRef="id-e18e110381a244d9b7ca1213c59aaa3a" />
+      <item identifierRef="id-46c475168f184342aff3386fa1a409f8" />
+      <item identifierRef="id-0c9b384a0f314c48bd6fd49c1a23367d" />
+      <item identifierRef="id-ccec811b82164a469276ca27701eb708" />
+      <item identifierRef="id-d637c518c2804e4bbf700a2a00cea06e" />
+      <item identifierRef="id-f8c2d334855e42aea1b8b3dddfae3511" />
+      <item identifierRef="id-4aeb5830e5be44a59f41e38852b51e10" />
+      <item identifierRef="id-bcb70aebfdf34d72ad32102c1edff687" />
+      <item identifierRef="id-d6ae7cd1b2014e8f8b9d0b0d38c41c60" />
+      <item identifierRef="id-dcee7b146bd64c8b80fbb6460181cf41" />
+      <item identifierRef="id-86bc53efc09a4d01b5d863ea4da169a1" />
+      <item identifierRef="id-dbfb1e8203a64297b4b46862578575d1" />
+      <item identifierRef="id-6213dcf0f30b45409a2b720997924d23" />
+      <item identifierRef="id-bd55ed3c11c1404e8d577f749890f91f" />
+      <item identifierRef="id-9e1687fda55a4ad3ae72f552ab81fa35" />
+      <item identifierRef="id-8ab746b84c13420787ea6833f3f740ef" />
+      <item identifierRef="id-73834b75835342c0852e918d323d1b4b" />
+      <item identifierRef="id-b3157f38393e4f3d91a6a7c006c87b44" />
+      <item identifierRef="id-e90321392fce4177b7d95e581a45fac6" />
+      <item identifierRef="id-5bc5b1f4ab2a4ca59d7b576654d10be3" />
+      <item identifierRef="id-5199875c53ef4161be35819c68faee1b" />
+      <item identifierRef="id-e7b2e1e8377d4a62988ec81702d8f805" />
+      <item identifierRef="id-69ffc5d95d864033870d64dd6f2cd029" />
+      <item identifierRef="id-1cc784cdeb4748e0a841245b478cdbe9" />
+      <item identifierRef="id-7128fc52b41645f2883190e4afd5803a" />
+      <item identifierRef="id-3a583934bb6e4b35a95ffd55de3f0b3d" />
+      <item identifierRef="id-c214b5cca9994a1e8588c4108eccac9a" />
+      <item identifierRef="id-8f8860b230a54eb3875dc5396b9d361f" />
+      <item identifierRef="id-118f040562a4476087aa2fe88f8631b1" />
+      <item identifierRef="id-c54f7e7ec880417881622de16ae01249" />
+      <item identifierRef="id-8b57d961a22f4ee7a37280bcf0605c3b" />
+      <item identifierRef="id-4355814ad2bd40fa8e7bf2b06e237f9b" />
+      <item identifierRef="id-09d464beef544058aa2967e77f4436ba" />
+      <item identifierRef="id-614ca33606b04853b992a8370c914142" />
+      <item identifierRef="id-7856a54511f24730a8d64f4147c5ea4c" />
+      <item identifierRef="id-cfa2c2b556254127b249c4ab0c58e425" />
+      <item identifierRef="id-9ccfdf80797d431b8b281efbe4bb6753" />
+      <item identifierRef="id-4bfc7945edb744ac9f74fe9621726447" />
+      <item identifierRef="id-6c4dbbfad1be42b6b9a8c4f81556cb43" />
+      <item identifierRef="id-bce367c94f9c417791e8bb987f220248" />
+      <item identifierRef="id-9b86b5def09747ccba106869f577267b" />
+      <item identifierRef="id-fb680925b6944ad49547daeb63178de8" />
+      <item identifierRef="id-8b5f76ead5464ebdace7dd4ffaacae91" />
+      <item identifierRef="id-854eab2f9d8446708ff00fc216fd026e" />
+      <item identifierRef="id-8e1e118effae4e4abbb7307191a4b76f" />
+      <item identifierRef="id-26a00b70891e43dd8e23d2386956d1c5" />
+      <item identifierRef="id-eafcc2e35d494c069d65233cc5431572" />
+      <item identifierRef="id-3037bdfa443f472588e0f4233a423eec" />
+      <item identifierRef="id-2d8ad9219a084314b9f6b34f0bbcb2ab" />
+      <item identifierRef="id-ade5af23ad054833950877e5d28a9743" />
+      <item identifierRef="id-026d56fafee84728936bb106a423b4b5" />
+      <item identifierRef="id-d9dd6f2624c94bd5be7bdebe95037219" />
+      <item identifierRef="id-dcc7e7bbdea2449fb76e4ce82ff7131d" />
+      <item identifierRef="id-ddf77800e82040caa3ab3ae7f93da8ae" />
+      <item identifierRef="id-8b40148638df402990222b414ed12358" />
+      <item identifierRef="id-b2f6b889474f475d9e537bc7767dc572" />
+      <item identifierRef="id-6e814dc25573414a8051b8d98d9ea3cb" />
+      <item identifierRef="id-4e2b77700d624c3fa6193891741156ac" />
+      <item identifierRef="id-dbbe3f8f66224ef292695f41c4ee60b1" />
+      <item identifierRef="id-68dd5f1df64840cd82fc19f574db7884" />
+      <item identifierRef="id-906ff6c00cce4a389d7c02c541a49522" />
+      <item identifierRef="id-696a146fe7a44bdd88efd1608dd5df47" />
+      <item identifierRef="id-99890b62ab614616971459f19ef22402" />
+      <item identifierRef="id-ea7c8a97872a444dbea31e97b5a1d422" />
+      <item identifierRef="id-7aa6c18eab5943e7ae0816a82cec4e51" />
+      <item identifierRef="id-7adc30f47d424be187ad7fb51fa8aa26" />
+      <item identifierRef="id-eff762786a4b434eb1ed3dd4919029cb" />
+      <item identifierRef="id-2fe6cb0e31bd45eb864c7535e83b4bb1" />
+      <item identifierRef="id-eafe2f0467a1431e901f1d13b97e4520" />
+      <item identifierRef="id-0eea1d6636e74768bb3c6dab3f89c637" />
+      <item identifierRef="id-3ffcda1623f6414d8d809df41bf4da82" />
+      <item identifierRef="id-b8b461839ac14b09877660b5c0c957d3" />
+      <item identifierRef="id-14ac215f81554bccb60dd834079eee55" />
+      <item identifierRef="id-f595dcb5bcf94d3e82371435f0a7edaf" />
+      <item identifierRef="id-b35f3d1831e64f798ebe5fba8cbe9f34" />
+      <item identifierRef="id-4bb031dc79024a6eb809db3c2a9de992" />
+      <item identifierRef="id-5e030eac9d3d4341a4a07a7dd9947f83" />
+      <item identifierRef="id-66c6765e590b4e7ebc371e58cf171fdc" />
+      <item identifierRef="id-eca59d66cde04c79b993f01a19723007" />
+      <item identifierRef="id-e81da98bf225425d88569aeb05ee2f25" />
+      <item identifierRef="id-35b554c3967343c8ad3256f6f128db1e" />
+      <item identifierRef="id-c4ed64b53e3f46d098ef73b1e6e581fc" />
+      <item identifierRef="id-ff096bd70c66467a9932402893dac1b7" />
+      <item identifierRef="id-fc28e7aaa8814b3ca8a199e3e59f7cc1" />
+      <item identifierRef="id-def095d2db5a421db8128235714397f9" />
+      <item identifierRef="id-46552ee6a0794c8880f5d3da74a0c89a" />
+      <item identifierRef="id-59364b03590d4e65beb4a8adf80f3dd0" />
+      <item identifierRef="id-aeb98da82ca84aa1850ad53e48b04c63" />
+      <item identifierRef="id-5285a85c637b4248b5f26de5cbaa0690" />
+      <item identifierRef="id-8c023a9ee9704765876cd47005b454e9" />
+      <item identifierRef="id-017b10c34d5747078797cb271805ea1a" />
+      <item identifierRef="id-a54cb72d96ed4ed185541b210e4643d4" />
+      <item identifierRef="id-c3f3310108d0446e828a199e8c1e1287" />
+      <item identifierRef="id-40c9de0556634b378770e2d0e82e6321" />
+      <item identifierRef="id-1a29fe0e1b4c4331877702f33268999d" />
+      <item identifierRef="id-4c8fd7a27e75437db169d1e84a083ffc" />
+      <item identifierRef="id-e6fb41e9b92c4c519a30cd42c432dc08" />
+      <item identifierRef="id-ff14d959f7d44dd0962777a0deaab52b" />
+      <item identifierRef="id-43eccc3c162e4e89a85c0da3d7140a5d" />
+      <item identifierRef="id-7cf01db640a545c28862f6bd64dfe7d4" />
+      <item identifierRef="id-a95c505e2e6a4d33897292a5ac05cefe" />
+      <item identifierRef="id-a5ca972c87a1493c969ab24a5404318f" />
+      <item identifierRef="id-2523d00aed2d4d008634b25bde995ecb" />
+      <item identifierRef="id-f22939f7189241ba95869a943b8cd0bb" />
+      <item identifierRef="id-fcf8aded662049e0b93b0d62962f2f21" />
+      <item identifierRef="id-b090dec397394ef681f15c3f519e817b" />
+      <item identifierRef="id-6422d873eda848ba91f09508ef4f72d8" />
+      <item identifierRef="id-6f0221f88d5d48cf94f91a98cf8bfec1" />
+      <item identifierRef="id-e4e24864e5164dfc95b8cc0ea97edbac" />
+      <item identifierRef="id-05c70459dd8c4b809d4b5a8be8e6546f" />
+      <item identifierRef="id-b1a7b166888f45d3bf4db9f7015c5b2a" />
+      <item identifierRef="id-3a90dbb3cd9a405eb636ff541425b895" />
+      <item identifierRef="id-7cdcdb4b40a242a9805c7befbbc484d8" />
+      <item identifierRef="id-855abfcab77b4399b9124ede0c28f1c1" />
+      <item identifierRef="id-15eaf22bbd514661a6986b679bf7bb5a" />
+      <item identifierRef="id-33409723619341ddac60e2901c77a9a2" />
+      <item identifierRef="id-3cc58aba3d844d8783f78300e809ac35" />
+      <item identifierRef="id-9b2dc0367c094304acfaabf7f2f0b125" />
+      <item identifierRef="id-e3aee34bae8247a99db2b29f555a9705" />
+      <item identifierRef="id-ff325924b75446a4b25aa54d26c46f14" />
+      <item identifierRef="id-35164ebce06748cebc3847aa49ac6dae" />
+      <item identifierRef="id-27978db60c43457381ac9ed8885ccf91" />
+      <item identifierRef="id-afac10b2330b4bc8be3444b79771b569" />
+      <item identifierRef="id-7482a60e92cc4f4a8de0d8aca202cd2a" />
+      <item identifierRef="id-669d682920734511accefa5b2cb7dd1f" />
+      <item identifierRef="id-9701ef25128c4149b850331677749aa1" />
+      <item identifierRef="id-8b7fdcbb1fb446b6a168bc53550a2842" />
+      <item identifierRef="id-eb71dae724ab4a6a9fad0e61d194eb26" />
+      <item identifierRef="id-ebebf195ec63472980382dab9e91ddac" />
+      <item identifierRef="id-44f95fe75c464b19a14a81609cd421db" />
+      <item identifierRef="id-07a1defae2014e9d855c59525c19c7b7" />
+      <item identifierRef="id-9a48df866be44d569b3ad2db9fb24086" />
+      <item identifierRef="id-84d40daec2984878ba7febd33358735a" />
+      <item identifierRef="id-1cb615feba4d41df9c417602872a99ed" />
+      <item identifierRef="id-9a3a3d96c2344514b644e1fdb8cdb8c7" />
+      <item identifierRef="id-e6e261c583274041b176b41f25ceb8ce" />
+      <item identifierRef="id-fc55fad85ad34c889c90180ca5d0dda8" />
+      <item identifierRef="id-7f3129c6dcf24ccc9aff60bcc4c592d0" />
+      <item identifierRef="id-34ce1e3219e64c8087d5076fe6ec0e0b" />
+      <item identifierRef="id-412391d8896349879b8c4b54ce5757dd" />
+      <item identifierRef="id-e092d643c58a4c84a0ed9793533a7547" />
+      <item identifierRef="id-166fcba5acf5471a8828202da41fa48c" />
+      <item identifierRef="id-2d92386db079451180d64d31f71f9c60" />
+      <item identifierRef="id-445880943583432fa58216cbf99d4442" />
+      <item identifierRef="id-9ed2457c1a9841aa8b16d241a189896e" />
+      <item identifierRef="id-0f71872a317d4921acd3753b037fa819" />
+      <item identifierRef="id-701d86f03871434fb57f5c3c212040de" />
+      <item identifierRef="id-c7b848b67db84c40bb4e52a025263c91" />
+      <item identifierRef="id-3f3f2c435d0543ef8da0f650a4bc8d93" />
+      <item identifierRef="id-5bacbca553ff43f88e881b7997d3d766" />
+      <item identifierRef="id-595be39534aa489bb62d5a3afd47940b" />
+      <item identifierRef="id-5dc81e5b1f474fd6a4549f8017b1e3cd" />
+      <item identifierRef="id-78a7fece31a74acbb9e47151730434e7" />
+      <item identifierRef="id-ff3d80c6edd54820b87ac51fee9726f8" />
+      <item identifierRef="id-87dc078893904a5f8e1628e083aae26e" />
+      <item identifierRef="id-d0b777594fbb4028be16bd38bac622d3" />
+      <item identifierRef="id-7d7f3fce2734465890ba509b7eec364c" />
+      <item identifierRef="id-00a2122c13fa4a5380523eaa404c8894" />
+      <item identifierRef="id-776b3dbb68a64026ae7e78f71246fda9" />
+      <item identifierRef="id-b0dbd0952d7e4c7a9db21298a3cd27af" />
+      <item identifierRef="id-3c157187e57042c983f84b01a9348cde" />
+      <item identifierRef="id-3ca88c32f00441349bd9aca0dd67f7c2" />
+      <item identifierRef="id-4abc7f162f9042f99a1ec563b8696d4f" />
+      <item identifierRef="id-61ebdc87de474e20a879a30a1c99fc82" />
+      <item identifierRef="id-9984fc4756e9471db662ba12b8aa4d83" />
+      <item identifierRef="id-8f2a9b3e59a347b682191c6cb2cd6971" />
+      <item identifierRef="id-a70f6ec37cf34a3c88adf7404a93aa5b" />
+      <item identifierRef="id-58e0c880b3db4f58bec1bdde212dc88a" />
+      <item identifierRef="id-baad7774d92d405e8f261b045ebd1e10" />
+      <item identifierRef="id-c4661a6ddd404053a3a448dfa9a1add1" />
+      <item identifierRef="id-0c490d09ad5e470d8e1f2fd8e1357ffe" />
+      <item identifierRef="id-40a93d8fc0674a83a55543c7d366f9de" />
+      <item identifierRef="id-3e2d1f927d6f4f7ba931c5cfbb8e6569" />
+      <item identifierRef="id-1cdecf4d901346dc92de35811d271b5f" />
+      <item identifierRef="id-76fd4032523f4952837124c227ea1b4e" />
+      <item identifierRef="id-a8ef868842644973850d7f8f8570bdd5" />
+      <item identifierRef="id-021c6830e7cc4b59aa81ddf73e16ad39" />
+      <item identifierRef="id-b3c7e6dd03204ea4811126d8d72dc929" />
+      <item identifierRef="id-b0e1f724270049b8ab6861a45b2a9d3a" />
+      <item identifierRef="id-b6fb2f69c7b84d36a9d7d44488f5dff3" />
+      <item identifierRef="id-a42603dd1d294eedab1ca39175719926" />
+      <item identifierRef="id-f666ddf925cb4a699663144ace30837f" />
+      <item identifierRef="id-62bec07ee1c24eea904e7bcd21dfedfc" />
+      <item identifierRef="id-c9f7575d9f0d454faf830c50662e129d" />
+      <item identifierRef="id-3a7a20f9ddee4102aa2a1009dda0f8d4" />
+      <item identifierRef="id-1a34c59912404e6ba82f8454bdaf6524" />
+      <item identifierRef="id-dca3f4be1a224856a5a9bdce91e6e892" />
+      <item identifierRef="id-601b1f6d053448549c198ec1264de387" />
+      <item identifierRef="id-920e152199a945a3a39f2a6baf73d5ee" />
+      <item identifierRef="id-e9ca401699e64d1ab329ab087245094e" />
+      <item identifierRef="id-1adb0aeeade143828ceb938596c1c7e1" />
+      <item identifierRef="id-c976a84c39b64f528e354ab055af02c8" />
+      <item identifierRef="id-67444b25581244038c95eea3e02a0e32" />
+      <item identifierRef="id-11c12e1b44674be8a92ab3a1966d0dfa" />
+      <item identifierRef="id-4acfc130f7c6410abd76bb415ab5eac8" />
+      <item identifierRef="id-37c41ebe851b4039a5c4a39602348b1e" />
+      <item identifierRef="id-cdf011fb0eab4d9bb00ffc06d99b9596" />
+      <item identifierRef="id-81d5cfc6f19b4154b4873315635856b2" />
+      <item identifierRef="id-a12883009a84471f8b0a29ab1bcd1c1e" />
+      <item identifierRef="id-e474ee3e3cb34846930f6d40e9ff420b" />
+      <item identifierRef="id-d45cb8e279204268b0ca24d0525501e6" />
+      <item identifierRef="id-77780f3d08b54989978885c4044a2752" />
+      <item identifierRef="id-f388e19e59cb4d7bbb6fad4581eeb779" />
+      <item identifierRef="id-0b0135218f6e4ecb86c1ae2b90c30f56" />
+      <item identifierRef="id-7f22df0afd51491d92d3a3e2b60078b3" />
+      <item identifierRef="id-1cd2bf284eb04a2c944dec5c9df1c7d3" />
+      <item identifierRef="id-321a08a5219c4a008ad0a979fb0e322e" />
+      <item identifierRef="id-19d1e371a99c4e68b5215de32b5a345e" />
+      <item identifierRef="id-f557926f05344ff18551e8b4978332e3" />
+      <item identifierRef="id-702d6863ed7f46ada5e5cc74fe18532a" />
+      <item identifierRef="id-9516dee9eb5b4e61890deb7c85343e19" />
+      <item identifierRef="id-a4a42b824a5b4a5c80af81efaecd1f8d" />
+      <item identifierRef="id-4108ed11a3b745c195ae42ea4e5874c2" />
+      <item identifierRef="id-f171221fa5d748fbbb70b55e74865a22" />
+      <item identifierRef="id-49b9afec4b8c47c9983c215c1266b051" />
+      <item identifierRef="id-8ad312451dd041db8dc813902ff0de4f" />
+      <item identifierRef="id-7440ad3b9c58469db7c876199c9cfb59" />
+      <item identifierRef="id-13866b172b4646acad8eecb024a962cb" />
+      <item identifierRef="id-839b8489c8be4f9b8c112979ed16c902" />
+      <item identifierRef="id-678b5212401e4f29b871752259798af5" />
+      <item identifierRef="id-02b422a2cf694522ada32c1e044d3e73" />
+      <item identifierRef="id-71ae997cd5d14ebb8e8f99cb8e23df0d" />
+      <item identifierRef="id-0723603c90374bc2b94bb7865d59e89d" />
+      <item identifierRef="id-9acacc74a46e4d8f90a07de7f6c40295" />
+      <item identifierRef="id-4dacd8a214d044b5aaf9d1f1b152f6c3" />
+      <item identifierRef="id-d2657cf7dbd3498bafce917d4b08cfd0" />
+      <item identifierRef="id-6068459dcf664ad5a7b0d37937524430" />
+      <item identifierRef="id-bda70888878c4491b39b4af4ee18f458" />
+      <item identifierRef="id-2f0d63ae8ea84153b6062fdd0dd312ba" />
+      <item identifierRef="id-e03267e87a984283a7ab52ca7a5d9a8c" />
+      <item identifierRef="id-d274fbfebd7a44e6b7b0c4fd7fd4df14" />
+      <item identifierRef="id-8ca6a7dfae9d4e619287374aea2c4126" />
+      <item identifierRef="id-9e76c169badb45cf9ef8550ac376cf63" />
+      <item identifierRef="id-91d310907d1f45ea83ab0bd401f3f8da" />
+      <item identifierRef="id-9c279ee6164144a7a4e86c85da5f415e" />
+      <item identifierRef="id-2313163af2504bcf97334f5e667739be" />
+      <item identifierRef="id-a7c3d87124b84e81baafbe77a112a5d5" />
+      <item identifierRef="id-d400f395329743d6a210542f0a7d07a6" />
+      <item identifierRef="id-359fe6f134a24f009c18dc19b1432e82" />
+      <item identifierRef="id-ea02ec226e9e44eabc67e3de952542ad" />
+      <item identifierRef="id-5f77215fb5c94ff89c5c29f09aeb4cd2" />
+      <item identifierRef="id-21ccfc64299947cf84608184faa689b8" />
+      <item identifierRef="id-d4c54ab4367246f1b8911ebd052c73c3" />
+      <item identifierRef="id-9f6bf9cce0914a0c90e8aed50db56eb6" />
+      <item identifierRef="id-f7564b50863d46339f8ecdde808e9711" />
+      <item identifierRef="id-4cf36345fa4849de86160e994cf9a29f" />
+      <item identifierRef="id-a5b4193a7da54c0882e995bc050cdc32" />
+      <item identifierRef="id-fe7b3c77e211485ebee8f59032c1da09" />
+      <item identifierRef="id-f3a7d86ac3a14acfa7c8d670c69e43bf" />
+      <item identifierRef="id-61e2ba8b92744d6697758aa50794d893" />
+      <item identifierRef="id-0445695e9fec438e9a5ef43857ccb243" />
+      <item identifierRef="id-d0a04647b05b48adb59e216cbbc5b46f" />
+      <item identifierRef="id-a268ca16d2f74427a688fc6d65599df2" />
+      <item identifierRef="id-6e1154ae7e1b42f8a587d4207ff79bad" />
+      <item identifierRef="id-95dccab6d18e4a35a29bf5f251eb16cc" />
+      <item identifierRef="id-0fb8c568ca7b465184f2d76486832e0b" />
+      <item identifierRef="id-65ef28d914c74e039bb9a406b2ac91b1" />
+      <item identifierRef="id-349e31e3a0204dee93eaeec603f58486" />
+      <item identifierRef="id-af85fc5501bc45d2b998787ea035996d" />
+      <item identifierRef="id-1f0d849706644335bfb100282c445c7f" />
+      <item identifierRef="id-10298aab69d64ad8a69e63cf794357c5" />
+      <item identifierRef="id-82012bdf7ac544d9822b2546c3b861ca" />
+      <item identifierRef="id-4a8d31f88d574a9089e90deee7ff98c9" />
+      <item identifierRef="id-67d03a22a57c4b9ca3536f514a2511a0" />
+      <item identifierRef="id-ee27f10dc39d47598d4911480a093e90" />
+      <item identifierRef="id-4d3664323e0548c5b2581f6f082dbc24" />
+      <item identifierRef="id-f0d55a3a939041ef8bcefb5254a0c77e" />
+      <item identifierRef="id-e72a2f5f97524207bd87ddc2d36996a5" />
+      <item identifierRef="id-1bb0d928e2764f88ae2a80a6b2373a31" />
+      <item identifierRef="id-418908fd95334c31ae1ee2304121ba62" />
+      <item identifierRef="id-343934eb45394fa7bc381bfefc4d056d" />
+      <item identifierRef="id-b3ac721f02534bf1b3ed9775aeac303e" />
+      <item identifierRef="id-937bbcf4bfaf45a498c651052fd04b47" />
+      <item identifierRef="id-910409c3681c46ec8fcf2be89b91c5ca" />
+      <item identifierRef="id-fc4152c18e8141b9808ff58527e8fb0e" />
+      <item identifierRef="id-56dcf3e0644c40dfa2e34e43094b5f79" />
+      <item identifierRef="id-3be81b3c59e54b4796ac2eb5caabb242" />
+      <item identifierRef="id-50568a62ff514fd9aabad89e255830ed" />
+      <item identifierRef="id-4a1f0e7f101248ec9e553b8b6690cd60" />
+      <item identifierRef="id-646eb2e3201c49f38c068d2f54c8097b" />
+      <item identifierRef="id-4cce7fe2273e4cbfa269d34993272379" />
+      <item identifierRef="id-16a3c76c26154a59939c26b16ea0ee47" />
+      <item identifierRef="id-830d0d07355a40b18354ca1be8f60e20" />
+      <item identifierRef="id-f96548e2bd6d4f508502d5f1dcb11b51" />
+      <item identifierRef="id-f6b2077e6187458280a345de367c7af1" />
+      <item identifierRef="id-09c9d7ae76044d66b5b9a408aa6154a0" />
+      <item identifierRef="id-8da91a3bad204d0dac78fdd9c4444bf2" />
+      <item identifierRef="id-e2b70f6020004bd08a615b2d4e2b5fd0" />
+      <item identifierRef="id-6bb180a4e44c4ca4b34b1fe8176c124a" />
+      <item identifierRef="id-bf60141d36f64c88b276fa4e759e2cf7" />
+      <item identifierRef="id-e16526d578e447fc82921dc99dec9332" />
+      <item identifierRef="id-53953760b2a44842adf5d843032c638a" />
+      <item identifierRef="id-43d49ff09883433d9e841aab36a0c9c2" />
+      <item identifierRef="id-7a139d573c7c4a9e8e7ee3c1e4f0da15" />
+      <item identifierRef="id-d47baa395fed460db6421a2aded17de2" />
+      <item identifierRef="id-382214250efd4231a02756416f05fcec" />
+      <item identifierRef="id-c270926850164f48b17d088aeb65730c" />
+      <item identifierRef="id-0392078f67334640b8dfed5f54dd9c78" />
+      <item identifierRef="id-3d55bc711a11449592ef575f1bac55f9" />
+      <item identifierRef="id-d0fc1d4dc3864dfb8336c6a37a243d47" />
+      <item identifierRef="id-fc89fbdf1b2e4d8884dbcca370d01424" />
+      <item identifierRef="id-a32f1e7d20d848c0b265b46c8f372f24" />
+      <item identifierRef="id-c2a8d9d9318d41549037025d71599ee7" />
+      <item identifierRef="id-d22a15e338ce4844866d59025d1bd167" />
+      <item identifierRef="id-e37063f05fff44f5a6c39c4a5b54dc07" />
+      <item identifierRef="id-a58fbc2d3df14bcca8aa115deaa97953" />
+      <item identifierRef="id-4f1372ca7501479fb4f27c842faba7ac" />
+      <item identifierRef="id-c8a8d78b65a84ccbb6dfbfafb7b1d8d2" />
+      <item identifierRef="id-646d97276df34c37b377c908186bd107" />
+      <item identifierRef="id-3c25d67261064ea28e199fe9a0b85f85" />
+      <item identifierRef="id-dcd4c81485474c4a8a58d0bc320d56fe" />
+      <item identifierRef="id-a74df18bcb2747a4a9e879dcb6b0820e" />
+      <item identifierRef="id-404aaef8afbd4c8cac91b3e7ce7e87fe" />
+      <item identifierRef="id-d416fcebaa42472d9eb4fbcbd17d6a56" />
+      <item identifierRef="id-17e42d417d1f4e609a0b754630811877" />
+      <item identifierRef="id-f2cd0f5cead94ed68cd27bf318a265a5" />
+      <item identifierRef="id-ad1e7e9f59954f18bf4803a1a0027669" />
+      <item identifierRef="id-f6989aa63ab24e2bb69cb321699de3af" />
+      <item identifierRef="id-1d71a1527dbe4fb5b8a2eb3365ace3b0" />
+      <item identifierRef="id-3cb2acbc8d374c47879d879a27ec69e6" />
+      <item identifierRef="id-4d22767cc0e74f62b7ea0425e51bb1b7" />
+      <item identifierRef="id-106c11a71e504c6d92b950e81ce22d80" />
+      <item identifierRef="id-11442bc6e2674460b518658d8acb923d" />
+      <item identifierRef="id-88dfc205b0174ee4bc449aa39843ad8a" />
+      <item identifierRef="id-8c2715be52c14efb8ff1b5f37db7a5d6" />
+      <item identifierRef="id-13bca28e98274e7787dab6fbff0b7fcc" />
+      <item identifierRef="id-0b96fb0d0e9941529d2f6c18b3561dec" />
+      <item identifierRef="id-f4cf9ae4b5b04c83b7ac68e8a7499459" />
+      <item identifierRef="id-ffce88df12ee4b758bf1850598c844b0" />
+      <item identifierRef="id-f33b67e9b6d6410fb7ecf59859619c44" />
+      <item identifierRef="id-e7bcaba7d8e8473e8d9274c6819e6831" />
+      <item identifierRef="id-8383478607a84e87a7f1ce4e435c7665" />
+      <item identifierRef="id-592d5a0e9516450baefeb2fb60880cdf" />
+      <item identifierRef="id-56c77f2ad63746b8a4462aab26b0828a" />
+      <item identifierRef="id-cd2051d687f246eb88bd29a38cc4d43d" />
+      <item identifierRef="id-e4fca00046234778adc85086d0dae34c" />
+      <item identifierRef="id-5ef40b745ffe400cbe17fc3086b8179b" />
+      <item identifierRef="id-4dc192fea4d348b0a4011f793a5a83ba" />
+      <item identifierRef="id-d771d69f102e4b0e9f2fcb044a0a2910" />
+      <item identifierRef="id-2b49f5e3aa1f4a33b2bf2d4da8d1ecc0" />
+      <item identifierRef="id-dfcfc71085c744dbab682a888185d405" />
+      <item identifierRef="id-bf5d0980823b459582f7b7f2ca9ff866" />
+      <item identifierRef="id-541d8ad87ec54da8b06ddbdb6ff32e15" />
+      <item identifierRef="id-58641959b27249948876585f234324fa" />
+      <item identifierRef="id-1c200b633efb4e7c849cb0b24a16d656" />
+      <item identifierRef="id-99869d8bdfac48688f90c48d7148b4b2" />
+      <item identifierRef="id-f885506aa5544949910befeb7b8102c0" />
+      <item identifierRef="id-e0fcfbc217c14d4fafb63d2d585286a2" />
+      <item identifierRef="id-19891cec3a20492d8f877fb5bae3dbb9" />
+      <item identifierRef="id-740a7f4e522a452c948d454e0a811794" />
+      <item identifierRef="id-e81b2399c4e64971be60ada42c619c0f" />
+      <item identifierRef="id-0739c23ade8a4fdf99d727faae31b258" />
+      <item identifierRef="id-e9086fe91ef3456fae5053977c81b421" />
+      <item identifierRef="id-07c3811485f74e0491fb790e4fae8639" />
+      <item identifierRef="id-c72cba963ef54e938eaa447bc2a20577" />
+      <item identifierRef="id-d7bd0e004f454d72a881e2390fe30424" />
+      <item identifierRef="id-4f58821d8da14945932926ae33866dd3" />
+      <item identifierRef="id-d459706aa3654228a428fcedeb76b861" />
+      <item identifierRef="id-2027668953494b6daf40f1f55cbc8cf5" />
+      <item identifierRef="id-c15f7da617cc4414b798c92b65e0f219" />
+      <item identifierRef="id-9804e1a77131460abc8ea27bc843599e" />
+      <item identifierRef="id-f9fdf0fb20234c39949eed2dbe14ca39" />
+      <item identifierRef="id-d0e38b9cc8ab452883a8e1382493b148" />
+      <item identifierRef="id-f8a8cba0406c44e18de6633183662c87" />
+      <item identifierRef="id-05f695f581bb49a6864f1df65e5d5070" />
+      <item identifierRef="id-e3f67792b2554a57b680763dfdea4f2e" />
+      <item identifierRef="id-aab4f269e6854079a2702641a2eef4b4" />
+      <item identifierRef="id-179a424cd7c742fe80ed7b2c9f2c941b" />
+      <item identifierRef="id-e1e447654c4c464f9aecbb736b45ec97" />
+      <item identifierRef="id-915dd08d40bc464dbe7cece410d8acc8" />
+      <item identifierRef="id-301460d307144c8faa0bbf2d5b49910a" />
+      <item identifierRef="id-58ab965d01fe4e05a0da156fc93f1cc1" />
+      <item identifierRef="id-399097ed6904460685975ae337897d43" />
+      <item identifierRef="id-0809459150ae416a80b97004e2c1918d" />
+      <item identifierRef="id-653a6be49b1f4b3e80dc7899b44bf46e" />
+    </item>
+    <item>
+      <label xml:lang="es">Views</label>
+      <item>
+        <label xml:lang="es">1_Challenges</label>
+        <item identifierRef="id-b768ec37f0154600b8f6194e5390d6fa" />
+        <item identifierRef="id-670f8d6ff94c4e76bb3ad53e15dd108e" />
+        <item identifierRef="id-acf28f4b213b4e1792c92562b698b24b" />
+        <item identifierRef="id-1f7257fcb11747ee91eadb2f3c221096" />
+        <item identifierRef="id-668094d6cc8f47849165a81c8ae4223c" />
+        <item identifierRef="id-b1443625aaa14845bd5966d40a83cec0" />
+        <item identifierRef="id-5259ce1cb1ab47d2ad3f28b75326991a" />
+      </item>
+      <item>
+        <label xml:lang="es">2_CRM Vision</label>
+        <item identifierRef="id-ad67dde28a3d4a1a922df1376a195e13" />
+      </item>
+      <item>
+        <label xml:lang="es">3_Transformation_Overview</label>
+        <item>
+          <label xml:lang="es">3.1_Baseline</label>
+          <item identifierRef="id-c7dc626670a3456c9a2632e54fd92b89" />
+          <item identifierRef="id-ca8ac0b4ff5f45d8b4a69771ef82d3d2" />
+          <item identifierRef="id-7b6ebcdc021540f89686548bd3048ed4" />
+          <item identifierRef="id-38cec8ead5b84a958460f04985aef9ac" />
+          <item identifierRef="id-b668c0c608804f83b47dbb32fd095ef9" />
+        </item>
+        <item>
+          <label xml:lang="es">3.2_Target</label>
+          <item identifierRef="id-0763811d83bd4fffa0c7b0223abb413a" />
+          <item identifierRef="id-0abd45ec74f947e6beae0e2d06d21f6c" />
+          <item identifierRef="id-f6e593ba71254893b67ed9c5860d4697" />
+          <item identifierRef="id-7a850a0ead4c403eabc7751934046715" />
+          <item identifierRef="id-c3a77d0773b446e7b51efc3d35c0d8ce" />
+          <item identifierRef="id-82be4d5be046439ab9795a4f31a92fd4" />
+        </item>
+        <item>
+          <label xml:lang="es">3.3_Imple-and-Migration</label>
+          <item identifierRef="id-640a2982a91e4056bb99356476dad35f" />
+        </item>
+      </item>
+      <item>
+        <label xml:lang="es">4_Detail_EA</label>
+        <item identifierRef="id-4c416cf02fca460ab93ad4b3936f63c9" />
+        <item identifierRef="id-845fa04712f144059ca8c3c5447f7a2f" />
+        <item identifierRef="id-c89990a2bdbe4fc191a37a5cf9d18855" />
+        <item identifierRef="id-0ee2e2bb25134094bbfb9ff204140f31" />
+        <item identifierRef="id-43f43fbb0b7f48b8ac861037cb5c046c" />
+        <item identifierRef="id-3a7130b63e8f40daad3e73435484ee95" />
+        <item identifierRef="id-76d85ee971ad4c8cba88b078993ef583" />
+      </item>
+      <item>
+        <label xml:lang="es">5_Target_State_Scenario</label>
+        <item identifierRef="id-8509079b3dcf499ba671c54e7f7712b6" />
+        <item identifierRef="id-f03808781d6040b7989085a534b8eab4" />
+        <item identifierRef="id-06ed635edfdf43a1af8d9c037507258c" />
+        <item identifierRef="id-184871b742bc4757b24d2d07c016d702" />
+        <item identifierRef="id-d395811f0d8647d185cd5be13cdd916f" />
+      </item>
+      <item identifierRef="id-8ad6c4933f22487281a2e3a873c32dee" />
+    </item>
+  </organizations>
+  <propertyDefinitions>
+    <propertyDefinition identifier="propid-1" type="string">
+      <name>Last Update</name>
+    </propertyDefinition>
+    <propertyDefinition identifier="propid-2" type="string">
+      <name>Last Updated by</name>
+    </propertyDefinition>
+  </propertyDefinitions>
+  <views>
+    <diagrams>
+      <view identifier="id-b768ec37f0154600b8f6194e5390d6fa" xsi:type="Diagram">
+        <name xml:lang="es">Figure01_Business-Units</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023-05-19</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-34f36912ee7f4d9cb061c4d267eea524" xsi:type="Label" x="204" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-08673930d49a4e63bbef3a53ed850dad" xsi:type="Label" x="540" y="516" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-54d84c0ea4874c02ba1f5f1753e16470" elementRef="id-70e443457ba447cf9f7be64c0a2e0ad1" xsi:type="Element" x="108" y="60" w="649" h="433">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-04884cd984304240b31e6a483a6fcd8c" elementRef="id-3bc7d428ccea48739c4d442f9f2364e7" xsi:type="Element" x="137" y="348" w="409" h="111">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+            <node identifier="id-70831dc9950c4bab9671acc4e4d24886" elementRef="id-65c1620fd1284553b20818224030a84d" xsi:type="Element" x="149" y="384" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-d627d77ac72145bb9895fb9cdb052828" elementRef="id-5987ea5989b34bb3b7b3b7df0c5d7596" xsi:type="Element" x="413" y="384" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-80e1bc5cb2884944afa76611d2f27c96" elementRef="id-b50ea84ae74845f3b8001028c0558e90" xsi:type="Element" x="281" y="384" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+          </node>
+          <node identifier="id-5a2db1623e324d7ea6e88b3874db9887" elementRef="id-ca35f8df80974169b04c1ffd58c12493" xsi:type="Element" x="137" y="216" w="589" h="109">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+            <node identifier="id-bde61151542b4b5fa8a848811145b28e" elementRef="id-6118370573ec480e85a1d4b2eed6eacd" xsi:type="Element" x="588" y="252" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-cc1efd2f233d4712bee8970a83262af9" elementRef="id-761d6b44b0084191bb0574b9b2c4e949" xsi:type="Element" x="161" y="252" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-eed4fc4cbb974a4fbcf47abc47383fc4" elementRef="id-eee6f468492e48efb54f44db721f75aa" xsi:type="Element" x="444" y="252" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-4e040bfb74a64a6384fe2e1e8b15b695" elementRef="id-dae853c3fdda4da9a99c066d144cc617" xsi:type="Element" x="300" y="252" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+          </node>
+          <node identifier="id-2e07b170e17d4ec0bb720c338f7b4f31" elementRef="id-ca27484ed8934cd2bb57cec774298909" xsi:type="Element" x="606" y="420" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-4c1564b75c98425c857aca49d687b053" elementRef="id-f96b2f70a48e42bb83646b89292b1286" xsi:type="Element" x="606" y="348" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-0f051b822230485bb168d1d26b26b945" elementRef="id-86d6a2f695b74347a264354315c8656f" xsi:type="Element" x="137" y="84" w="589" h="109">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+            <node identifier="id-7cf1de14b9424944bba37e87ad2b628d" elementRef="id-b6d4eb2c1e184d33897f7862f6317033" xsi:type="Element" x="540" y="120" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-21cc108858c14207965debfa3c5f002b" elementRef="id-628c9b29c1254f3c8d0aea92d13e5d65" xsi:type="Element" x="372" y="120" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-adbe6fa395914fc189321e9031cb982c" elementRef="id-2bcc0251b630425ea4c325246a35f5b8" xsi:type="Element" x="204" y="120" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+          </node>
+        </node>
+      </view>
+      <view identifier="id-670f8d6ff94c4e76bb3ad53e15dd108e" xsi:type="Diagram">
+        <name xml:lang="es">Figure02_Value-Stream</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/5/19</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-05e617136a6f4417b892476935b63f91" xsi:type="Label" x="212" y="24" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-5f0d83c7ca0f4096b4e75aa053656d2a" xsi:type="Label" x="636" y="240" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-d3d258a10e1c48afbda92c97ca4ac6e0" elementRef="id-1e3683a995704e0bb1abe93aeba4d203" xsi:type="Element" x="24" y="72" w="841" h="133">
+          <style>
+            <fillColor r="245" g="222" b="170" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-1f8fc2a07be7418ab5b1d88ad161a94c" elementRef="id-c93b9d430cd2423b95c52c610e12f720" xsi:type="Element" x="240" y="108" w="120" h="55">
+            <style>
+              <fillColor r="245" g="222" b="170" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-243dac3ecbbd4c0191df3844b2e00d09" elementRef="id-051bc17974ef4cedb0424a31e975d727" xsi:type="Element" x="552" y="108" w="120" h="55">
+            <style>
+              <fillColor r="245" g="222" b="170" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-a03b4a8f3c1d499cacd40d02aa1ecaa1" elementRef="id-fc034ab99bfa4b9e9ae7f51fa8de905f" xsi:type="Element" x="84" y="108" w="120" h="55">
+            <style>
+              <fillColor r="245" g="222" b="170" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-d207623809714f3bb712f22159c5a0f5" elementRef="id-281d523a5a0e45e686b8d9c6726a5be9" xsi:type="Element" x="396" y="108" w="120" h="55">
+            <style>
+              <fillColor r="245" g="222" b="170" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-42935cc53239412d84a2ca2b5be65d43" elementRef="id-53228d509e7c444dbf57f5dd19df3484" xsi:type="Element" x="708" y="108" w="120" h="55">
+            <style>
+              <fillColor r="245" g="222" b="170" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <connection identifier="id-17aff4c936ef48e48429aad2af42798e" relationshipRef="id-eb38b69298ee46dfbe0d976f84d8d262" xsi:type="Relationship" source="id-1f8fc2a07be7418ab5b1d88ad161a94c" target="id-d207623809714f3bb712f22159c5a0f5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-ef14033d0b2942ca8f2f9c4bb94b4c54" relationshipRef="id-7e623a892b494202b7fa8ea6a1a06c80" xsi:type="Relationship" source="id-243dac3ecbbd4c0191df3844b2e00d09" target="id-42935cc53239412d84a2ca2b5be65d43">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-bfda487e4db34b9cbc84fd4daef8c3bc" relationshipRef="id-f3bf5f25f60e4c89b7f6b9de305ff28c" xsi:type="Relationship" source="id-a03b4a8f3c1d499cacd40d02aa1ecaa1" target="id-1f8fc2a07be7418ab5b1d88ad161a94c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-fcfdb2ac846c4af68115564b4ac3922d" relationshipRef="id-6f5c6dceb0594ca8ba8be8e85214b686" xsi:type="Relationship" source="id-d207623809714f3bb712f22159c5a0f5" target="id-243dac3ecbbd4c0191df3844b2e00d09">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-acf28f4b213b4e1792c92562b698b24b" xsi:type="Diagram">
+        <name xml:lang="es">Figure03_Production-and-Logistics-Process</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/5/19</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-4096c2ab6acb4d25a59d351fb8c8b09f" xsi:type="Label" x="243" y="24" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-1d17e40200e04666b829617c0bb76c36" xsi:type="Label" x="746" y="372" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-3e9168170be342c9b351cb836fa36150" elementRef="id-bb08ebde1b25412bb52d9e4d35afa404" xsi:type="Element" x="186" y="96" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-b9df0e5595314756aedf5324811b5436" elementRef="id-a6992b23c09c44dba47e8e06ad7655c5" xsi:type="Element" x="684" y="96" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-a359a6bbf782448183956b7f9013e6f6" elementRef="id-ca35f8df80974169b04c1ffd58c12493" xsi:type="Element" x="432" y="96" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-3444534095bc4a0c8cf973815159d1de" elementRef="id-d894787e002341deb3688fbc1084e63c" xsi:type="Element" x="0" y="204" w="577" h="140">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-d251b33a3ef14fbbb1f540768880561f" elementRef="id-cfa53abb5fea4aac8c1ad6901b1b2470" xsi:type="Element" x="12" y="252" w="120" h="55">
+            <style>
+              <fillColor r="201" g="231" b="183" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-7c954f66892741c7a952c0dc44c736d4" elementRef="id-e36661dac4014c0bb54cc138c8af5485" xsi:type="Element" x="300" y="252" w="120" h="55">
+            <style>
+              <fillColor r="201" g="231" b="183" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-799fdf3372f44b97ad5b89d77370d180" elementRef="id-169ba8405759474db2179d246f01216d" xsi:type="Element" x="156" y="252" w="120" h="55">
+            <style>
+              <fillColor r="201" g="231" b="183" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-901a1ccab4a9484f97a3dd9b9d8e764a" elementRef="id-493d8b255dcd4c249087ff7e85f0f16a" xsi:type="Element" x="444" y="252" w="120" h="55">
+            <style>
+              <fillColor r="201" g="231" b="183" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-d533a16e09b547cead57957ce3099fea" elementRef="id-32425a437e9b4d6e88c7ea527389db79" xsi:type="Element" x="588" y="204" w="289" h="140">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-6f3329d2fe6b4841ac9c8dd8c1a033e0" elementRef="id-868a037328914ca79d43352cdccc890f" xsi:type="Element" x="600" y="252" w="120" h="55">
+            <style>
+              <fillColor r="201" g="231" b="183" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-28b1e61e51604148aa33ff0c86ce4c52" elementRef="id-330b37e7d3bf425a8da334998ed4b559" xsi:type="Element" x="744" y="252" w="120" h="55">
+            <style>
+              <fillColor r="201" g="231" b="183" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <connection identifier="id-f6cf80f293c94756aee9a12bf543ccee" relationshipRef="id-61b7abe559c64c4ea18fcba54c1ae17e" xsi:type="Relationship" source="id-a359a6bbf782448183956b7f9013e6f6" target="id-b9df0e5595314756aedf5324811b5436">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-e3d61bf0c9394faca7300c07db23fa94" relationshipRef="id-91cf3830343346699650c97c4962a76c" xsi:type="Relationship" source="id-a359a6bbf782448183956b7f9013e6f6" target="id-3e9168170be342c9b351cb836fa36150">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-8be0908b61da46c6bc9b3185041093c5" relationshipRef="id-aab1dbccb34f4d43b104b4a8c5f70a37" xsi:type="Relationship" source="id-3444534095bc4a0c8cf973815159d1de" target="id-3e9168170be342c9b351cb836fa36150">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-e6104dbcd60b4e788271cfd2be00012d" relationshipRef="id-46390cc95d6246c08208fa25fb06aa49" xsi:type="Relationship" source="id-d251b33a3ef14fbbb1f540768880561f" target="id-799fdf3372f44b97ad5b89d77370d180">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-9841f4e5a283463ab75453e72ad0d00e" relationshipRef="id-0eb3c88263d84399bb798d8e24afa00b" xsi:type="Relationship" source="id-7c954f66892741c7a952c0dc44c736d4" target="id-901a1ccab4a9484f97a3dd9b9d8e764a">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-4f2e8ad946ce48dcbfe4cc9a568f43ab" relationshipRef="id-1d368509cab740e4bcfc5fdf91b827a2" xsi:type="Relationship" source="id-799fdf3372f44b97ad5b89d77370d180" target="id-7c954f66892741c7a952c0dc44c736d4">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-0109bfdc99324233a2750c9bc2439111" relationshipRef="id-33cdf3f2d9e344199ba50e2ab92e4ec3" xsi:type="Relationship" source="id-901a1ccab4a9484f97a3dd9b9d8e764a" target="id-6f3329d2fe6b4841ac9c8dd8c1a033e0">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-74e599dabacc48a18f9119307d6e9942" relationshipRef="id-94ecdff105684a36bcf339a4bda8499e" xsi:type="Relationship" source="id-d533a16e09b547cead57957ce3099fea" target="id-b9df0e5595314756aedf5324811b5436">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-5ba826b4f2ff418d84449fc4348d232c" relationshipRef="id-dee89864271043df898a92ae5b001fd7" xsi:type="Relationship" source="id-6f3329d2fe6b4841ac9c8dd8c1a033e0" target="id-28b1e61e51604148aa33ff0c86ce4c52">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-1f7257fcb11747ee91eadb2f3c221096" xsi:type="Diagram">
+        <name xml:lang="es">Figure04_Steel-Production</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/5/19</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-301d0b500b614a2584aeebcf3f1a56d2" xsi:type="Label" x="255" y="24" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-2571df71124846209d745b3e7290baa6" xsi:type="Label" x="828" y="36" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-aa0b8ad288cd4bd78f5466e891012080" elementRef="id-169ba8405759474db2179d246f01216d" xsi:type="Element" x="557" y="96" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-37b4388af0d74420a449768c3b3ce9cb" elementRef="id-493d8b255dcd4c249087ff7e85f0f16a" xsi:type="Element" x="512" y="528" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-8ed37a973fce4e1991e4de5dbcd09bf9" elementRef="id-e36661dac4014c0bb54cc138c8af5485" xsi:type="Element" x="179" y="528" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-b79b41b18c4c41b0a8d7eb834c591bd7" elementRef="id-868a037328914ca79d43352cdccc890f" xsi:type="Element" x="840" y="528" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-d8b6b828fcbb4911978680fd39e15937" elementRef="id-cfa53abb5fea4aac8c1ad6901b1b2470" xsi:type="Element" x="204" y="96" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-2f8e77be7e2a42a684d0fc06ac32184b" elementRef="id-e79b5c486e7b472ea4db37e0d5a19efb" xsi:type="Element" x="12" y="204" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-ee77fe870e1e4b62b9024e08bdb3c57c" elementRef="id-64e6961cbc5b4c03b984593db7d9ae8a" xsi:type="Element" x="12" y="288" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-76a7731c1f6d480b9587af16d3eaec2c" elementRef="id-a9ed7174af0548d5b138b47fba446282" xsi:type="Element" x="12" y="372" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-9c8fbcf1ab634c8582f940db4b876837" elementRef="id-c3e80fb693bd48ebbfe756c998d7384b" xsi:type="Element" x="179" y="177" w="169" h="277">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-75106153bf434766a3726306a4ca17b7" elementRef="id-3bfc5d5eae14479aa57922a2f99ab3d6" xsi:type="Element" x="203" y="207" w="120" h="55">
+            <style>
+              <fillColor r="201" g="231" b="183" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-d5c9bd727d3946ad8b417e0d5e7cd59d" elementRef="id-e54ac98461364b6f89be0d7ce49996b0" xsi:type="Element" x="203" y="369" w="120" h="55">
+            <style>
+              <fillColor r="201" g="231" b="183" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-5631de1216d14d1699138ba7af6407f4" elementRef="id-143ca1ce20d2492caf819e0787d23823" xsi:type="Element" x="203" y="285" w="120" h="55">
+            <style>
+              <fillColor r="201" g="231" b="183" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-f2e4abfb74f7474c807f56ebf6fa6a0f" elementRef="id-5903ad80d51e413dab64159cdf1f6fd0" xsi:type="Element" x="392" y="209" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-78ab98dbbbaf470abc655278f778f752" elementRef="id-02c0f4e1301f46cfbf2453b11e1c6de0" xsi:type="Element" x="393" y="286" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-90c84c65203146e89891d936cda1625f" elementRef="id-0cc3e6f3dca340b58f7b177619936176" xsi:type="Element" x="392" y="370" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-b0d94a5223db4c8c9a783cb1c082805b" elementRef="id-3d3294e5d139473e965cacb7ad9e4e7f" xsi:type="Element" x="557" y="205" w="120" h="220">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-46a415ecc7fa4e3a9e563ff40d27f154" elementRef="id-23d2166d570f40bdad1417d39f10373f" xsi:type="Element" x="758" y="171" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-0492ea7d5a064fa1899829c5a82d893d" elementRef="id-809e6563310c4e15b7697fa525023abf" xsi:type="Element" x="755" y="86" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-9ccee44b06d845d7ab161ea60d98ad0c" elementRef="id-4364086f4188452084a6168dcbd7b186" xsi:type="Element" x="2" y="623" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-9ebe01732ae8419887dbc0d4a4459977" elementRef="id-cf389c783061458f822a388324e89b09" xsi:type="Element" x="0" y="691" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-89e61d6737d441d49efc5fd0dae65244" elementRef="id-1d8b234a0add4fdca68c71514f32e981" xsi:type="Element" x="0" y="756" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-6a7a372c584444248274dfa148b7af80" elementRef="id-9d1d0adbfe2c43cba2db422b4ca184cc" xsi:type="Element" x="179" y="623" w="120" h="188">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-7e01df8777d3491fa969d54bf0ac20a4" elementRef="id-64a3c89d49ff447f9dab07ddcaf002ec" xsi:type="Element" x="347" y="731" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-5447e7002e784a53a3e3ac21327bae1c" elementRef="id-2ce4621d4a164842b29cce506cde7a68" xsi:type="Element" x="512" y="731" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-64dc2ab111a547c4b04c1fb946cf7b77" elementRef="id-9d3639bc0b2c46deafc67db505ca796b" xsi:type="Element" x="660" y="627" w="157" h="178">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-2bb5a833dc4b4c4483ae7cc5465acfef" elementRef="id-10b667b736514a2da297f4dea0a14645" xsi:type="Element" x="682" y="663" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-f32de70e2b3c4015bee6db13f47e5baf" elementRef="id-131c1792801b40a49a9041661dec5ed8" xsi:type="Element" x="681" y="730" w="120" h="55">
+            <style>
+              <fillColor r="201" g="231" b="183" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-72a927318e88450bac9cd9cdbed83e80" elementRef="id-8b9b1e49a27848f68fea836a25a610d6" xsi:type="Element" x="840" y="731" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-c173a62971844d608bdf69261676fc79" relationshipRef="id-1d368509cab740e4bcfc5fdf91b827a2" xsi:type="Relationship" source="id-aa0b8ad288cd4bd78f5466e891012080" target="id-8ed37a973fce4e1991e4de5dbcd09bf9">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="720" y="120" />
+          <bendpoint x="720" y="480" />
+          <bendpoint x="96" y="480" />
+          <bendpoint x="96" y="552" />
+        </connection>
+        <connection identifier="id-5e76bc8789f34c9a90fb513f84e5a69a" relationshipRef="id-33cdf3f2d9e344199ba50e2ab92e4ec3" xsi:type="Relationship" source="id-37b4388af0d74420a449768c3b3ce9cb" target="id-b79b41b18c4c41b0a8d7eb834c591bd7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-9589a88a57814255adef139e009b3340" relationshipRef="id-0eb3c88263d84399bb798d8e24afa00b" xsi:type="Relationship" source="id-8ed37a973fce4e1991e4de5dbcd09bf9" target="id-37b4388af0d74420a449768c3b3ce9cb">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-3c8c49f4ee0843c6b7e406e9e85c2eb3" relationshipRef="id-46390cc95d6246c08208fa25fb06aa49" xsi:type="Relationship" source="id-d8b6b828fcbb4911978680fd39e15937" target="id-aa0b8ad288cd4bd78f5466e891012080">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-c77448f5934e43778363c9f87f555a11" relationshipRef="id-11d4a56d51c3476aafda510d68127aeb" xsi:type="Relationship" source="id-2f8e77be7e2a42a684d0fc06ac32184b" target="id-ee77fe870e1e4b62b9024e08bdb3c57c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-29bfbf5980734736993a6c88b4cfb344" relationshipRef="id-a921b99ac27d48daaa7f4257f848df46" xsi:type="Relationship" source="id-76a7731c1f6d480b9587af16d3eaec2c" target="id-ee77fe870e1e4b62b9024e08bdb3c57c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-3ba734e080cd437bbea152698ddb450f" relationshipRef="id-bed57c56146f445780694bb9c7b097e0" xsi:type="Relationship" source="id-9c8fbcf1ab634c8582f940db4b876837" target="id-d8b6b828fcbb4911978680fd39e15937">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-c9cf01fa2e5140c68421f76635640074" relationshipRef="id-e290eaf5e13d42828c1998b01b6c9028" xsi:type="Relationship" source="id-75106153bf434766a3726306a4ca17b7" target="id-2f8e77be7e2a42a684d0fc06ac32184b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-c5abbb1b2b8b4423b6995c88a6386d80" relationshipRef="id-6f9d014c9eeb44aba2a3f468e1f09c7d" xsi:type="Relationship" source="id-75106153bf434766a3726306a4ca17b7" target="id-f2e4abfb74f7474c807f56ebf6fa6a0f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-6f16cce8072e4f99a2399113114e1e2a" relationshipRef="id-b9257449c58a4d5e868cc2142dd128c7" xsi:type="Relationship" source="id-75106153bf434766a3726306a4ca17b7" target="id-46a415ecc7fa4e3a9e563ff40d27f154">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="264" y="192" />
+        </connection>
+        <connection identifier="id-ef5d1fa31a0949a0a25a6b82531abdea" relationshipRef="id-86ee34f4fdb14ac4957aa6ea6ef34e6a" xsi:type="Relationship" source="id-d5c9bd727d3946ad8b417e0d5e7cd59d" target="id-76a7731c1f6d480b9587af16d3eaec2c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a92a4656feea4478a08c402bb9248745" relationshipRef="id-8934907edada473fa5878d326d9a47d1" xsi:type="Relationship" source="id-d5c9bd727d3946ad8b417e0d5e7cd59d" target="id-90c84c65203146e89891d936cda1625f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-10b8e64b0c1b4b4aa15aaef35d7b0e2c" relationshipRef="id-47095985ccd84fd49165d5854bbda0af" xsi:type="Relationship" source="id-5631de1216d14d1699138ba7af6407f4" target="id-76a7731c1f6d480b9587af16d3eaec2c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="156" y="312" />
+          <bendpoint x="156" y="384" />
+        </connection>
+        <connection identifier="id-4ed7d32513dc4b25ae6477168a575c8a" relationshipRef="id-ff93f89996444d5e96d293c778a769e5" xsi:type="Relationship" source="id-5631de1216d14d1699138ba7af6407f4" target="id-78ab98dbbbaf470abc655278f778f752">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-d207fd9b108d4c7fac10e086839c4ef4" relationshipRef="id-25649e1af41945b4b77cda1050fa9904" xsi:type="Relationship" source="id-b0d94a5223db4c8c9a783cb1c082805b" target="id-f2e4abfb74f7474c807f56ebf6fa6a0f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-137989fc529c459dafe5fe14e2e69951" relationshipRef="id-ac83455bf9384f09b5dfb7d04f8d5d4d" xsi:type="Relationship" source="id-b0d94a5223db4c8c9a783cb1c082805b" target="id-78ab98dbbbaf470abc655278f778f752">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-db769918f0f544fd8a1e436d864bcd0c" relationshipRef="id-444656e2076d467c96a713b0a58a058f" xsi:type="Relationship" source="id-b0d94a5223db4c8c9a783cb1c082805b" target="id-90c84c65203146e89891d936cda1625f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-3930b00d94de4b7b9e575c8b6e67339f" relationshipRef="id-d155f8d0a8e84fb6b20de1e991a7e56d" xsi:type="Relationship" source="id-b0d94a5223db4c8c9a783cb1c082805b" target="id-aa0b8ad288cd4bd78f5466e891012080">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a9115ac8aa9c43e2a7f75b0a7fd4991c" relationshipRef="id-a5b2a14f9da845529fa6a4cc6e589e71" xsi:type="Relationship" source="id-b0d94a5223db4c8c9a783cb1c082805b" target="id-46a415ecc7fa4e3a9e563ff40d27f154">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="660" y="192" />
+        </connection>
+        <connection identifier="id-686b9c38087142439d6d3756c57f9ceb" relationshipRef="id-6816b6a7ed46492a87251d726ec06d7a" xsi:type="Relationship" source="id-b0d94a5223db4c8c9a783cb1c082805b" target="id-9ccee44b06d845d7ab161ea60d98ad0c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="696" y="312" />
+          <bendpoint x="696" y="468" />
+          <bendpoint x="36" y="468" />
+        </connection>
+        <connection identifier="id-720e29f250b44e8e9c5ae8e2003c9bab" relationshipRef="id-fb0e9ab738a840a69b6711d3ed7e7725" xsi:type="Relationship" source="id-46a415ecc7fa4e3a9e563ff40d27f154" target="id-0492ea7d5a064fa1899829c5a82d893d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-6d95e449a308479ab20de9ac680d328f" relationshipRef="id-a5beea4740974139825a59c15b6d8dfa" xsi:type="Relationship" source="id-6a7a372c584444248274dfa148b7af80" target="id-9ccee44b06d845d7ab161ea60d98ad0c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-f9cb0c81d81f43bb97bf84a5ca63bb68" relationshipRef="id-b063cacf85f6455f915ba818b5dda91d" xsi:type="Relationship" source="id-6a7a372c584444248274dfa148b7af80" target="id-9ebe01732ae8419887dbc0d4a4459977">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-69ab2a3e3a614df38a742f4cfb7be9a3" relationshipRef="id-4657a2510445450fb2a5a8f28e4c8e33" xsi:type="Relationship" source="id-6a7a372c584444248274dfa148b7af80" target="id-89e61d6737d441d49efc5fd0dae65244">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-ed2eb451353848c6935e8094e6e14e97" relationshipRef="id-8c2a1aee70be437bb9e08b17947d781d" xsi:type="Relationship" source="id-6a7a372c584444248274dfa148b7af80" target="id-8ed37a973fce4e1991e4de5dbcd09bf9">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-c44801e75fde4018b4aabf586fbf9465" relationshipRef="id-2b4fc33da23c481b9f315c3b3802eb0e" xsi:type="Relationship" source="id-6a7a372c584444248274dfa148b7af80" target="id-7e01df8777d3491fa969d54bf0ac20a4">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-f7719eb54a7a46faa0a65a63a5e78e55" relationshipRef="id-e742d45767a04a99a009bf800315f50f" xsi:type="Relationship" source="id-6a7a372c584444248274dfa148b7af80" target="id-46a415ecc7fa4e3a9e563ff40d27f154">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="240" y="852" />
+          <bendpoint x="1020" y="852" />
+          <bendpoint x="1020" y="192" />
+        </connection>
+        <connection identifier="id-5385bc3117594843bd7025d24d97662d" relationshipRef="id-69b7bdfe1fe947c092947aa785e55822" xsi:type="Relationship" source="id-5447e7002e784a53a3e3ac21327bae1c" target="id-7e01df8777d3491fa969d54bf0ac20a4">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-0bbc724849714094bb6128e7c020f55f" relationshipRef="id-92b485ef57bb4833baa3de4f30d3cf93" xsi:type="Relationship" source="id-5447e7002e784a53a3e3ac21327bae1c" target="id-37b4388af0d74420a449768c3b3ce9cb">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-070f44518ba244d1a405a9a9fc1c24bc" relationshipRef="id-db7373bcc3314ebbb731ef7e07d26388" xsi:type="Relationship" source="id-5447e7002e784a53a3e3ac21327bae1c" target="id-f32de70e2b3c4015bee6db13f47e5baf">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-8272caa40f63458fb1fa252b60b663fb" relationshipRef="id-8aa225cf93f945b790e82a0dacf6a2c0" xsi:type="Relationship" source="id-5447e7002e784a53a3e3ac21327bae1c" target="id-46a415ecc7fa4e3a9e563ff40d27f154">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="576" y="828" />
+          <bendpoint x="1008" y="828" />
+          <bendpoint x="1008" y="192" />
+        </connection>
+        <connection identifier="id-5bc0970b250549efb4e9eec5c858e300" relationshipRef="id-39e52a103c804df8a13a9340ae3012db" xsi:type="Relationship" source="id-72a927318e88450bac9cd9cdbed83e80" target="id-f32de70e2b3c4015bee6db13f47e5baf">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a2b48891ce9b4169a74369769daebcfd" relationshipRef="id-73f64dea1cb446d197c2196ecb8e38e3" xsi:type="Relationship" source="id-72a927318e88450bac9cd9cdbed83e80" target="id-b79b41b18c4c41b0a8d7eb834c591bd7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-ac5ebafe8d7047198d3eebc6c8549e63" relationshipRef="id-e645861dcfa348e4908b38a236f7c987" xsi:type="Relationship" source="id-72a927318e88450bac9cd9cdbed83e80" target="id-46a415ecc7fa4e3a9e563ff40d27f154">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="996" y="756" />
+          <bendpoint x="996" y="192" />
+        </connection>
+      </view>
+      <view identifier="id-668094d6cc8f47849165a81c8ae4223c" xsi:type="Diagram">
+        <name xml:lang="es">Figure05_Hot-Strip-Mill</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/5/19</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-a8a73b9c9e7a4bf19688be83b4745cf2" xsi:type="Label" x="204" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-06bacb18d1bd4d64af24fb6070fdf0f0" xsi:type="Label" x="502" y="288" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-2cad38419d6d4310b55e7e4a00f2bc46" elementRef="id-2ce4621d4a164842b29cce506cde7a68" xsi:type="Element" x="157" y="60" w="560" h="205">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-f79a8358daf34a35bd399a2eb05150c7" elementRef="id-7d3aa9ac0b804060a502de4b8ad537fc" xsi:type="Element" x="193" y="108" w="481" h="133">
+            <style>
+              <fillColor r="201" g="231" b="183" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+            <node identifier="id-da884ab0e25947bfb193fdb9370903fa" elementRef="id-64e12c6aa1954c6486e01bda92a18d82" xsi:type="Element" x="517" y="160" w="120" h="55">
+              <style>
+                <fillColor r="201" g="231" b="183" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-4183adebb13242f685b9365407059ae7" elementRef="id-dc154c48f080459ca6e29d7f1edaf050" xsi:type="Element" x="229" y="160" w="120" h="55">
+              <style>
+                <fillColor r="201" g="231" b="183" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+          </node>
+        </node>
+        <connection identifier="id-4756e0e3939b40feb9618b7b708b3cfa" relationshipRef="id-77d3c7ec3c7d40b792c69a7e77fc05fc" xsi:type="Relationship" source="id-da884ab0e25947bfb193fdb9370903fa" target="id-4183adebb13242f685b9365407059ae7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="432" y="204" />
+        </connection>
+        <connection identifier="id-c03233e2ac6f411d9fde6531dbba8bc5" relationshipRef="id-e3360c30fe79439aad031c4ab0179f73" xsi:type="Relationship" source="id-4183adebb13242f685b9365407059ae7" target="id-da884ab0e25947bfb193fdb9370903fa">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="432" y="168" />
+        </connection>
+      </view>
+      <view identifier="id-b1443625aaa14845bd5966d40a83cec0" xsi:type="Diagram">
+        <name xml:lang="es">Figure06_Overall-Challenges</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/5/19</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-7f2a660ff5644a48a95c2e9fb209b7fb" xsi:type="Label" x="204" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-df6ad8f6a99541fea9081544186e8edc" xsi:type="Label" x="624" y="360" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-0615fd623f704e5084f1fb09b98e925d" elementRef="id-fcb1db6aa783410aa3856df684699fd3" xsi:type="Element" x="386" y="66" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-744fdcc176b445daa4239e80c45abbeb" elementRef="id-985c644ebbe343c5a32fc36353e0535d" xsi:type="Element" x="300" y="156" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-0aeb86a08b384ec28fbc066aaa04b3c0" elementRef="id-41f712023d8b4f9babb41249355dfc7b" xsi:type="Element" x="456" y="156" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-f96cef96648043f98ca283ba44d54fe4" elementRef="id-4c52d1762cb8468c92950f0bc509e045" xsi:type="Element" x="228" y="252" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-d781ba9c22044d16857baded99019960" elementRef="id-e929318a3ae441ba9dd96b8d4623557a" xsi:type="Element" x="386" y="252" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-9548537c65e34c45a5bd8ad717349572" elementRef="id-773494ddbf30427a8218ff76abbe0d5f" xsi:type="Element" x="36" y="360" w="144" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-9bde96ba19c74eb88cd523015f790434" elementRef="id-73a045146ae94517bca67365cd206c1a" xsi:type="Element" x="216" y="360" w="144" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-83f7f1af901b4f5289cc0851fd9acc4d" elementRef="id-bf3da697d4314f33bcb03ae7ed84d665" xsi:type="Element" x="396" y="360" w="144" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-f7c0daf68f164b7c973fbef1d81c6de2" relationshipRef="id-fe5b1c1a7b7b4feb8c332646fb491054" xsi:type="Relationship" source="id-744fdcc176b445daa4239e80c45abbeb" target="id-0615fd623f704e5084f1fb09b98e925d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-97349aa012994df2a573c42f01b726aa" relationshipRef="id-ffd2cd9166134f5696a00d225c52da64" xsi:type="Relationship" source="id-0aeb86a08b384ec28fbc066aaa04b3c0" target="id-0615fd623f704e5084f1fb09b98e925d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-c4834632279048128a4192ce47c1be44" relationshipRef="id-0348cd1eb1584e9b8c3e227e3ac1e452" xsi:type="Relationship" source="id-f96cef96648043f98ca283ba44d54fe4" target="id-744fdcc176b445daa4239e80c45abbeb">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-0fcadf1cf99d4a05b6cdf2d747702dbb" relationshipRef="id-19d3440bf3644351a243e4643a1a10d8" xsi:type="Relationship" source="id-d781ba9c22044d16857baded99019960" target="id-744fdcc176b445daa4239e80c45abbeb">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-9021077dea9b4b89bd6dc99ea9e380eb" relationshipRef="id-d3469f3809b4441d942adf3ef2741833" xsi:type="Relationship" source="id-d781ba9c22044d16857baded99019960" target="id-0aeb86a08b384ec28fbc066aaa04b3c0">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-f14a88c73f994b86a8c3449d8acc582a" relationshipRef="id-7669e65ab1034b6d878df79babb655a5" xsi:type="Relationship" source="id-9548537c65e34c45a5bd8ad717349572" target="id-f96cef96648043f98ca283ba44d54fe4">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-3ab0cc2f6e4342dc95215429ba05e698" relationshipRef="id-ba744d730a164cf0b0c5719100b2569c" xsi:type="Relationship" source="id-9bde96ba19c74eb88cd523015f790434" target="id-f96cef96648043f98ca283ba44d54fe4">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-558064eba28c47c69861f2c6d90fe189" relationshipRef="id-7b538a04c895462c9ccf34c555b3fcbc" xsi:type="Relationship" source="id-83f7f1af901b4f5289cc0851fd9acc4d" target="id-f96cef96648043f98ca283ba44d54fe4">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-757c3c6a49cd4c67844ab2c9b366fa21" relationshipRef="id-3b75b3117c164ed78c02b13d9d72f03b" xsi:type="Relationship" source="id-83f7f1af901b4f5289cc0851fd9acc4d" target="id-d781ba9c22044d16857baded99019960">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-5259ce1cb1ab47d2ad3f28b75326991a" xsi:type="Diagram">
+        <name xml:lang="es">Figure07_More-Challenges</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/5/19</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-d01a70be36f840d3b4a8aed48e58ad2d" xsi:type="Label" x="288" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-320340daba294002a6e031d9ec80c3ba" xsi:type="Label" x="136" y="481" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-dc1128d0a0fb454b98fab8d20a5db58c" elementRef="id-fcb1db6aa783410aa3856df684699fd3" xsi:type="Element" x="444" y="60" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-f5ac8b63559a4b18a21303e4fbb4f7d5" elementRef="id-985c644ebbe343c5a32fc36353e0535d" xsi:type="Element" x="264" y="156" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-2c12e0bea5164919bb44696a104f5763" elementRef="id-41f712023d8b4f9babb41249355dfc7b" xsi:type="Element" x="444" y="156" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-b3e05ce0504743898913ec50a780b1a7" elementRef="id-4c52d1762cb8468c92950f0bc509e045" xsi:type="Element" x="192" y="252" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-d019b63433bf40309bf27f3e5238bcc7" elementRef="id-e929318a3ae441ba9dd96b8d4623557a" xsi:type="Element" x="350" y="252" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-d7c54a72de294667a37f25651e31535f" elementRef="id-773494ddbf30427a8218ff76abbe0d5f" xsi:type="Element" x="0" y="360" w="144" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-b27c175c7d5d409aa2627987fd5139b8" elementRef="id-73a045146ae94517bca67365cd206c1a" xsi:type="Element" x="180" y="360" w="144" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-00a785c3e59c46d9af364bdee05b2f29" elementRef="id-bf3da697d4314f33bcb03ae7ed84d665" xsi:type="Element" x="360" y="360" w="144" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-188fe17c2010452aa3c7cd5e8a0a5bad" elementRef="id-8939bfb16933425c952bd4ca553d90e2" xsi:type="Element" x="648" y="60" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-a58bdd94f161420da5c3958351d709a5" elementRef="id-1008ebfba144417f8e8a58e889c3b9c6" xsi:type="Element" x="708" y="156" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-10a79efc245241b5aa0c58dacd436500" elementRef="id-70189a83837444a798183ae73a7bc5b2" xsi:type="Element" x="540" y="258" w="132" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-ed3cb386285f41a69675276bf1965428" elementRef="id-26dae395ffb343dcbb3a410b88d3021d" xsi:type="Element" x="708" y="258" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-a270d1de39ad43ba95bf48874fb0a00e" elementRef="id-db9483ab0a3b4f1eb7259e53426eee09" xsi:type="Element" x="876" y="258" w="133" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-dc32dee1645e4515805eb178f6bfa4c5" elementRef="id-b9d676d91e5e40ebaa9338c0e87463bf" xsi:type="Element" x="540" y="360" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-a982495e31354617a3bd380d1271f33e" elementRef="id-f19bc7ea65c94679b97db1774cb2ef34" xsi:type="Element" x="671" y="360" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-7cda29aefe3f40ab88adb971602eedbd" elementRef="id-d57beba0aeca4d5884d9f79cee2cacad" xsi:type="Element" x="804" y="360" w="145" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-64660a001ae140219743b8c84244c98b" elementRef="id-a0f64c7e0e3b43c6a9ea32a9b35e99eb" xsi:type="Element" x="972" y="360" w="145" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-cb903bf357944f0eafef6f6cb6c42231" elementRef="id-4b6a9ff03a9b4b1689350806c022f681" xsi:type="Element" x="804" y="468" w="142" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-e7dc6610e03740e3b72257d63ec9d76c" elementRef="id-9960fb227da24f57b727e05fd81a7739" xsi:type="Element" x="588" y="468" w="144" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-1368064591844f0782999f32144acb6e" relationshipRef="id-fe5b1c1a7b7b4feb8c332646fb491054" xsi:type="Relationship" source="id-f5ac8b63559a4b18a21303e4fbb4f7d5" target="id-dc1128d0a0fb454b98fab8d20a5db58c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-81ec58fc7f1b45be94c2ea2182d58c85" relationshipRef="id-ffd2cd9166134f5696a00d225c52da64" xsi:type="Relationship" source="id-2c12e0bea5164919bb44696a104f5763" target="id-dc1128d0a0fb454b98fab8d20a5db58c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-fea9ead717f4402ab44745420123c4f4" relationshipRef="id-3bda25cdcd914997bcfbce7508a2b52f" xsi:type="Relationship" source="id-2c12e0bea5164919bb44696a104f5763" target="id-188fe17c2010452aa3c7cd5e8a0a5bad">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-b55c833e4304491087c1f3df1b360f8e" relationshipRef="id-0348cd1eb1584e9b8c3e227e3ac1e452" xsi:type="Relationship" source="id-b3e05ce0504743898913ec50a780b1a7" target="id-f5ac8b63559a4b18a21303e4fbb4f7d5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-825b123d165043d08213b693c1d100f9" relationshipRef="id-19d3440bf3644351a243e4643a1a10d8" xsi:type="Relationship" source="id-d019b63433bf40309bf27f3e5238bcc7" target="id-f5ac8b63559a4b18a21303e4fbb4f7d5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-e928d43510c64068ae3eced656213240" relationshipRef="id-d3469f3809b4441d942adf3ef2741833" xsi:type="Relationship" source="id-d019b63433bf40309bf27f3e5238bcc7" target="id-2c12e0bea5164919bb44696a104f5763">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-cccdeac732ad4010bafa6cc0a42c9f0f" relationshipRef="id-7669e65ab1034b6d878df79babb655a5" xsi:type="Relationship" source="id-d7c54a72de294667a37f25651e31535f" target="id-b3e05ce0504743898913ec50a780b1a7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-517f557018b343b5a5f20248166bf462" relationshipRef="id-ba744d730a164cf0b0c5719100b2569c" xsi:type="Relationship" source="id-b27c175c7d5d409aa2627987fd5139b8" target="id-b3e05ce0504743898913ec50a780b1a7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-97e03fbf60c44189897e5d5f068557b3" relationshipRef="id-7b538a04c895462c9ccf34c555b3fcbc" xsi:type="Relationship" source="id-00a785c3e59c46d9af364bdee05b2f29" target="id-b3e05ce0504743898913ec50a780b1a7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-4ffbda8ac5c74cca87e1d473a148716a" relationshipRef="id-3b75b3117c164ed78c02b13d9d72f03b" xsi:type="Relationship" source="id-00a785c3e59c46d9af364bdee05b2f29" target="id-d019b63433bf40309bf27f3e5238bcc7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-dae1ac91465f43aa88a47f67c68b497f" relationshipRef="id-5e4ced2c083341aaa1d43e43cc386f59" xsi:type="Relationship" source="id-a58bdd94f161420da5c3958351d709a5" target="id-dc1128d0a0fb454b98fab8d20a5db58c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a4515563c3e248d2b0e50d7e0fdaad06" relationshipRef="id-29cf98286e404826813e3fd5d363faa4" xsi:type="Relationship" source="id-a58bdd94f161420da5c3958351d709a5" target="id-188fe17c2010452aa3c7cd5e8a0a5bad">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-68aaee72387d4f75b3c2f2eb4de5550b" relationshipRef="id-edbfed03abca46d0b0fa9f301af49848" xsi:type="Relationship" source="id-10a79efc245241b5aa0c58dacd436500" target="id-a58bdd94f161420da5c3958351d709a5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-854dabc361bf44e09c708a3334601ebb" relationshipRef="id-a2a0c2f582964d98ae5e90d434018f18" xsi:type="Relationship" source="id-ed3cb386285f41a69675276bf1965428" target="id-10a79efc245241b5aa0c58dacd436500">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-38a159862acf4e64a7d02570a84cb062" relationshipRef="id-284558569ac940e1a5b0e3000096850f" xsi:type="Relationship" source="id-a270d1de39ad43ba95bf48874fb0a00e" target="id-a58bdd94f161420da5c3958351d709a5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-f23bb87e455346ffa858edd979a4969f" relationshipRef="id-30522f5fa02146338ce89262dba83fb5" xsi:type="Relationship" source="id-dc32dee1645e4515805eb178f6bfa4c5" target="id-10a79efc245241b5aa0c58dacd436500">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-c957509f568f400aae07d4212fd8a165" relationshipRef="id-13604f57255f42d2aba9fa1285d8425f" xsi:type="Relationship" source="id-a982495e31354617a3bd380d1271f33e" target="id-ed3cb386285f41a69675276bf1965428">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-dbe84ae9cace46a4a53cc4db5125464e" relationshipRef="id-52fd056560dc472a9e3437d3fecd4bbc" xsi:type="Relationship" source="id-7cda29aefe3f40ab88adb971602eedbd" target="id-a270d1de39ad43ba95bf48874fb0a00e">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-4165b06167ae412da65d0b8ef7a07ec7" relationshipRef="id-c2bea22fcc67491e8f94e92c284a6ffe" xsi:type="Relationship" source="id-7cda29aefe3f40ab88adb971602eedbd" target="id-ed3cb386285f41a69675276bf1965428">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-6afb8d25883142ea95c08d4349311eee" relationshipRef="id-02ed4c260f494d798413cd888ed9a225" xsi:type="Relationship" source="id-64660a001ae140219743b8c84244c98b" target="id-a270d1de39ad43ba95bf48874fb0a00e">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-7e6f024fec664bb5a546293450b60bdd" relationshipRef="id-8bb3d6c2686a47bea3048439d73a7961" xsi:type="Relationship" source="id-cb903bf357944f0eafef6f6cb6c42231" target="id-a982495e31354617a3bd380d1271f33e">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-927c8ffc55e64525a74e5faf2fbb330b" relationshipRef="id-6bc9b8fd5f864ec1b28f44033ab4bc34" xsi:type="Relationship" source="id-cb903bf357944f0eafef6f6cb6c42231" target="id-7cda29aefe3f40ab88adb971602eedbd">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-914a97e826524280a601b0424b9a4ca3" relationshipRef="id-e18e110381a244d9b7ca1213c59aaa3a" xsi:type="Relationship" source="id-cb903bf357944f0eafef6f6cb6c42231" target="id-64660a001ae140219743b8c84244c98b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-6f2fe897810845f5b98b630f3d0ad40a" relationshipRef="id-46c475168f184342aff3386fa1a409f8" xsi:type="Relationship" source="id-cb903bf357944f0eafef6f6cb6c42231" target="id-e7dc6610e03740e3b72257d63ec9d76c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-ad67dde28a3d4a1a922df1376a195e13" xsi:type="Diagram">
+        <name xml:lang="es">Figure08_ArchiMetal-CRM-Vision</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/5/19</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-14935b55edf34af4a6c1e125d4778b99" xsi:type="Label" x="204" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-75b7508c91ee4888a37821584a3880e1" xsi:type="Label" x="709" y="804" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-c6e7629454314ebbb42b8db4305aaa0d" elementRef="id-1a7757e999c54d6085462db7df22a296" xsi:type="Element" x="528" y="60" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-92f852161a0d4931958d15ec49010cc9" elementRef="id-d95e1aa70fcd4c8bba40177204ebca8d" xsi:type="Element" x="252" y="348" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-95a56abb95354fc7965b318c2dd12a79" elementRef="id-50fbcd5489444693bcbc3efe86d1df80" xsi:type="Element" x="540" y="348" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-56b437385fd94c8e8adea987969ac77c" elementRef="id-e73fde26e4094a1c9f97edfb48139287" xsi:type="Element" x="348" y="62" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-e2a7a2a1604241e0a3f56bc2d29dc058" elementRef="id-c35cc8ce1a73415080bf804d76727b72" xsi:type="Element" x="228" y="156" w="456" h="169">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-c9e677a5d015431e85f17178fb50fe5f" elementRef="id-15b84bcdf6374633b8225b636f14f140" xsi:type="Element" x="396" y="181" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-971b95e9164648428468bd2bf6700bf9" elementRef="id-9341d876214745edb68cdc91b7b8ffe7" xsi:type="Element" x="252" y="181" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-27b05c4a7d974886a4b88100ceb58893" elementRef="id-a6992b23c09c44dba47e8e06ad7655c5" xsi:type="Element" x="540" y="252" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-f1e4c83d5ef348df8cef503011767ca1" elementRef="id-bb08ebde1b25412bb52d9e4d35afa404" xsi:type="Element" x="252" y="252" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-4805265fd64f4b228c0c83f6658c740c" elementRef="id-04e04b7fccd14a7a88229604fccc7a86" xsi:type="Element" x="396" y="252" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-9a31f7e62db64bd2942e8a2e78d25be1" elementRef="id-ec198d6b44094aea97ee9bb93659c30d" xsi:type="Element" x="540" y="181" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-1ed8e1d69c73460bac7eca3892a17d73" elementRef="id-b184c5661a354a80a26061333635c927" xsi:type="Element" x="732" y="62" w="181" h="421">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-7c3d5a1bef784350a2175ce3c659f09e" elementRef="id-fde9a2a74e544857bcdcd5c127214475" xsi:type="Element" x="768" y="398" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-40f58c8f4e0446748605e4e52fb0b33a" elementRef="id-d970cdcf5ac247698017f1e9732e2a07" xsi:type="Element" x="769" y="98" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-4f75e41d297e4a6591471e52bf80840e" elementRef="id-b42e8f45867b487ca2ccd136ebfafde7" xsi:type="Element" x="769" y="158" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-9cb5fc5827f844c38428a59ac7d70a90" elementRef="id-b56b5c461fc94c06b00ed6d33955fcb2" xsi:type="Element" x="769" y="218" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-08456b859a1b4b50a27d42d3463b0a44" elementRef="id-e59bb5647dc6486c8ea1d08b67c19bc1" xsi:type="Element" x="768" y="278" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-758ddf36a1fd477a8bbd670e9a47b183" elementRef="id-0bed0f0876c6428fa25879de80d47208" xsi:type="Element" x="769" y="338" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-9d034701779946c19ee337dc314d555d" elementRef="id-c8586b2db2314b17852d6e100b1c633f" xsi:type="Element" x="12" y="116" w="169" h="299">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-6f5b9704d2574fda9167e55dc11941f0" elementRef="id-3c646c52bc8e45cfafa3b767bb3af35f" xsi:type="Element" x="36" y="272" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-42400a886d6d49359078fd8f17acd7ec" elementRef="id-17ef9d3c310b4a5aa7463cd6d85db619" xsi:type="Element" x="36" y="140" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-7983f08715ac4412ae5c17d39bd96d4c" elementRef="id-d1edd2e27b3c48f0b4753883ba9ef65f" xsi:type="Element" x="36" y="205" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-b1f4d7182cd54844af2c5d349e5c4de9" elementRef="id-389fa5299bd54976a7e31306656cbb42" xsi:type="Element" x="36" y="344" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-16a28485d61e4f1faedf12701313527a" elementRef="id-300c7dd906cb45b4b0b8e6bb0828221f" xsi:type="Element" x="138" y="744" w="576" h="49">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-3af808a217f04dbd801b32f8317c255d" elementRef="id-9a865b3c106b4c5cb4800029ac3d54a7" xsi:type="Element" x="144" y="432" w="566" h="158">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-a1d7aefa4d474fa6b596364ef0fa7788" elementRef="id-5c6ae3c285034247837fe4118e5c76d9" xsi:type="Element" x="563" y="456" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-0c24d4a0dee646338f21e614cad1bb2c" elementRef="id-226179e7cbaa4a919383bdd4e44b41dc" xsi:type="Element" x="299" y="456" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-c6f804bc17be495c81131b37c6c549bb" elementRef="id-a4e2426aa6344ff49a4d9f5a22b67ad9" xsi:type="Element" x="430" y="516" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-eb6ea9c35b3d49d9b1e7322b6a449548" elementRef="id-72854cd1e4ff40a1bdf77773165e2bdc" xsi:type="Element" x="168" y="516" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-7270266ede4d42c38ddcaf2e362c0ac7" elementRef="id-ba8ce89c442d457c845d849f2ba0b8e5" xsi:type="Element" x="168" y="456" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-28db24c4e81540d492ef95ef67135b66" elementRef="id-99bc4a3c85954400915f6e7433440cb0" xsi:type="Element" x="299" y="516" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-1f466672c6e84784834ef790793c9568" elementRef="id-2dbbbff37e7644338f16ac2fbf784265" xsi:type="Element" x="563" y="516" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-ce041a26b25e4477a577b26ec4a0cb0a" elementRef="id-e9a3e42545534d519a9221494e2afb44" xsi:type="Element" x="430" y="456" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-b1b1ae7e0b5c4028a96a77f65efbfb40" elementRef="id-3237b47e6ecc442b87d63a2c0ff8077c" xsi:type="Element" x="142" y="620" w="568" h="101">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-99d0c093bc6f4e05bcd8e50360c530b7" elementRef="id-4e06ee45db904a88aa46e9dce611528e" xsi:type="Element" x="376" y="644" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-7e7c5da3a4ba4bb89b25a81e071f1999" elementRef="id-c728f7f622be468380062354ffbf4f57" xsi:type="Element" x="526" y="644" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-e753aecacff94fa5849e3358fb957d63" elementRef="id-2a8eb6786915456d92df41a8b9349314" xsi:type="Element" x="226" y="644" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <connection identifier="id-831007985f3c4530b1caec1127dd6aa3" relationshipRef="id-dbfb1e8203a64297b4b46862578575d1" xsi:type="Relationship" source="id-92f852161a0d4931958d15ec49010cc9" target="id-f1e4c83d5ef348df8cef503011767ca1">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-ba0be64a318044bb8d8989f420393a42" relationshipRef="id-86bc53efc09a4d01b5d863ea4da169a1" xsi:type="Relationship" source="id-95a56abb95354fc7965b318c2dd12a79" target="id-27b05c4a7d974886a4b88100ceb58893">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-1f2988236abf4c779975b631e5cee5ff" relationshipRef="id-0c9b384a0f314c48bd6fd49c1a23367d" xsi:type="Relationship" source="id-56b437385fd94c8e8adea987969ac77c" target="id-c6e7629454314ebbb42b8db4305aaa0d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-64ac6290e51b48918e767a6d2ce947a4" relationshipRef="id-ccec811b82164a469276ca27701eb708" xsi:type="Relationship" source="id-e2a7a2a1604241e0a3f56bc2d29dc058" target="id-56b437385fd94c8e8adea987969ac77c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-85b5e90008b14905a7f9a5d623474882" relationshipRef="id-73834b75835342c0852e918d323d1b4b" xsi:type="Relationship" source="id-e2a7a2a1604241e0a3f56bc2d29dc058" target="id-9d034701779946c19ee337dc314d555d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-53ed3a8f69264f1696ea5b35b94a7755" relationshipRef="id-1cc784cdeb4748e0a841245b478cdbe9" xsi:type="Relationship" source="id-e2a7a2a1604241e0a3f56bc2d29dc058" target="id-1ed8e1d69c73460bac7eca3892a17d73">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-7fa9c3fc811848bb81d0313d60bd9e3d" relationshipRef="id-9b86b5def09747ccba106869f577267b" xsi:type="Relationship" source="id-16a28485d61e4f1faedf12701313527a" target="id-1ed8e1d69c73460bac7eca3892a17d73">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="828" y="768" />
+        </connection>
+        <connection identifier="id-a64c38c7b3864d759439aa8f9900173a" relationshipRef="id-fb680925b6944ad49547daeb63178de8" xsi:type="Relationship" source="id-16a28485d61e4f1faedf12701313527a" target="id-9d034701779946c19ee337dc314d555d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="72" y="768" />
+        </connection>
+        <connection identifier="id-2a47c828ff8942c080dd9ce4ac4c5d83" relationshipRef="id-09d464beef544058aa2967e77f4436ba" xsi:type="Relationship" source="id-3af808a217f04dbd801b32f8317c255d" target="id-e2a7a2a1604241e0a3f56bc2d29dc058">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-2ce9e953fede42be8b119263e1a62ee5" relationshipRef="id-614ca33606b04853b992a8370c914142" xsi:type="Relationship" source="id-b1b1ae7e0b5c4028a96a77f65efbfb40" target="id-3af808a217f04dbd801b32f8317c255d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-014eb1eb99604bc59e966dddb8c95574" relationshipRef="id-bce367c94f9c417791e8bb987f220248" xsi:type="Relationship" source="id-99d0c093bc6f4e05bcd8e50360c530b7" target="id-16a28485d61e4f1faedf12701313527a">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-edd20936be734ead95002c136e112028" relationshipRef="id-cfa2c2b556254127b249c4ab0c58e425" xsi:type="Relationship" source="id-7e7c5da3a4ba4bb89b25a81e071f1999" target="id-99d0c093bc6f4e05bcd8e50360c530b7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-06690068dabe414a957aee33efa23614" relationshipRef="id-7856a54511f24730a8d64f4147c5ea4c" xsi:type="Relationship" source="id-e753aecacff94fa5849e3358fb957d63" target="id-99d0c093bc6f4e05bcd8e50360c530b7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-c7dc626670a3456c9a2632e54fd92b89" xsi:type="Diagram">
+        <name xml:lang="es">Figure09_Customer-Service-Provided-by-DC-Benelux</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023-05-19</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-57ff519fac9944dd8100df126d47d2fa" xsi:type="Label" x="204" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-7ae9cd21309449af906ece94562cea71" xsi:type="Label" x="576" y="408" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-8db54a2ba4834ba1b9d964332a756de7" elementRef="id-1a7757e999c54d6085462db7df22a296" xsi:type="Element" x="101" y="72" w="679" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-ba8de91a854a47b6a05dbc1898602efb" elementRef="id-d02d8886a7934dc898143a97a8376606" xsi:type="Element" x="660" y="180" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-0b59778ac14c4b659076904428481c0e" elementRef="id-73d6be570bd344aeb933d06b9566af35" xsi:type="Element" x="101" y="180" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-7d3c5922c3494aedacb3e9de30ba773d" elementRef="id-cbc5896e78284e23b5bbca5e9a15dc76" xsi:type="Element" x="516" y="180" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-b768a6c46c234f2dac970e59f818eafa" elementRef="id-633f46a9f9f84bbda07115037faf71eb" xsi:type="Element" x="377" y="180" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-37b6d47e5e8b48df9b82962cab3f0b43" elementRef="id-c160bb04a89643a880d79a2dce37bd38" xsi:type="Element" x="240" y="180" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-4ad6f5bf74ee4649b6307fdfde3431cb" elementRef="id-3bc7d428ccea48739c4d442f9f2364e7" xsi:type="Element" x="64" y="276" w="745" h="109">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-28ebee41acd542828f5473158d3d051f" elementRef="id-eb6681ab4dd94ce3996ade5875bdf3ef" xsi:type="Element" x="239" y="295" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-69a94007d62e4fa88339c782094df040" elementRef="id-56a4ef970d314200bc4e95d8ea928093" xsi:type="Element" x="100" y="295" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-5977444a39c04fd5be672ee236bc7033" elementRef="id-b7900be563de46529b9fc8d1975b2b37" xsi:type="Element" x="378" y="295" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-b731d3a16e3b4e8b89926f977184c068" elementRef="id-8584078cf77640869fc4b4ff7a60d00d" xsi:type="Element" x="659" y="295" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-03077d50bc994d2a954b2e6d1d00c575" elementRef="id-103caa122d7e4d63a5b6479756634453" xsi:type="Element" x="515" y="295" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <connection identifier="id-aaa07c9385884b85a1e44f217ec6f9d8" relationshipRef="id-8b5f76ead5464ebdace7dd4ffaacae91" xsi:type="Relationship" source="id-ba8de91a854a47b6a05dbc1898602efb" target="id-8db54a2ba4834ba1b9d964332a756de7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-823c0f954b0c430f92f82f37866e7093" relationshipRef="id-eafcc2e35d494c069d65233cc5431572" xsi:type="Relationship" source="id-0b59778ac14c4b659076904428481c0e" target="id-8db54a2ba4834ba1b9d964332a756de7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-dff2652031e74bb49013e6ba056db697" relationshipRef="id-854eab2f9d8446708ff00fc216fd026e" xsi:type="Relationship" source="id-7d3c5922c3494aedacb3e9de30ba773d" target="id-8db54a2ba4834ba1b9d964332a756de7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-6999cab94768427aa5f6bbbbb57903fd" relationshipRef="id-8e1e118effae4e4abbb7307191a4b76f" xsi:type="Relationship" source="id-b768a6c46c234f2dac970e59f818eafa" target="id-8db54a2ba4834ba1b9d964332a756de7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-0d53e36ce41943ccbad3c73bf60dcf33" relationshipRef="id-26a00b70891e43dd8e23d2386956d1c5" xsi:type="Relationship" source="id-37b6d47e5e8b48df9b82962cab3f0b43" target="id-8db54a2ba4834ba1b9d964332a756de7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-5abfb63f6a4844bab12cebe61f596a3e" relationshipRef="id-b2f6b889474f475d9e537bc7767dc572" xsi:type="Relationship" source="id-28ebee41acd542828f5473158d3d051f" target="id-37b6d47e5e8b48df9b82962cab3f0b43">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-ef895a26968d43ada413bd7f076e4850" relationshipRef="id-6e814dc25573414a8051b8d98d9ea3cb" xsi:type="Relationship" source="id-69a94007d62e4fa88339c782094df040" target="id-0b59778ac14c4b659076904428481c0e">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-d4405364eebb40b09180af9cb893f3a1" relationshipRef="id-8b40148638df402990222b414ed12358" xsi:type="Relationship" source="id-5977444a39c04fd5be672ee236bc7033" target="id-b768a6c46c234f2dac970e59f818eafa">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-c7081b30c99f4e0fa5cfea797dbc069c" relationshipRef="id-dcc7e7bbdea2449fb76e4ce82ff7131d" xsi:type="Relationship" source="id-b731d3a16e3b4e8b89926f977184c068" target="id-ba8de91a854a47b6a05dbc1898602efb">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-87adab9234e7489299b30da37eeaef7d" relationshipRef="id-ddf77800e82040caa3ab3ae7f93da8ae" xsi:type="Relationship" source="id-03077d50bc994d2a954b2e6d1d00c575" target="id-7d3c5922c3494aedacb3e9de30ba773d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-ca8ac0b4ff5f45d8b4a69771ef82d3d2" xsi:type="Diagram">
+        <name xml:lang="es">Figure10_BusinessProcess-BusinessUnit-Mapping</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/5/19</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-8a3bf4a7a82847689d20e87d08a11f05" xsi:type="Label" x="204" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-cc71088062a34127a9067ae438c7c0f2" xsi:type="Label" x="660" y="498" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-8176d5a6e32b4700ba26159d673588e0" elementRef="id-1a7757e999c54d6085462db7df22a296" xsi:type="Element" x="99" y="55" w="679" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-d8e8965087164673bc31a148411b21e4" elementRef="id-d02d8886a7934dc898143a97a8376606" xsi:type="Element" x="660" y="151" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-e5446fc86cb541408cf0e31da09aaedc" elementRef="id-73d6be570bd344aeb933d06b9566af35" xsi:type="Element" x="101" y="151" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-fdec21350ec04110803e25f6b304d088" elementRef="id-cbc5896e78284e23b5bbca5e9a15dc76" xsi:type="Element" x="516" y="151" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-2f600e7b4c784b37a3e34d7b5331f878" elementRef="id-633f46a9f9f84bbda07115037faf71eb" xsi:type="Element" x="377" y="151" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-09b91ce107fe4461bdf08b09a3c8baa3" elementRef="id-c160bb04a89643a880d79a2dce37bd38" xsi:type="Element" x="240" y="151" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-aec308215d2c4812b43207ca4f25873a" elementRef="id-3bc7d428ccea48739c4d442f9f2364e7" xsi:type="Element" x="588" y="367" w="192" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-2874246fff014d5b8b995d0aa16ed02d" elementRef="id-eb6681ab4dd94ce3996ade5875bdf3ef" xsi:type="Element" x="240" y="235" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-5c01e8789d484e2abc4ea9dde803da14" elementRef="id-103caa122d7e4d63a5b6479756634453" xsi:type="Element" x="516" y="235" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-e5de687a82b44cd2a7a92c3753a083f5" elementRef="id-56a4ef970d314200bc4e95d8ea928093" xsi:type="Element" x="101" y="235" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-6c489cbcde8b4a09add6751fb9fc4f10" elementRef="id-8584078cf77640869fc4b4ff7a60d00d" xsi:type="Element" x="660" y="235" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-82d84292c6d74ca7b7b58fb03cfae1a1" elementRef="id-b7900be563de46529b9fc8d1975b2b37" xsi:type="Element" x="379" y="235" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-f4f4fa1d12b34f29946d146d8ed1318e" elementRef="id-8c910863999445c0b2afceb98acbefff" xsi:type="Element" x="312" y="367" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-16284df37ce142f9aa5bcde2e83743e9" elementRef="id-5f7aebddd3ad4a0593301978fca34bab" xsi:type="Element" x="101" y="367" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-aac04295c3a441cbac3c5cf7cedc9ed8" elementRef="id-f4676bc1d45f43e89921d3e0303037b1" xsi:type="Element" x="312" y="456" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-5297318a921a4f458e00b350e47e54a9" elementRef="id-86d6a2f695b74347a264354315c8656f" xsi:type="Element" x="101" y="456" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-8536e113f4f94cf59ceaa17e5a886a95" elementRef="id-ca35f8df80974169b04c1ffd58c12493" xsi:type="Element" x="492" y="456" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-922320c4161343b29b6bec5c17760b1b" relationshipRef="id-8b5f76ead5464ebdace7dd4ffaacae91" xsi:type="Relationship" source="id-d8e8965087164673bc31a148411b21e4" target="id-8176d5a6e32b4700ba26159d673588e0">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-faee455b358c4f428602447341ef4583" relationshipRef="id-eafcc2e35d494c069d65233cc5431572" xsi:type="Relationship" source="id-e5446fc86cb541408cf0e31da09aaedc" target="id-8176d5a6e32b4700ba26159d673588e0">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-bdd4c7e8d0cf45eb8e77a296e8770d25" relationshipRef="id-854eab2f9d8446708ff00fc216fd026e" xsi:type="Relationship" source="id-fdec21350ec04110803e25f6b304d088" target="id-8176d5a6e32b4700ba26159d673588e0">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-b597eda32eef41979fb197bbff120443" relationshipRef="id-8e1e118effae4e4abbb7307191a4b76f" xsi:type="Relationship" source="id-2f600e7b4c784b37a3e34d7b5331f878" target="id-8176d5a6e32b4700ba26159d673588e0">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a7d09e9b718048909866444fc47d5baa" relationshipRef="id-26a00b70891e43dd8e23d2386956d1c5" xsi:type="Relationship" source="id-09b91ce107fe4461bdf08b09a3c8baa3" target="id-8176d5a6e32b4700ba26159d673588e0">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-7ae4517dfbe04cca8d13c28ba6222bbb" relationshipRef="id-3037bdfa443f472588e0f4233a423eec" xsi:type="Relationship" source="id-aec308215d2c4812b43207ca4f25873a" target="id-2874246fff014d5b8b995d0aa16ed02d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="624" y="331" />
+          <bendpoint x="348" y="331" />
+        </connection>
+        <connection identifier="id-6ab5ae2b359645bb8ef84e5c2c863044" relationshipRef="id-2d8ad9219a084314b9f6b34f0bbcb2ab" xsi:type="Relationship" source="id-aec308215d2c4812b43207ca4f25873a" target="id-e5de687a82b44cd2a7a92c3753a083f5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="600" y="343" />
+          <bendpoint x="192" y="343" />
+        </connection>
+        <connection identifier="id-8fd3d73229d8455195ce3a355f4a1b40" relationshipRef="id-ade5af23ad054833950877e5d28a9743" xsi:type="Relationship" source="id-aec308215d2c4812b43207ca4f25873a" target="id-82d84292c6d74ca7b7b58fb03cfae1a1">
+          <style>
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="636" y="319" />
+          <bendpoint x="468" y="319" />
+        </connection>
+        <connection identifier="id-10f018a249414fdfbfa23a74ee8531e8" relationshipRef="id-026d56fafee84728936bb106a423b4b5" xsi:type="Relationship" source="id-aec308215d2c4812b43207ca4f25873a" target="id-6c489cbcde8b4a09add6751fb9fc4f10">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-16ce01acf39746449a77b2c6f6dc6ad3" relationshipRef="id-d9dd6f2624c94bd5be7bdebe95037219" xsi:type="Relationship" source="id-aec308215d2c4812b43207ca4f25873a" target="id-5c01e8789d484e2abc4ea9dde803da14">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="660" y="307" />
+          <bendpoint x="600" y="307" />
+        </connection>
+        <connection identifier="id-4298b51a085945429c5df9895b34b022" relationshipRef="id-68dd5f1df64840cd82fc19f574db7884" xsi:type="Relationship" source="id-aec308215d2c4812b43207ca4f25873a" target="id-f4f4fa1d12b34f29946d146d8ed1318e">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-7ce6890e85244a93b8c1130434983c39" relationshipRef="id-b2f6b889474f475d9e537bc7767dc572" xsi:type="Relationship" source="id-2874246fff014d5b8b995d0aa16ed02d" target="id-09b91ce107fe4461bdf08b09a3c8baa3">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-5e16da54745c48d2870d4875237f4b3d" relationshipRef="id-4e2b77700d624c3fa6193891741156ac" xsi:type="Relationship" source="id-2874246fff014d5b8b995d0aa16ed02d" target="id-f4f4fa1d12b34f29946d146d8ed1318e">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-61d89c95c5d847369321426fbbdc61e0" relationshipRef="id-ddf77800e82040caa3ab3ae7f93da8ae" xsi:type="Relationship" source="id-5c01e8789d484e2abc4ea9dde803da14" target="id-fdec21350ec04110803e25f6b304d088">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-68c4590c90064a0585c60837771de64b" relationshipRef="id-6e814dc25573414a8051b8d98d9ea3cb" xsi:type="Relationship" source="id-e5de687a82b44cd2a7a92c3753a083f5" target="id-e5446fc86cb541408cf0e31da09aaedc">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-f52e23bc07f24fc88970eb3b4e54aa27" relationshipRef="id-dcc7e7bbdea2449fb76e4ce82ff7131d" xsi:type="Relationship" source="id-6c489cbcde8b4a09add6751fb9fc4f10" target="id-d8e8965087164673bc31a148411b21e4">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-eb2023360b0241ebae433aa84fdfaff7" relationshipRef="id-8b40148638df402990222b414ed12358" xsi:type="Relationship" source="id-82d84292c6d74ca7b7b58fb03cfae1a1" target="id-2f600e7b4c784b37a3e34d7b5331f878">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-c14fafbfb1c14db0b376dc3a12c18d0f" relationshipRef="id-dbbe3f8f66224ef292695f41c4ee60b1" xsi:type="Relationship" source="id-f4f4fa1d12b34f29946d146d8ed1318e" target="id-82d84292c6d74ca7b7b58fb03cfae1a1">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-70fc541d850040efb45dd4194c719875" relationshipRef="id-99890b62ab614616971459f19ef22402" xsi:type="Relationship" source="id-f4f4fa1d12b34f29946d146d8ed1318e" target="id-aac04295c3a441cbac3c5cf7cedc9ed8">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="357" y="433" />
+        </connection>
+        <connection identifier="id-ac8177861b9a4a219286d663cecd239d" relationshipRef="id-906ff6c00cce4a389d7c02c541a49522" xsi:type="Relationship" source="id-16284df37ce142f9aa5bcde2e83743e9" target="id-e5de687a82b44cd2a7a92c3753a083f5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-74156e846b13490e9eee335c887aaf1c" relationshipRef="id-696a146fe7a44bdd88efd1608dd5df47" xsi:type="Relationship" source="id-16284df37ce142f9aa5bcde2e83743e9" target="id-2874246fff014d5b8b995d0aa16ed02d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="180" y="331" />
+          <bendpoint x="288" y="331" />
+        </connection>
+        <connection identifier="id-1c65a27d496d44d8a71fe85b4b7d4123" relationshipRef="id-ea7c8a97872a444dbea31e97b5a1d422" xsi:type="Relationship" source="id-aac04295c3a441cbac3c5cf7cedc9ed8" target="id-f4f4fa1d12b34f29946d146d8ed1318e">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="387" y="444" />
+        </connection>
+        <connection identifier="id-1a6a1b3472874dd985982f6b3ec0db96" relationshipRef="id-7aa6c18eab5943e7ae0816a82cec4e51" xsi:type="Relationship" source="id-5297318a921a4f458e00b350e47e54a9" target="id-16284df37ce142f9aa5bcde2e83743e9">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-770fc5450ed24a02854cd9d3f93e047f" relationshipRef="id-7adc30f47d424be187ad7fb51fa8aa26" xsi:type="Relationship" source="id-8536e113f4f94cf59ceaa17e5a886a95" target="id-aac04295c3a441cbac3c5cf7cedc9ed8">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-7b6ebcdc021540f89686548bd3048ed4" xsi:type="Diagram">
+        <name xml:lang="es">Figure11_Information-Flows-between-the-Units</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/5/20</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-cf94ec2cca8442f09d98860254ea2d43" xsi:type="Label" x="204" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-06c4f6dc319446c6888a7cb7d72f1083" xsi:type="Label" x="669" y="624" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-f06962824b244ca5b2429386f242eac9" elementRef="id-1a7757e999c54d6085462db7df22a296" xsi:type="Element" x="828" y="162" w="120" h="427">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-3a76ca8635fd4d5099e109abca9b19d4" elementRef="id-3bc7d428ccea48739c4d442f9f2364e7" xsi:type="Element" x="396" y="162" w="337" h="427">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-e96ef67503f54f4294dd6886c2414d69" elementRef="id-6bb84a70a70c4899963d5370b82d42af" xsi:type="Element" x="420" y="438" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-6c75aedc5298421091b9baef88f4cf7b" elementRef="id-eb2a8dd22fad4020b70d683b9adf85bc" xsi:type="Element" x="492" y="198" w="204" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-c62ebcb503754b0fbb79e9425b74f1b8" elementRef="id-94aed85cd04d4960b53f9db553d91e1c" xsi:type="Element" x="564" y="510" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-32bc910a0e6a40188a87909e7c0e7ada" elementRef="id-d4ae5cd23a3f4c04b5778446859595ab" xsi:type="Element" x="432" y="306" w="264" h="85">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-26fe00c700314bb08ee657c0fa520bc8" elementRef="id-86d6a2f695b74347a264354315c8656f" xsi:type="Element" x="193" y="48" w="540" h="61">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-5fe50ee83d3a49cf92c672c9efccb6b9" elementRef="id-15b84bcdf6374633b8225b636f14f140" xsi:type="Element" x="505" y="60" w="193" h="37">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-aaf3b214bd37480c8b049ba8cbc68fdf" elementRef="id-ca35f8df80974169b04c1ffd58c12493" xsi:type="Element" x="12" y="162" w="349" h="427">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-751b5c367ad2420d9ef48469660e1950" elementRef="id-5fb09df777514d79afbec30bf3a49c72" xsi:type="Element" x="217" y="505" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-16822f72c94446b8b805b48968e78470" elementRef="id-bb08ebde1b25412bb52d9e4d35afa404" xsi:type="Element" x="217" y="414" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-c39d5b66068c44b88b7c99527fb7ec6a" elementRef="id-ec198d6b44094aea97ee9bb93659c30d" xsi:type="Element" x="36" y="198" w="301" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-8ddb62f6638d40529a359316989213ed" elementRef="id-a6992b23c09c44dba47e8e06ad7655c5" xsi:type="Element" x="24" y="414" w="97" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <connection identifier="id-958a3934dfb0470cba1b430ad04a6020" relationshipRef="id-f595dcb5bcf94d3e82371435f0a7edaf" xsi:type="Relationship" source="id-f06962824b244ca5b2429386f242eac9" target="id-6c75aedc5298421091b9baef88f4cf7b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="768" y="233" />
+        </connection>
+        <connection identifier="id-8e4a5d6065284908950122fe549d9b0a" relationshipRef="id-4bb031dc79024a6eb809db3c2a9de992" xsi:type="Relationship" source="id-f06962824b244ca5b2429386f242eac9" target="id-32bc910a0e6a40188a87909e7c0e7ada">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="753" y="373" />
+        </connection>
+        <connection identifier="id-664ff204918e410a8c2e40769f71ff38" relationshipRef="id-8c023a9ee9704765876cd47005b454e9" xsi:type="Relationship" source="id-f06962824b244ca5b2429386f242eac9" target="id-c62ebcb503754b0fbb79e9425b74f1b8">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="756" y="545" />
+        </connection>
+        <connection identifier="id-7a9fdc2cdf424f0ab2fb74c57932cca5" relationshipRef="id-b35f3d1831e64f798ebe5fba8cbe9f34" xsi:type="Relationship" source="id-6c75aedc5298421091b9baef88f4cf7b" target="id-f06962824b244ca5b2429386f242eac9">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="768" y="216" />
+        </connection>
+        <connection identifier="id-22b53e45a07a43259ce2c55e668e4736" relationshipRef="id-35b554c3967343c8ad3256f6f128db1e" xsi:type="Relationship" source="id-6c75aedc5298421091b9baef88f4cf7b" target="id-32bc910a0e6a40188a87909e7c0e7ada">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="564" y="270" />
+        </connection>
+        <connection identifier="id-c79dcca614f6471fbf151438ec9d26c2" relationshipRef="id-fc28e7aaa8814b3ca8a199e3e59f7cc1" xsi:type="Relationship" source="id-6c75aedc5298421091b9baef88f4cf7b" target="id-5fe50ee83d3a49cf92c672c9efccb6b9">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="660" y="144" />
+        </connection>
+        <connection identifier="id-06ff707b8bea4108824aed8a2d00f9ce" relationshipRef="id-aeb98da82ca84aa1850ad53e48b04c63" xsi:type="Relationship" source="id-c62ebcb503754b0fbb79e9425b74f1b8" target="id-32bc910a0e6a40188a87909e7c0e7ada">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="588" y="420" />
+        </connection>
+        <connection identifier="id-a73aadce17b94ff2800920c6e801e5b9" relationshipRef="id-5285a85c637b4248b5f26de5cbaa0690" xsi:type="Relationship" source="id-c62ebcb503754b0fbb79e9425b74f1b8" target="id-f06962824b244ca5b2429386f242eac9">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="756" y="527" />
+        </connection>
+        <connection identifier="id-0d504d63c6b844ebb1dbf7c41342d551" relationshipRef="id-5e030eac9d3d4341a4a07a7dd9947f83" xsi:type="Relationship" source="id-32bc910a0e6a40188a87909e7c0e7ada" target="id-f06962824b244ca5b2429386f242eac9">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="753" y="323" />
+        </connection>
+        <connection identifier="id-049b6718dc6045f39bed57d9b620f1b5" relationshipRef="id-66c6765e590b4e7ebc371e58cf171fdc" xsi:type="Relationship" source="id-32bc910a0e6a40188a87909e7c0e7ada" target="id-f06962824b244ca5b2429386f242eac9">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="753" y="340" />
+        </connection>
+        <connection identifier="id-22fed01177be477090b18f3a6a51301f" relationshipRef="id-eca59d66cde04c79b993f01a19723007" xsi:type="Relationship" source="id-32bc910a0e6a40188a87909e7c0e7ada" target="id-f06962824b244ca5b2429386f242eac9">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="753" y="356" />
+        </connection>
+        <connection identifier="id-6811b6d874db4a58a435f3d7f74597e8" relationshipRef="id-e81da98bf225425d88569aeb05ee2f25" xsi:type="Relationship" source="id-32bc910a0e6a40188a87909e7c0e7ada" target="id-6c75aedc5298421091b9baef88f4cf7b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="660" y="288" />
+        </connection>
+        <connection identifier="id-fcd13ad99b1c444bbec2590178f6f54a" relationshipRef="id-c4ed64b53e3f46d098ef73b1e6e581fc" xsi:type="Relationship" source="id-32bc910a0e6a40188a87909e7c0e7ada" target="id-c39d5b66068c44b88b7c99527fb7ec6a">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="303" y="324" />
+        </connection>
+        <connection identifier="id-c224a92b8a0542c29e9e633916d77b14" relationshipRef="id-46552ee6a0794c8880f5d3da74a0c89a" xsi:type="Relationship" source="id-32bc910a0e6a40188a87909e7c0e7ada" target="id-e96ef67503f54f4294dd6886c2414d69">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-1c75823932a74c80a2902ff6e54ebc10" relationshipRef="id-59364b03590d4e65beb4a8adf80f3dd0" xsi:type="Relationship" source="id-32bc910a0e6a40188a87909e7c0e7ada" target="id-c62ebcb503754b0fbb79e9425b74f1b8">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="639" y="460" />
+        </connection>
+        <connection identifier="id-7520bc1e91d1481d80028727d594c003" relationshipRef="id-def095d2db5a421db8128235714397f9" xsi:type="Relationship" source="id-5fe50ee83d3a49cf92c672c9efccb6b9" target="id-6c75aedc5298421091b9baef88f4cf7b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="528" y="120" />
+        </connection>
+        <connection identifier="id-4e8b8e175e144d22afa646c6164a621a" relationshipRef="id-1a29fe0e1b4c4331877702f33268999d" xsi:type="Relationship" source="id-751b5c367ad2420d9ef48469660e1950" target="id-16822f72c94446b8b805b48968e78470">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-0d24ef7e162c4f12999f3c3428c99ab7" relationshipRef="id-40c9de0556634b378770e2d0e82e6321" xsi:type="Relationship" source="id-16822f72c94446b8b805b48968e78470" target="id-8ddb62f6638d40529a359316989213ed">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-ae85c40c28ab450eaa0d09f207a7e60e" relationshipRef="id-ff096bd70c66467a9932402893dac1b7" xsi:type="Relationship" source="id-c39d5b66068c44b88b7c99527fb7ec6a" target="id-32bc910a0e6a40188a87909e7c0e7ada">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="456" y="240" />
+        </connection>
+        <connection identifier="id-01e2f6147df142c9a993feaf28408ec3" relationshipRef="id-017b10c34d5747078797cb271805ea1a" xsi:type="Relationship" source="id-c39d5b66068c44b88b7c99527fb7ec6a" target="id-8ddb62f6638d40529a359316989213ed">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="108" y="372" />
+        </connection>
+        <connection identifier="id-d6258a53ab18401287dcda2786bea5b4" relationshipRef="id-c3f3310108d0446e828a199e8c1e1287" xsi:type="Relationship" source="id-c39d5b66068c44b88b7c99527fb7ec6a" target="id-16822f72c94446b8b805b48968e78470">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="252" y="360" />
+        </connection>
+        <connection identifier="id-0718bc9d02964625a49fc31bcc880ae2" relationshipRef="id-a54cb72d96ed4ed185541b210e4643d4" xsi:type="Relationship" source="id-8ddb62f6638d40529a359316989213ed" target="id-c39d5b66068c44b88b7c99527fb7ec6a">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="48" y="300" />
+        </connection>
+      </view>
+      <view identifier="id-38cec8ead5b84a958460f04985aef9ac" xsi:type="Diagram">
+        <name xml:lang="es">Figure12_Basline-Application-Landscape</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/5/20</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-b24ea9eef984447ead4420df7e620c7c" xsi:type="Label" x="228" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-1ea89756d4284ac3bca14c81bfd2a459" xsi:type="Label" x="722" y="552" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-f4611daf85994461b2c862b7b3ec8139" elementRef="id-93c74e2f4b8b4b0491164e6d79c445d6" xsi:type="Element" x="499" y="60" w="438" h="349">
+          <style>
+            <fillColor r="237" g="207" b="226" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-fff8a246eaf34566bb73600a19ac6398" elementRef="id-9d0751d373ec482b925d0f28f04f6608" xsi:type="Element" x="535" y="96" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-4ff6fbc23e4644af88afab02d040a167" elementRef="id-021e6ea0d09f433f92532777a5980497" xsi:type="Element" x="692" y="96" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-8d8f3bacd16d4c6d8e55e909190a26d1" elementRef="id-51d42a1da36a42c2811e84ff8952cb58" xsi:type="Element" x="559" y="264" w="109" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-a8db1e74566c4660a73a3b7262609e13" elementRef="id-3dfec7838acb47f588677d6e8f948fd9" xsi:type="Element" x="685" y="263" w="109" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-7ea3ac261a004e71b49d06f37b5aa6f4" elementRef="id-09b37e64a61d4c4183f49930d1237509" xsi:type="Element" x="808" y="264" w="109" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-7f8fe45a7eae4d58bfe30f3b3df35423" elementRef="id-26586078852645d59ea8b14781701c65" xsi:type="Element" x="499" y="432" w="438" h="109">
+          <style>
+            <fillColor r="237" g="207" b="226" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-f13ae942b3da47aa83d3dbd8c0ca12d0" elementRef="id-3eb0685faebf42cfa81567c6a4e7db24" xsi:type="Element" x="516" y="463" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-d3f053411c5549938ee4e20c515f9340" elementRef="id-8b75218115db49b9aecd0501d04d5545" xsi:type="Element" x="36" y="60" w="433" h="481">
+          <style>
+            <fillColor r="237" g="207" b="226" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-efe8cc57856a490c82c919106a480cae" elementRef="id-c728f7f622be468380062354ffbf4f57" xsi:type="Element" x="48" y="264" w="277" h="157">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+            <node identifier="id-2a8b5819ff5549268e2f1faeb3da449c" elementRef="id-df71ee7baba64cfbb35bcd00ed36040c" xsi:type="Element" x="196" y="355" w="120" h="55">
+              <style>
+                <fillColor r="181" g="255" b="255" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-c34737bec2c748f19d1618becf873f54" elementRef="id-a9c72e1cb5344e3ab7a8a7bc8271776d" xsi:type="Element" x="60" y="288" w="120" h="55">
+              <style>
+                <fillColor r="181" g="255" b="255" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-2ccc10b5f99946d7a0fd57069de8edef" elementRef="id-927db0f85d244a08b92e4925eb053d2b" xsi:type="Element" x="60" y="355" w="120" h="55">
+              <style>
+                <fillColor r="181" g="255" b="255" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-524c67ecf7cd42869296ab31af5d1204" elementRef="id-2eec1a4a343142c09574a74d773e2224" xsi:type="Element" x="196" y="288" w="120" h="55">
+              <style>
+                <fillColor r="181" g="255" b="255" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+          </node>
+          <node identifier="id-db3a70af75f644e08f9e8f71c16f0b73" elementRef="id-5538d8de4e6c4918a62221922988c957" xsi:type="Element" x="127" y="444" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-2de45f5f867046dd94653abefcba9dba" elementRef="id-68903f066cfc4959a4e940405e47f6cd" xsi:type="Element" x="336" y="324" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-71f27a0a5a39459fa5b32c0081425915" elementRef="id-970722b900b14871becf437967275425" xsi:type="Element" x="336" y="96" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-a4a7d93c789444039941d59cacecbdf4" elementRef="id-132442dad80345129362408c87cdde9b" xsi:type="Element" x="48" y="96" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-d098a47aa4f544ee87ce5e6ad2b63a5f" elementRef="id-641d335281ca4b53932f250e695f1f94" xsi:type="Element" x="193" y="96" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-b089d0d71d664364ac04167f099f9436" elementRef="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Element" x="48" y="180" w="877" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-e870309de5c34941b29e93e4fe0ba042" relationshipRef="id-ff325924b75446a4b25aa54d26c46f14" xsi:type="Relationship" source="id-fff8a246eaf34566bb73600a19ac6398" target="id-b089d0d71d664364ac04167f099f9436">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="579" y="160" />
+        </connection>
+        <connection identifier="id-0a44b324e3a148a7bc2080ec83cb5958" relationshipRef="id-27978db60c43457381ac9ed8885ccf91" xsi:type="Relationship" source="id-4ff6fbc23e4644af88afab02d040a167" target="id-b089d0d71d664364ac04167f099f9436">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="736" y="160" />
+        </connection>
+        <connection identifier="id-e60d398f3c1341ce87bc06c2fc7774b6" relationshipRef="id-ebebf195ec63472980382dab9e91ddac" xsi:type="Relationship" source="id-8d8f3bacd16d4c6d8e55e909190a26d1" target="id-b089d0d71d664364ac04167f099f9436">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="597" y="244" />
+        </connection>
+        <connection identifier="id-942c0e8d25084bffa89d9061d365172e" relationshipRef="id-8b7fdcbb1fb446b6a168bc53550a2842" xsi:type="Relationship" source="id-a8db1e74566c4660a73a3b7262609e13" target="id-b089d0d71d664364ac04167f099f9436">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="723" y="244" />
+        </connection>
+        <connection identifier="id-3f7b1e1605e146459d2b4337cc2a009d" relationshipRef="id-669d682920734511accefa5b2cb7dd1f" xsi:type="Relationship" source="id-7ea3ac261a004e71b49d06f37b5aa6f4" target="id-b089d0d71d664364ac04167f099f9436">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="876" y="254" />
+        </connection>
+        <connection identifier="id-a3d5f5de5e484566a1d617149b0ce21e" relationshipRef="id-07a1defae2014e9d855c59525c19c7b7" xsi:type="Relationship" source="id-f13ae942b3da47aa83d3dbd8c0ca12d0" target="id-b089d0d71d664364ac04167f099f9436">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="552" y="354" />
+        </connection>
+        <connection identifier="id-a63369fc5d0f4bc083469be9712078d9" relationshipRef="id-2523d00aed2d4d008634b25bde995ecb" xsi:type="Relationship" source="id-efe8cc57856a490c82c919106a480cae" target="id-db3a70af75f644e08f9e8f71c16f0b73">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="205" y="439" />
+        </connection>
+        <connection identifier="id-16cb8e5e30b5467ab42f9c5d95f344ec" relationshipRef="id-9a3a3d96c2344514b644e1fdb8cdb8c7" xsi:type="Relationship" source="id-efe8cc57856a490c82c919106a480cae" target="id-b089d0d71d664364ac04167f099f9436">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="171" y="240" />
+        </connection>
+        <connection identifier="id-7118a92ac78c443e9b76cc8cec4219d5" relationshipRef="id-a5ca972c87a1493c969ab24a5404318f" xsi:type="Relationship" source="id-db3a70af75f644e08f9e8f71c16f0b73" target="id-efe8cc57856a490c82c919106a480cae">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="175" y="425" />
+        </connection>
+        <connection identifier="id-3ed633a2422d4cf6b66707ca5608aeb7" relationshipRef="id-84d40daec2984878ba7febd33358735a" xsi:type="Relationship" source="id-2de45f5f867046dd94653abefcba9dba" target="id-b089d0d71d664364ac04167f099f9436">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="380" y="269" />
+        </connection>
+        <connection identifier="id-21bbc2cdefa24f2788eb1d6d872ced61" relationshipRef="id-9b2dc0367c094304acfaabf7f2f0b125" xsi:type="Relationship" source="id-71f27a0a5a39459fa5b32c0081425915" target="id-b089d0d71d664364ac04167f099f9436">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="410" y="170" />
+        </connection>
+        <connection identifier="id-b85fc39b50f34945bc59161aeb914a6c" relationshipRef="id-855abfcab77b4399b9124ede0c28f1c1" xsi:type="Relationship" source="id-a4a7d93c789444039941d59cacecbdf4" target="id-b089d0d71d664364ac04167f099f9436">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="122" y="170" />
+        </connection>
+        <connection identifier="id-da4337324dc3437d9b5d4c91e9464675" relationshipRef="id-33409723619341ddac60e2901c77a9a2" xsi:type="Relationship" source="id-d098a47aa4f544ee87ce5e6ad2b63a5f" target="id-b089d0d71d664364ac04167f099f9436">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="237" y="160" />
+        </connection>
+        <connection identifier="id-d9345c5dbae64303a12dea4f3aaf12bc" relationshipRef="id-15eaf22bbd514661a6986b679bf7bb5a" xsi:type="Relationship" source="id-b089d0d71d664364ac04167f099f9436" target="id-a4a7d93c789444039941d59cacecbdf4">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="92" y="160" />
+        </connection>
+        <connection identifier="id-60cea402987f414c98ea6fab59eec4f8" relationshipRef="id-3cc58aba3d844d8783f78300e809ac35" xsi:type="Relationship" source="id-b089d0d71d664364ac04167f099f9436" target="id-d098a47aa4f544ee87ce5e6ad2b63a5f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="267" y="170" />
+        </connection>
+        <connection identifier="id-6e3ccf96c891443c9db79f1e3a92df89" relationshipRef="id-e3aee34bae8247a99db2b29f555a9705" xsi:type="Relationship" source="id-b089d0d71d664364ac04167f099f9436" target="id-71f27a0a5a39459fa5b32c0081425915">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="380" y="160" />
+        </connection>
+        <connection identifier="id-4f1b8566ee9a4244873bf537e1f2f42c" relationshipRef="id-35164ebce06748cebc3847aa49ac6dae" xsi:type="Relationship" source="id-b089d0d71d664364ac04167f099f9436" target="id-fff8a246eaf34566bb73600a19ac6398">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="609" y="170" />
+        </connection>
+        <connection identifier="id-c6b3322e5fc04f758f5cee2196ee5d51" relationshipRef="id-afac10b2330b4bc8be3444b79771b569" xsi:type="Relationship" source="id-b089d0d71d664364ac04167f099f9436" target="id-4ff6fbc23e4644af88afab02d040a167">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="766" y="170" />
+        </connection>
+        <connection identifier="id-6bee93eb68d54ef497355d8760ed2b3f" relationshipRef="id-7482a60e92cc4f4a8de0d8aca202cd2a" xsi:type="Relationship" source="id-b089d0d71d664364ac04167f099f9436" target="id-7ea3ac261a004e71b49d06f37b5aa6f4">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="846" y="244" />
+        </connection>
+        <connection identifier="id-c2edc4cbedb842aeaaa5c03bee9ce660" relationshipRef="id-9701ef25128c4149b850331677749aa1" xsi:type="Relationship" source="id-b089d0d71d664364ac04167f099f9436" target="id-a8db1e74566c4660a73a3b7262609e13">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="753" y="253" />
+        </connection>
+        <connection identifier="id-fe6d7bb3fd31472e9f815804ac867013" relationshipRef="id-eb71dae724ab4a6a9fad0e61d194eb26" xsi:type="Relationship" source="id-b089d0d71d664364ac04167f099f9436" target="id-8d8f3bacd16d4c6d8e55e909190a26d1">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="627" y="254" />
+        </connection>
+        <connection identifier="id-6c0485c9b77645d789cf00394bf39083" relationshipRef="id-44f95fe75c464b19a14a81609cd421db" xsi:type="Relationship" source="id-b089d0d71d664364ac04167f099f9436" target="id-f13ae942b3da47aa83d3dbd8c0ca12d0">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="528" y="354" />
+        </connection>
+        <connection identifier="id-1e29a9667bb14472b1b61a843385c25b" relationshipRef="id-9a48df866be44d569b3ad2db9fb24086" xsi:type="Relationship" source="id-b089d0d71d664364ac04167f099f9436" target="id-2de45f5f867046dd94653abefcba9dba">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="410" y="289" />
+        </connection>
+        <connection identifier="id-7b7b314621854e4e98258e56e1af842f" relationshipRef="id-1cb615feba4d41df9c417602872a99ed" xsi:type="Relationship" source="id-b089d0d71d664364ac04167f099f9436" target="id-efe8cc57856a490c82c919106a480cae">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="200" y="258" />
+        </connection>
+      </view>
+      <view identifier="id-b668c0c608804f83b47dbb32fd095ef9" xsi:type="Diagram">
+        <name xml:lang="es">Figure13_Corp-Data-Center-Infrastructure</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/5/23</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-9891d9814f22460086c98ffd76b11444" xsi:type="Label" x="276" y="24" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-d98f59a6e7db47f78fafff09a025e571" xsi:type="Label" x="708" y="468" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-185809e029174d53af403dcc7e71c7a1" elementRef="id-40f1e7bdf4c74241b1ac5763b3aa9d50" xsi:type="Element" x="122" y="84" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-e8261af2b8bf4f89931fcf5253b7cc2a" elementRef="id-79c6674039c14444a51dc8f5c7491b23" xsi:type="Element" x="264" y="84" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-98ccbfa350b14b50b7029316782212c0" elementRef="id-6ace217c8c624d229ee2cc11528d52e4" xsi:type="Element" x="408" y="84" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-61291860ace842e6a7742f4d45d43cb1" elementRef="id-772a5d3d408142a28ab040048e09e7ff" xsi:type="Element" x="632" y="84" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-3a5f28e21bd748228653599495dd63b2" elementRef="id-094df2608dbf49078615591a945c3681" xsi:type="Element" x="632" y="204" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-45db1f18d53941cfb35f26d4468b8033" elementRef="id-b0541156f9194546bd0922c13349649a" xsi:type="Element" x="804" y="183" w="172" h="202">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-479302a7ca3d4514817f3d3239a937d2" elementRef="id-4196a1f9d7464198aad03a7a67bfc82e" xsi:type="Element" x="828" y="303" w="120" h="55">
+            <style>
+              <fillColor r="201" g="231" b="183" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-3ebd7402426f4a6191b487db149cff46" elementRef="id-7eb87af87eb349d9b8a5a8b5cbad8856" xsi:type="Element" x="828" y="233" w="120" h="55">
+            <style>
+              <fillColor r="201" g="231" b="183" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-50e3b9b258e84a78a923a6b259391b4e" elementRef="id-9d76a90f5163422494119c99f6a908f3" xsi:type="Element" x="83" y="204" w="481" h="289">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-5697e51de9fa4ae1818bdc3cf166c956" elementRef="id-a1337fb63ca144ad9473d94406ab187e" xsi:type="Element" x="143" y="228" w="169" h="253">
+            <style>
+              <fillColor r="201" g="231" b="183" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+            <node identifier="id-e25d6e64b4674ed4a62ba15aa2bb91cb" elementRef="id-7eb87af87eb349d9b8a5a8b5cbad8856" xsi:type="Element" x="164" y="264" w="120" h="55">
+              <style>
+                <fillColor r="201" g="231" b="183" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-3491c908aded467e966efe1bf069abb2" elementRef="id-2f548011437a41048be837f74c3f4d00" xsi:type="Element" x="164" y="337" w="120" h="55">
+              <style>
+                <fillColor r="201" g="231" b="183" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-f5a1c380f8234882be672075223c6158" elementRef="id-0b84596d01f04499b880d15e58879759" xsi:type="Element" x="164" y="404" w="120" h="55">
+              <style>
+                <fillColor r="201" g="231" b="183" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+          </node>
+          <node identifier="id-41b312eaec464d58bd7e2b9b9e0d97b7" elementRef="id-f0b5bad31d9246ba8689143d271f6c38" xsi:type="Element" x="335" y="228" w="169" h="253">
+            <style>
+              <fillColor r="201" g="231" b="183" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+            <node identifier="id-2c9030c276994425b32f0e5fa9aa4c0a" elementRef="id-7eb87af87eb349d9b8a5a8b5cbad8856" xsi:type="Element" x="356" y="264" w="120" h="55">
+              <style>
+                <fillColor r="201" g="231" b="183" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-9d66f20ba9104b2da89e3b94eec1e99f" elementRef="id-2f548011437a41048be837f74c3f4d00" xsi:type="Element" x="356" y="336" w="120" h="55">
+              <style>
+                <fillColor r="201" g="231" b="183" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-81051d1acb0e4037bb893556b35d0286" elementRef="id-69f1b9c8a59146a8938218dc363b3895" xsi:type="Element" x="356" y="404" w="120" h="55">
+              <style>
+                <fillColor r="201" g="231" b="183" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+          </node>
+        </node>
+        <node identifier="id-434ceb679c4d4cb89ae1f6b4a3f1efe2" elementRef="id-7bd8507070fc42b2802ffc882e48484e" xsi:type="Element" x="632" y="303" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-b1926c23d40244e98d9959f4920efca9" relationshipRef="id-e6e261c583274041b176b41f25ceb8ce" xsi:type="Relationship" source="id-3a5f28e21bd748228653599495dd63b2" target="id-61291860ace842e6a7742f4d45d43cb1">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-02931a44eb644df69613f2e29b0f19d0" relationshipRef="id-fc55fad85ad34c889c90180ca5d0dda8" xsi:type="Relationship" source="id-45db1f18d53941cfb35f26d4468b8033" target="id-3a5f28e21bd748228653599495dd63b2">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-c41b39afd0e64ed0b734a21bc152126a" relationshipRef="id-412391d8896349879b8c4b54ce5757dd" xsi:type="Relationship" source="id-50e3b9b258e84a78a923a6b259391b4e" target="id-98ccbfa350b14b50b7029316782212c0">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-b7a7c5a1e78b47ad98ea6c75379b80a2" relationshipRef="id-e092d643c58a4c84a0ed9793533a7547" xsi:type="Relationship" source="id-50e3b9b258e84a78a923a6b259391b4e" target="id-e8261af2b8bf4f89931fcf5253b7cc2a">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-662de4d92b6c400d850076ee9541c1d1" relationshipRef="id-166fcba5acf5471a8828202da41fa48c" xsi:type="Relationship" source="id-50e3b9b258e84a78a923a6b259391b4e" target="id-185809e029174d53af403dcc7e71c7a1">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-c4b2a9308ca14805831f9ef21d9a520b" relationshipRef="id-9ed2457c1a9841aa8b16d241a189896e" xsi:type="Relationship" source="id-434ceb679c4d4cb89ae1f6b4a3f1efe2" target="id-45db1f18d53941cfb35f26d4468b8033">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-4b80bba1672d4036bf39a6a9a22abd8a" relationshipRef="id-0f71872a317d4921acd3753b037fa819" xsi:type="Relationship" source="id-434ceb679c4d4cb89ae1f6b4a3f1efe2" target="id-50e3b9b258e84a78a923a6b259391b4e">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-0763811d83bd4fffa0c7b0223abb413a" xsi:type="Diagram">
+        <name xml:lang="es">Figure14_Changes-to-ArchiMetal-Org</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/5/23</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-e54fc8ce76124630a4e48cbff3138855" xsi:type="Label" x="204" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-d82a6b1b12a24bfd9918036a2b0ff6d3" xsi:type="Label" x="542" y="504" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-f9b7ca1dbe78499d98f7a80863b62d9c" elementRef="id-70e443457ba447cf9f7be64c0a2e0ad1" xsi:type="Element" x="108" y="60" w="649" h="433">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-15d8c522f42145d58d7aa9b4407989ed" elementRef="id-3bc7d428ccea48739c4d442f9f2364e7" xsi:type="Element" x="137" y="348" w="409" h="111">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+            <node identifier="id-5bd176d9de6e4801bb3d0a52fccfc8a8" elementRef="id-65c1620fd1284553b20818224030a84d" xsi:type="Element" x="149" y="384" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-588e2727974143fd9538cbb7b3622bbe" elementRef="id-5987ea5989b34bb3b7b3b7df0c5d7596" xsi:type="Element" x="413" y="384" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-3cf7cefcccf746c187ecefc01e41dd61" elementRef="id-b50ea84ae74845f3b8001028c0558e90" xsi:type="Element" x="281" y="384" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+          </node>
+          <node identifier="id-36dc29cf4f6048a4ac8f8d8739cf2bea" elementRef="id-ca35f8df80974169b04c1ffd58c12493" xsi:type="Element" x="137" y="216" w="589" h="109">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+            <node identifier="id-8608764572e243c8b9e58242c3ed4775" elementRef="id-6118370573ec480e85a1d4b2eed6eacd" xsi:type="Element" x="588" y="252" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-839b3699107c4e86a7c19fde0ce1be6f" elementRef="id-761d6b44b0084191bb0574b9b2c4e949" xsi:type="Element" x="161" y="252" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-0149e4d84fcc41c989ded6a0c51c6c89" elementRef="id-eee6f468492e48efb54f44db721f75aa" xsi:type="Element" x="444" y="252" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-bcb8019383994c218ca08c436cd381c7" elementRef="id-dae853c3fdda4da9a99c066d144cc617" xsi:type="Element" x="300" y="252" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+          </node>
+          <node identifier="id-197ed16ec9c5468e831dbf9d21b0d8ad" elementRef="id-ca27484ed8934cd2bb57cec774298909" xsi:type="Element" x="606" y="420" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-bbbe8550fb7c4b2c91f6e1ffd39d061b" elementRef="id-f96b2f70a48e42bb83646b89292b1286" xsi:type="Element" x="606" y="348" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-0ec9aa95197f4ac0b78a3bed1b51e459" elementRef="id-86d6a2f695b74347a264354315c8656f" xsi:type="Element" x="137" y="84" w="589" h="109">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+            <node identifier="id-63f33a292e9740e2aefbfc291a6ce473" elementRef="id-b6d4eb2c1e184d33897f7862f6317033" xsi:type="Element" x="437" y="120" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-d10c81517ab34f3ca9d712f058c4fca2" elementRef="id-628c9b29c1254f3c8d0aea92d13e5d65" xsi:type="Element" x="293" y="120" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-71b0fac639d64aa6840026c592399119" elementRef="id-2bcc0251b630425ea4c325246a35f5b8" xsi:type="Element" x="149" y="120" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+            <node identifier="id-4b696f3739124058a96e9974416335b7" elementRef="id-23b94c08d0494535bd9804b94923f83e" xsi:type="Element" x="581" y="120" w="120" h="55">
+              <style>
+                <fillColor r="255" g="255" b="181" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Segoe UI" size="12" style="bold italic">
+                  <color r="255" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+          </node>
+        </node>
+      </view>
+      <view identifier="id-0abd45ec74f947e6beae0e2d06d21f6c" xsi:type="Diagram">
+        <name xml:lang="es">Figure15_Relevant_Information-Flows-between-the-Units</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/5/25</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-ce8b86d894b243c58919c43cadf77680" xsi:type="Label" x="204" y="0" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-efb88854e9a34e59ba1171c0dc620eb5" xsi:type="Label" x="669" y="648" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-69e76d0dc9ea46a0a2e3701af6dfd3da" elementRef="id-1a7757e999c54d6085462db7df22a296" xsi:type="Element" x="828" y="186" w="120" h="427">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-4e17675e13774f898b1559a668bf4dd7" elementRef="id-3bc7d428ccea48739c4d442f9f2364e7" xsi:type="Element" x="396" y="186" w="337" h="427">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-aa8181d7c81b4fe098b70dc5d1b3e926" elementRef="id-6bb84a70a70c4899963d5370b82d42af" xsi:type="Element" x="420" y="462" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-f6a2a1a8a982497fa64b808da7f334f1" elementRef="id-eb2a8dd22fad4020b70d683b9adf85bc" xsi:type="Element" x="492" y="222" w="204" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-a076ba6458cd48309c5d3ca2bdd724ef" elementRef="id-94aed85cd04d4960b53f9db553d91e1c" xsi:type="Element" x="564" y="534" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-f211cf4488c74a208036df77d6d5f74f" elementRef="id-d4ae5cd23a3f4c04b5778446859595ab" xsi:type="Element" x="432" y="330" w="264" h="85">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-e79fdae483694f70b7906b17e06581b4" elementRef="id-86d6a2f695b74347a264354315c8656f" xsi:type="Element" x="24" y="48" w="709" h="85">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-1b10f658d39b4c3788759d6b56764bcd" elementRef="id-15b84bcdf6374633b8225b636f14f140" xsi:type="Element" x="505" y="72" w="193" h="49">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-db484141c9d045709e3c8603bc6bc1bb" elementRef="id-1ba327b721494627b45b68e6ab88ce73" xsi:type="Element" x="48" y="73" w="207" h="48">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Segoe UI" size="9" style="bold">
+                <color r="255" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-9fd52df6b3ab4112aec9f73473ae836b" elementRef="id-ca35f8df80974169b04c1ffd58c12493" xsi:type="Element" x="12" y="186" w="349" h="427">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-908808fba0fa42d39b20a8adf7a01034" elementRef="id-5fb09df777514d79afbec30bf3a49c72" xsi:type="Element" x="217" y="529" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-9db67f15196c4784acb197c2f9c541b8" elementRef="id-bb08ebde1b25412bb52d9e4d35afa404" xsi:type="Element" x="217" y="438" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-59de6a7a8b1b412abcce561dc6badaab" elementRef="id-ec198d6b44094aea97ee9bb93659c30d" xsi:type="Element" x="36" y="222" w="301" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-3570e142384f48c09c89c84154b33228" elementRef="id-a6992b23c09c44dba47e8e06ad7655c5" xsi:type="Element" x="24" y="438" w="97" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <connection identifier="id-5dbeed4b20664fd08332bb0f94da50b8" relationshipRef="id-f595dcb5bcf94d3e82371435f0a7edaf" xsi:type="Relationship" source="id-69e76d0dc9ea46a0a2e3701af6dfd3da" target="id-f6a2a1a8a982497fa64b808da7f334f1">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="768" y="257" />
+        </connection>
+        <connection identifier="id-fbc7f6eb4a2d4e9f86568177bf647a38" relationshipRef="id-4bb031dc79024a6eb809db3c2a9de992" xsi:type="Relationship" source="id-69e76d0dc9ea46a0a2e3701af6dfd3da" target="id-f211cf4488c74a208036df77d6d5f74f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="753" y="397" />
+        </connection>
+        <connection identifier="id-29fb801a8a67427db40b48465a5b3783" relationshipRef="id-8c023a9ee9704765876cd47005b454e9" xsi:type="Relationship" source="id-69e76d0dc9ea46a0a2e3701af6dfd3da" target="id-a076ba6458cd48309c5d3ca2bdd724ef">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="756" y="569" />
+        </connection>
+        <connection identifier="id-0847d87864a047289dbab3c4b15d7126" relationshipRef="id-b35f3d1831e64f798ebe5fba8cbe9f34" xsi:type="Relationship" source="id-f6a2a1a8a982497fa64b808da7f334f1" target="id-69e76d0dc9ea46a0a2e3701af6dfd3da">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="768" y="240" />
+        </connection>
+        <connection identifier="id-69ed24a258614767901d00ed74ab3037" relationshipRef="id-35b554c3967343c8ad3256f6f128db1e" xsi:type="Relationship" source="id-f6a2a1a8a982497fa64b808da7f334f1" target="id-f211cf4488c74a208036df77d6d5f74f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="564" y="294" />
+        </connection>
+        <connection identifier="id-07d767f5b5f24c42b28bd4cf63f66a9b" relationshipRef="id-fc28e7aaa8814b3ca8a199e3e59f7cc1" xsi:type="Relationship" source="id-f6a2a1a8a982497fa64b808da7f334f1" target="id-1b10f658d39b4c3788759d6b56764bcd">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Segoe UI" size="9" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="660" y="165" />
+        </connection>
+        <connection identifier="id-1b3c25d9b584428ebfbb6cf4b3d1c5f9" relationshipRef="id-87dc078893904a5f8e1628e083aae26e" xsi:type="Relationship" source="id-f6a2a1a8a982497fa64b808da7f334f1" target="id-db484141c9d045709e3c8603bc6bc1bb">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Segoe UI" size="9" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="456" y="240" />
+          <bendpoint x="456" y="168" />
+          <bendpoint x="204" y="168" />
+          <bendpoint x="204" y="168" />
+        </connection>
+        <connection identifier="id-ddd33e7b29fe4c2c9c78da1ef55e5d12" relationshipRef="id-aeb98da82ca84aa1850ad53e48b04c63" xsi:type="Relationship" source="id-a076ba6458cd48309c5d3ca2bdd724ef" target="id-f211cf4488c74a208036df77d6d5f74f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="588" y="444" />
+        </connection>
+        <connection identifier="id-09b89f0e491344c1a95b239cb0e3ce83" relationshipRef="id-5285a85c637b4248b5f26de5cbaa0690" xsi:type="Relationship" source="id-a076ba6458cd48309c5d3ca2bdd724ef" target="id-69e76d0dc9ea46a0a2e3701af6dfd3da">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="756" y="551" />
+        </connection>
+        <connection identifier="id-ede5fa8d347847f28fdebe63c41bacc5" relationshipRef="id-5e030eac9d3d4341a4a07a7dd9947f83" xsi:type="Relationship" source="id-f211cf4488c74a208036df77d6d5f74f" target="id-69e76d0dc9ea46a0a2e3701af6dfd3da">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="753" y="347" />
+        </connection>
+        <connection identifier="id-9911f9ec26db43b59119c542a8f96507" relationshipRef="id-66c6765e590b4e7ebc371e58cf171fdc" xsi:type="Relationship" source="id-f211cf4488c74a208036df77d6d5f74f" target="id-69e76d0dc9ea46a0a2e3701af6dfd3da">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="753" y="364" />
+        </connection>
+        <connection identifier="id-f1f7ab205db743d9b43a58d6a496364a" relationshipRef="id-eca59d66cde04c79b993f01a19723007" xsi:type="Relationship" source="id-f211cf4488c74a208036df77d6d5f74f" target="id-69e76d0dc9ea46a0a2e3701af6dfd3da">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="753" y="380" />
+        </connection>
+        <connection identifier="id-02eaacd47c014d8692d395f590bf1451" relationshipRef="id-e81da98bf225425d88569aeb05ee2f25" xsi:type="Relationship" source="id-f211cf4488c74a208036df77d6d5f74f" target="id-f6a2a1a8a982497fa64b808da7f334f1">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="660" y="312" />
+        </connection>
+        <connection identifier="id-2fdac314a8a44b68ae19e430dcb4b50b" relationshipRef="id-46552ee6a0794c8880f5d3da74a0c89a" xsi:type="Relationship" source="id-f211cf4488c74a208036df77d6d5f74f" target="id-aa8181d7c81b4fe098b70dc5d1b3e926">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-082d9fb5f26e48f3a073371dcd41323c" relationshipRef="id-59364b03590d4e65beb4a8adf80f3dd0" xsi:type="Relationship" source="id-f211cf4488c74a208036df77d6d5f74f" target="id-a076ba6458cd48309c5d3ca2bdd724ef">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="639" y="484" />
+        </connection>
+        <connection identifier="id-6589380347fd442bbefea5e975d29e76" relationshipRef="id-7d7f3fce2734465890ba509b7eec364c" xsi:type="Relationship" source="id-f211cf4488c74a208036df77d6d5f74f" target="id-59de6a7a8b1b412abcce561dc6badaab">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Segoe UI" size="9" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="324" y="348" />
+        </connection>
+        <connection identifier="id-4e3b83e42abe456eb5d63fe74450aa58" relationshipRef="id-def095d2db5a421db8128235714397f9" xsi:type="Relationship" source="id-1b10f658d39b4c3788759d6b56764bcd" target="id-f6a2a1a8a982497fa64b808da7f334f1">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Segoe UI" size="9" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="528" y="141" />
+        </connection>
+        <connection identifier="id-5fb5f29ed21d4d63b78a51725b35c811" relationshipRef="id-d0b777594fbb4028be16bd38bac622d3" xsi:type="Relationship" source="id-db484141c9d045709e3c8603bc6bc1bb" target="id-f6a2a1a8a982497fa64b808da7f334f1">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Segoe UI" size="9" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="336" y="96" />
+          <bendpoint x="336" y="156" />
+          <bendpoint x="504" y="156" />
+        </connection>
+        <connection identifier="id-7f9c8b0a875a41689d50c79013002e90" relationshipRef="id-1a29fe0e1b4c4331877702f33268999d" xsi:type="Relationship" source="id-908808fba0fa42d39b20a8adf7a01034" target="id-9db67f15196c4784acb197c2f9c541b8">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-18f6cedc8c8c449f9d056fe7b545f1a7" relationshipRef="id-40c9de0556634b378770e2d0e82e6321" xsi:type="Relationship" source="id-9db67f15196c4784acb197c2f9c541b8" target="id-3570e142384f48c09c89c84154b33228">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-5f49e39491c34f4d90aed8fbe412dd41" relationshipRef="id-017b10c34d5747078797cb271805ea1a" xsi:type="Relationship" source="id-59de6a7a8b1b412abcce561dc6badaab" target="id-3570e142384f48c09c89c84154b33228">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="108" y="396" />
+        </connection>
+        <connection identifier="id-2f891106a1ea4a23b440901f61f65f94" relationshipRef="id-c3f3310108d0446e828a199e8c1e1287" xsi:type="Relationship" source="id-59de6a7a8b1b412abcce561dc6badaab" target="id-9db67f15196c4784acb197c2f9c541b8">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="252" y="384" />
+        </connection>
+        <connection identifier="id-3b966a8da30b476cb958b15ceb1dfd82" relationshipRef="id-a54cb72d96ed4ed185541b210e4643d4" xsi:type="Relationship" source="id-3570e142384f48c09c89c84154b33228" target="id-59de6a7a8b1b412abcce561dc6badaab">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="48" y="324" />
+        </connection>
+      </view>
+      <view identifier="id-f6e593ba71254893b67ed9c5860d4697" xsi:type="Diagram">
+        <name xml:lang="es">Figure16_Overall-Changes-in-EA</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/5/27</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-bf53e237b5184df395c94a373d9d2688" xsi:type="Label" x="204" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-7c2bf2414bdc49f4bd57ac2b87ea0208" xsi:type="Label" x="626" y="36" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-1b762eaec8984241af75972f4ad13f46" x="48" y="72" w="796" h="136" xsi:type="Container">
+          <label xml:lang="es">Actors</label>
+          <style>
+            <fillColor r="210" g="215" b="215" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-de75d6072d5e43cbb6df31e0a88ca410" elementRef="id-1a7757e999c54d6085462db7df22a296" xsi:type="Element" x="84" y="120" w="697" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-6daaaec2cb004ff2b3189db5bfccf138" x="45" y="216" w="796" h="121" xsi:type="Container">
+          <label xml:lang="es">External Business Services</label>
+          <style>
+            <fillColor r="210" g="215" b="215" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-ddbeeeaa8c6c4300919d6ee0b3dc55f1" elementRef="id-d02d8886a7934dc898143a97a8376606" xsi:type="Element" x="513" y="254" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-4c1a436784d040cc8c531c6d9dc09157" elementRef="id-73d6be570bd344aeb933d06b9566af35" xsi:type="Element" x="81" y="254" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-ebb065f737964a659a1ef714c52ed1dc" elementRef="id-cbc5896e78284e23b5bbca5e9a15dc76" xsi:type="Element" x="369" y="254" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-ebdaf42aaf8b43f0a11de1aa09507d57" elementRef="id-633f46a9f9f84bbda07115037faf71eb" xsi:type="Element" x="657" y="254" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Segoe UI" size="9" style="bold">
+                <color r="255" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-92b8d61ad1e441b9a0205422a2a08402" elementRef="id-c160bb04a89643a880d79a2dce37bd38" xsi:type="Element" x="225" y="254" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-68a70bb5da694b37869b5f6d3d122c5b" x="45" y="348" w="796" h="136" xsi:type="Container">
+          <label xml:lang="es">Internal Bsuiness Services</label>
+          <style>
+            <fillColor r="210" g="215" b="215" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-0db50c82671449fda0b0f5522e5965c0" elementRef="id-8108cbbc4ed64abbbe5b87014468f35b" xsi:type="Element" x="165" y="396" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Segoe UI" size="9" style="bold">
+                <color r="255" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-d4857d020edd441d90bad84a96f2597d" elementRef="id-5f7aebddd3ad4a0593301978fca34bab" xsi:type="Element" x="345" y="396" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-3b451f182587453594ca2a0674b7054b" x="45" y="492" w="796" h="181" xsi:type="Container">
+          <label xml:lang="es">Business Processes</label>
+          <style>
+            <fillColor r="210" g="215" b="215" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-89d1da4cf7d747ac9dd84714eed3c1ed" elementRef="id-56a4ef970d314200bc4e95d8ea928093" xsi:type="Element" x="69" y="526" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-99e5982fdafc472ca78d7cd9189bdeba" elementRef="id-eb6681ab4dd94ce3996ade5875bdf3ef" xsi:type="Element" x="297" y="526" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-e0500e51e5c5462eb972462787ad2ec0" elementRef="id-322294a1d3b441b2a55c57b8dca6e7ff" xsi:type="Element" x="465" y="588" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Segoe UI" size="9" style="bold">
+                <color r="255" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-a8ad398177194329adc74784cf725eb2" elementRef="id-590b2196df43475cb4e2cd018686ea66" xsi:type="Element" x="657" y="526" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Segoe UI" size="9" style="bold">
+                <color r="255" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-34f5c67b9a374316acecfbdc96e1e462" x="45" y="684" w="796" h="220" xsi:type="Container">
+          <label xml:lang="es">Applications</label>
+          <style>
+            <fillColor r="210" g="215" b="215" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-8435239845d5424ba90256389cd182a9" elementRef="id-4e06ee45db904a88aa46e9dce611528e" xsi:type="Element" x="205" y="732" w="212" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Segoe UI" size="9" style="bold">
+                <color r="255" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-d05279ae46a643259a6ce75ec5f920ba" elementRef="id-c728f7f622be468380062354ffbf4f57" xsi:type="Element" x="477" y="732" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-e1419f1fd1b34714a441a5041b828df2" elementRef="id-e26375257d8440228f37158ecf5b8524" xsi:type="Element" x="669" y="732" w="147" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Segoe UI" size="9" style="bold">
+                <color r="255" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-8a956be6262a44eabe889abe07a56c36" elementRef="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Element" x="205" y="827" w="539" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Segoe UI" size="9" style="bold">
+                <color r="255" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <connection identifier="id-05b31ccfaa6a4e708f55ea31a1de4b2b" relationshipRef="id-8b5f76ead5464ebdace7dd4ffaacae91" xsi:type="Relationship" source="id-ddbeeeaa8c6c4300919d6ee0b3dc55f1" target="id-de75d6072d5e43cbb6df31e0a88ca410">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-777d41cc383d4bb5ae7658335004d40a" relationshipRef="id-eafcc2e35d494c069d65233cc5431572" xsi:type="Relationship" source="id-4c1a436784d040cc8c531c6d9dc09157" target="id-de75d6072d5e43cbb6df31e0a88ca410">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-63ee18f0f05a4d15b9316c43732df629" relationshipRef="id-854eab2f9d8446708ff00fc216fd026e" xsi:type="Relationship" source="id-ebb065f737964a659a1ef714c52ed1dc" target="id-de75d6072d5e43cbb6df31e0a88ca410">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-80c62994b6394bda8100c453bb9dd5e2" relationshipRef="id-8e1e118effae4e4abbb7307191a4b76f" xsi:type="Relationship" source="id-ebdaf42aaf8b43f0a11de1aa09507d57" target="id-de75d6072d5e43cbb6df31e0a88ca410">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-f23e17113d5147349453a61fd68ed264" relationshipRef="id-26a00b70891e43dd8e23d2386956d1c5" xsi:type="Relationship" source="id-92b8d61ad1e441b9a0205422a2a08402" target="id-de75d6072d5e43cbb6df31e0a88ca410">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-9e20a0eef0d14f948aacdac391b79ab8" relationshipRef="id-776b3dbb68a64026ae7e78f71246fda9" xsi:type="Relationship" source="id-0db50c82671449fda0b0f5522e5965c0" target="id-4c1a436784d040cc8c531c6d9dc09157">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-27e17cc6a3af4752a340463f1fefead3" relationshipRef="id-906ff6c00cce4a389d7c02c541a49522" xsi:type="Relationship" source="id-d4857d020edd441d90bad84a96f2597d" target="id-89d1da4cf7d747ac9dd84714eed3c1ed">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-1f23ab9c0e9b46d4aa1ab45572d9c515" relationshipRef="id-696a146fe7a44bdd88efd1608dd5df47" xsi:type="Relationship" source="id-d4857d020edd441d90bad84a96f2597d" target="id-99e5982fdafc472ca78d7cd9189bdeba">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-fed4f409506b4b35b77b5abc92227c5d" relationshipRef="id-00a2122c13fa4a5380523eaa404c8894" xsi:type="Relationship" source="id-d4857d020edd441d90bad84a96f2597d" target="id-4c1a436784d040cc8c531c6d9dc09157">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-e3cf074c361b4047a91bc6ac746320bf" relationshipRef="id-6e814dc25573414a8051b8d98d9ea3cb" xsi:type="Relationship" source="id-89d1da4cf7d747ac9dd84714eed3c1ed" target="id-4c1a436784d040cc8c531c6d9dc09157">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-f04f8c0941494807a889f2d4eda5429e" relationshipRef="id-b2f6b889474f475d9e537bc7767dc572" xsi:type="Relationship" source="id-99e5982fdafc472ca78d7cd9189bdeba" target="id-92b8d61ad1e441b9a0205422a2a08402">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-3c95b2a043844103805b07745885314b" relationshipRef="id-3c157187e57042c983f84b01a9348cde" xsi:type="Relationship" source="id-99e5982fdafc472ca78d7cd9189bdeba" target="id-a8ad398177194329adc74784cf725eb2">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-78579a9d65ac48599f8156275287cab3" relationshipRef="id-4abc7f162f9042f99a1ec563b8696d4f" xsi:type="Relationship" source="id-99e5982fdafc472ca78d7cd9189bdeba" target="id-e0500e51e5c5462eb972462787ad2ec0">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-7c2560ec5bc04b7ca1400e3e93b0aba1" relationshipRef="id-3ca88c32f00441349bd9aca0dd67f7c2" xsi:type="Relationship" source="id-e0500e51e5c5462eb972462787ad2ec0" target="id-a8ad398177194329adc74784cf725eb2">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a14e4253361f42beb3b72dc965ed46c6" relationshipRef="id-b0dbd0952d7e4c7a9db21298a3cd27af" xsi:type="Relationship" source="id-a8ad398177194329adc74784cf725eb2" target="id-ebdaf42aaf8b43f0a11de1aa09507d57">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-bc37256ababc4f30af4fae5e21c66a85" relationshipRef="id-61ebdc87de474e20a879a30a1c99fc82" xsi:type="Relationship" source="id-8435239845d5424ba90256389cd182a9" target="id-8a956be6262a44eabe889abe07a56c36">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="273" y="800" />
+        </connection>
+        <connection identifier="id-7894dded49fa48cb875b02705ba30389" relationshipRef="id-58e0c880b3db4f58bec1bdde212dc88a" xsi:type="Relationship" source="id-8435239845d5424ba90256389cd182a9" target="id-89d1da4cf7d747ac9dd84714eed3c1ed">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-5c1d7279717842978a536bbc3ee6b38e" relationshipRef="id-baad7774d92d405e8f261b045ebd1e10" xsi:type="Relationship" source="id-8435239845d5424ba90256389cd182a9" target="id-0db50c82671449fda0b0f5522e5965c0">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-10816fc6c044446da959bdad9561068b" relationshipRef="id-c4661a6ddd404053a3a448dfa9a1add1" xsi:type="Relationship" source="id-8435239845d5424ba90256389cd182a9" target="id-99e5982fdafc472ca78d7cd9189bdeba">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-2df21faebad2483b8a466f334c1a1963" relationshipRef="id-0c490d09ad5e470d8e1f2fd8e1357ffe" xsi:type="Relationship" source="id-8435239845d5424ba90256389cd182a9" target="id-d4857d020edd441d90bad84a96f2597d">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="432" y="624" />
+        </connection>
+        <connection identifier="id-8d2ade2daf334341afb7582e9516c140" relationshipRef="id-40a93d8fc0674a83a55543c7d366f9de" xsi:type="Relationship" source="id-8435239845d5424ba90256389cd182a9" target="id-e0500e51e5c5462eb972462787ad2ec0">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-b83c35dc529f4449b9b14f68b942c595" relationshipRef="id-cfa2c2b556254127b249c4ab0c58e425" xsi:type="Relationship" source="id-d05279ae46a643259a6ce75ec5f920ba" target="id-8435239845d5424ba90256389cd182a9">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-154b32d365454266830cdddd966e4e51" relationshipRef="id-9a3a3d96c2344514b644e1fdb8cdb8c7" xsi:type="Relationship" source="id-d05279ae46a643259a6ce75ec5f920ba" target="id-8a956be6262a44eabe889abe07a56c36">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="521" y="800" />
+        </connection>
+        <connection identifier="id-cbf9087bbc584cc2875e0efdbf2857ac" relationshipRef="id-3e2d1f927d6f4f7ba931c5cfbb8e6569" xsi:type="Relationship" source="id-d05279ae46a643259a6ce75ec5f920ba" target="id-e0500e51e5c5462eb972462787ad2ec0">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a9b5992d5c3a426aaffc30b5ce3689f7" relationshipRef="id-8f2a9b3e59a347b682191c6cb2cd6971" xsi:type="Relationship" source="id-e1419f1fd1b34714a441a5041b828df2" target="id-8a956be6262a44eabe889abe07a56c36">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="690" y="800" />
+        </connection>
+        <connection identifier="id-b35f266a8140437e9f93848436953006" relationshipRef="id-1cdecf4d901346dc92de35811d271b5f" xsi:type="Relationship" source="id-e1419f1fd1b34714a441a5041b828df2" target="id-a8ad398177194329adc74784cf725eb2">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-bfb16db3de714763a39c025e499a6081" relationshipRef="id-1cb615feba4d41df9c417602872a99ed" xsi:type="Relationship" source="id-8a956be6262a44eabe889abe07a56c36" target="id-d05279ae46a643259a6ce75ec5f920ba">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="551" y="813" />
+        </connection>
+        <connection identifier="id-eb6f9468722040b9a5ab072baa92f024" relationshipRef="id-9984fc4756e9471db662ba12b8aa4d83" xsi:type="Relationship" source="id-8a956be6262a44eabe889abe07a56c36" target="id-8435239845d5424ba90256389cd182a9">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="302" y="813" />
+        </connection>
+        <connection identifier="id-0f1367e98ab44836adc441df6646c736" relationshipRef="id-a70f6ec37cf34a3c88adf7404a93aa5b" xsi:type="Relationship" source="id-8a956be6262a44eabe889abe07a56c36" target="id-e1419f1fd1b34714a441a5041b828df2">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="720" y="813" />
+        </connection>
+      </view>
+      <view identifier="id-7a850a0ead4c403eabc7751934046715" xsi:type="Diagram">
+        <name xml:lang="es">Figure17_New Customer Service Enabling to Customer Orders</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/5/27</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-b01cf841ae2c470a98c6ba9914e78250" xsi:type="Label" x="142" y="24" w="589" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-d3ec44c24ce0463e9bbc9f01b232353b" xsi:type="Label" x="576" y="468" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-1a2dc7c2438d41508bb260057eb72582" elementRef="id-56a4ef970d314200bc4e95d8ea928093" xsi:type="Element" x="89" y="288" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-3a57b5cf59e2498999a557eaedfb20a7" elementRef="id-eb6681ab4dd94ce3996ade5875bdf3ef" xsi:type="Element" x="233" y="288" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-7774b63b8f554a0ea38a15cbe19f2609" elementRef="id-590b2196df43475cb4e2cd018686ea66" xsi:type="Element" x="665" y="288" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="9" style="bold">
+              <color r="255" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-e29ba09c14984c78b3352eb4dc6cf06b" elementRef="id-103caa122d7e4d63a5b6479756634453" xsi:type="Element" x="377" y="288" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-63192ef3e2ee4398a4b15a02a1a3c13d" elementRef="id-8584078cf77640869fc4b4ff7a60d00d" xsi:type="Element" x="521" y="288" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-fd57565217854dfab0add28e2faf7712" elementRef="id-3bc7d428ccea48739c4d442f9f2364e7" xsi:type="Element" x="89" y="384" w="552" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-7c4b99ce2b2b44e28b5417354fbe0335" elementRef="id-86d6a2f695b74347a264354315c8656f" xsi:type="Element" x="665" y="384" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-98263fc97877468dae5f79f412dd7209" elementRef="id-c160bb04a89643a880d79a2dce37bd38" xsi:type="Element" x="233" y="180" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-0d0ad81add4540eabd028fba8bbf2dd5" elementRef="id-633f46a9f9f84bbda07115037faf71eb" xsi:type="Element" x="665" y="180" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="9" style="bold">
+              <color r="255" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-8ea7349cd98949a3a8e5f81db659294d" elementRef="id-cbc5896e78284e23b5bbca5e9a15dc76" xsi:type="Element" x="377" y="180" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-c8ad3a0103bc44039e603f8e9759756b" elementRef="id-d02d8886a7934dc898143a97a8376606" xsi:type="Element" x="521" y="180" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-0987c3b0c1bf45489ed145dc1da59a74" elementRef="id-73d6be570bd344aeb933d06b9566af35" xsi:type="Element" x="89" y="180" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-aba757b6dc05441fa338390b2c547ccb" elementRef="id-1a7757e999c54d6085462db7df22a296" xsi:type="Element" x="88" y="72" w="697" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-49b894c6a63e47e4947b7389ef59bfc7" relationshipRef="id-6e814dc25573414a8051b8d98d9ea3cb" xsi:type="Relationship" source="id-1a2dc7c2438d41508bb260057eb72582" target="id-0987c3b0c1bf45489ed145dc1da59a74">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-79e4909ed36c471b8075801ea16be74d" relationshipRef="id-b2f6b889474f475d9e537bc7767dc572" xsi:type="Relationship" source="id-3a57b5cf59e2498999a557eaedfb20a7" target="id-98263fc97877468dae5f79f412dd7209">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-eeb57257f6a34938802b562baf5a8aeb" relationshipRef="id-b0dbd0952d7e4c7a9db21298a3cd27af" xsi:type="Relationship" source="id-7774b63b8f554a0ea38a15cbe19f2609" target="id-0d0ad81add4540eabd028fba8bbf2dd5">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-39ac222e629e41fd90097f3af79d03a6" relationshipRef="id-ddf77800e82040caa3ab3ae7f93da8ae" xsi:type="Relationship" source="id-e29ba09c14984c78b3352eb4dc6cf06b" target="id-8ea7349cd98949a3a8e5f81db659294d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-f50c4dc6b3554a72855dc165553e6080" relationshipRef="id-dcc7e7bbdea2449fb76e4ce82ff7131d" xsi:type="Relationship" source="id-63192ef3e2ee4398a4b15a02a1a3c13d" target="id-c8ad3a0103bc44039e603f8e9759756b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-1f6b1601335d4a138e37acba6d43aa7e" relationshipRef="id-3037bdfa443f472588e0f4233a423eec" xsi:type="Relationship" source="id-fd57565217854dfab0add28e2faf7712" target="id-3a57b5cf59e2498999a557eaedfb20a7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-4435baf692b14b2cad1e9789bef604be" relationshipRef="id-d9dd6f2624c94bd5be7bdebe95037219" xsi:type="Relationship" source="id-fd57565217854dfab0add28e2faf7712" target="id-e29ba09c14984c78b3352eb4dc6cf06b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-7b81f0c16e004dedb08cd06794527bc0" relationshipRef="id-2d8ad9219a084314b9f6b34f0bbcb2ab" xsi:type="Relationship" source="id-fd57565217854dfab0add28e2faf7712" target="id-1a2dc7c2438d41508bb260057eb72582">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-db6ab3054260484f810c119016bbdd25" relationshipRef="id-026d56fafee84728936bb106a423b4b5" xsi:type="Relationship" source="id-fd57565217854dfab0add28e2faf7712" target="id-63192ef3e2ee4398a4b15a02a1a3c13d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-80066091fdbf455a8848c181caaaa12d" relationshipRef="id-76fd4032523f4952837124c227ea1b4e" xsi:type="Relationship" source="id-7c4b99ce2b2b44e28b5417354fbe0335" target="id-7774b63b8f554a0ea38a15cbe19f2609">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-8a408db42fe24ad5acc08fe3d8740f5f" relationshipRef="id-26a00b70891e43dd8e23d2386956d1c5" xsi:type="Relationship" source="id-98263fc97877468dae5f79f412dd7209" target="id-aba757b6dc05441fa338390b2c547ccb">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-ab88d233dc25444a815ad446079cc173" relationshipRef="id-8e1e118effae4e4abbb7307191a4b76f" xsi:type="Relationship" source="id-0d0ad81add4540eabd028fba8bbf2dd5" target="id-aba757b6dc05441fa338390b2c547ccb">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-4b1c10ce4063434d8ba70b7a0422e4ac" relationshipRef="id-854eab2f9d8446708ff00fc216fd026e" xsi:type="Relationship" source="id-8ea7349cd98949a3a8e5f81db659294d" target="id-aba757b6dc05441fa338390b2c547ccb">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-6ebeacf83ef041388f9d70387c0d368f" relationshipRef="id-8b5f76ead5464ebdace7dd4ffaacae91" xsi:type="Relationship" source="id-c8ad3a0103bc44039e603f8e9759756b" target="id-aba757b6dc05441fa338390b2c547ccb">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-6bdc816969734cab80e23035a497c9c1" relationshipRef="id-eafcc2e35d494c069d65233cc5431572" xsi:type="Relationship" source="id-0987c3b0c1bf45489ed145dc1da59a74" target="id-aba757b6dc05441fa338390b2c547ccb">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-c3a77d0773b446e7b51efc3d35c0d8ce" xsi:type="Diagram">
+        <name xml:lang="es">Figure18_New Processes and Inter-Dependencies with Existing Processes</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/5/27</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-74d1e0a8b7824d88b5317f4bd61e4447" xsi:type="Label" x="142" y="24" w="589" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-dbdefb3987e34ba9aea6b1dbb7a411d4" xsi:type="Label" x="588" y="438" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-0763fce095034ccb811b2f2dfa087ee9" elementRef="id-56a4ef970d314200bc4e95d8ea928093" xsi:type="Element" x="89" y="288" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-143d4a45e28e4491bc174d50b16c0b3a" elementRef="id-eb6681ab4dd94ce3996ade5875bdf3ef" xsi:type="Element" x="233" y="288" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-236e1e921ba84c75b8889a321f0fa470" elementRef="id-590b2196df43475cb4e2cd018686ea66" xsi:type="Element" x="402" y="288" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="9" style="bold">
+              <color r="255" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-0c41900723cc426db696b1d5467c9844" elementRef="id-103caa122d7e4d63a5b6479756634453" xsi:type="Element" x="552" y="288" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-9f8aab0ceb8842079263c3ded6e3cc1b" elementRef="id-8584078cf77640869fc4b4ff7a60d00d" xsi:type="Element" x="696" y="288" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-30a4ecd3dfb7415f924c67afff665598" elementRef="id-86d6a2f695b74347a264354315c8656f" xsi:type="Element" x="233" y="384" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-0bc71d036574476ebbd185b1d61ad956" elementRef="id-c160bb04a89643a880d79a2dce37bd38" xsi:type="Element" x="233" y="180" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-41097405be5844ba8b27955dfe3e97d8" elementRef="id-633f46a9f9f84bbda07115037faf71eb" xsi:type="Element" x="377" y="180" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="9" style="bold">
+              <color r="255" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-1d5f92607c6c4b11857cca8bad7201e6" elementRef="id-cbc5896e78284e23b5bbca5e9a15dc76" xsi:type="Element" x="521" y="180" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-fd15ffae70104b618173fb345daa279b" elementRef="id-d02d8886a7934dc898143a97a8376606" xsi:type="Element" x="660" y="180" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-11d0a1bfe041471c837eeade87c29a09" elementRef="id-73d6be570bd344aeb933d06b9566af35" xsi:type="Element" x="89" y="180" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-55cdea38e5b14b0e881c2ad60e63fbaf" elementRef="id-1a7757e999c54d6085462db7df22a296" xsi:type="Element" x="88" y="72" w="697" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-85539905108a466d96ba68abf54d18f1" elementRef="id-ca35f8df80974169b04c1ffd58c12493" xsi:type="Element" x="396" y="468" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-7bd3b4cb6726411d9b5446d132e203aa" elementRef="id-5f7aebddd3ad4a0593301978fca34bab" xsi:type="Element" x="84" y="384" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-bffa623e285341f18649eb6c2795cac7" elementRef="id-322294a1d3b441b2a55c57b8dca6e7ff" xsi:type="Element" x="396" y="384" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="9" style="bold">
+              <color r="255" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-b61e9e6c325e43d6ac08173cb4926c36" relationshipRef="id-6e814dc25573414a8051b8d98d9ea3cb" xsi:type="Relationship" source="id-0763fce095034ccb811b2f2dfa087ee9" target="id-11d0a1bfe041471c837eeade87c29a09">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-5586719bb5f64e0589e3a079511bf361" relationshipRef="id-b2f6b889474f475d9e537bc7767dc572" xsi:type="Relationship" source="id-143d4a45e28e4491bc174d50b16c0b3a" target="id-0bc71d036574476ebbd185b1d61ad956">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-8c51f423e53b47d793bb4254f94496d8" relationshipRef="id-3c157187e57042c983f84b01a9348cde" xsi:type="Relationship" source="id-143d4a45e28e4491bc174d50b16c0b3a" target="id-236e1e921ba84c75b8889a321f0fa470">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-2db5335cf329456ebfead4aeadf52510" relationshipRef="id-4abc7f162f9042f99a1ec563b8696d4f" xsi:type="Relationship" source="id-143d4a45e28e4491bc174d50b16c0b3a" target="id-bffa623e285341f18649eb6c2795cac7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-138fcbfe5b0b42f9acf805d8796e4481" relationshipRef="id-b0dbd0952d7e4c7a9db21298a3cd27af" xsi:type="Relationship" source="id-236e1e921ba84c75b8889a321f0fa470" target="id-41097405be5844ba8b27955dfe3e97d8">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-ccc031291c6e469f98f245c1d087bbd2" relationshipRef="id-ddf77800e82040caa3ab3ae7f93da8ae" xsi:type="Relationship" source="id-0c41900723cc426db696b1d5467c9844" target="id-1d5f92607c6c4b11857cca8bad7201e6">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-48bcb1a3d16649feab5deda832dc3cef" relationshipRef="id-dcc7e7bbdea2449fb76e4ce82ff7131d" xsi:type="Relationship" source="id-9f8aab0ceb8842079263c3ded6e3cc1b" target="id-fd15ffae70104b618173fb345daa279b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-d417b742819744e3bb9152042f5434f0" relationshipRef="id-76fd4032523f4952837124c227ea1b4e" xsi:type="Relationship" source="id-30a4ecd3dfb7415f924c67afff665598" target="id-236e1e921ba84c75b8889a321f0fa470">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a69924d20d2e46e8b2ed9f191cd0cb3e" relationshipRef="id-7aa6c18eab5943e7ae0816a82cec4e51" xsi:type="Relationship" source="id-30a4ecd3dfb7415f924c67afff665598" target="id-7bd3b4cb6726411d9b5446d132e203aa">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-079888e74ee54e9ea677cdab6610da84" relationshipRef="id-26a00b70891e43dd8e23d2386956d1c5" xsi:type="Relationship" source="id-0bc71d036574476ebbd185b1d61ad956" target="id-55cdea38e5b14b0e881c2ad60e63fbaf">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-66f64aef3f40469aad142afb93be6f41" relationshipRef="id-8e1e118effae4e4abbb7307191a4b76f" xsi:type="Relationship" source="id-41097405be5844ba8b27955dfe3e97d8" target="id-55cdea38e5b14b0e881c2ad60e63fbaf">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-b93ad649b85848ab98fb29cdbbee3e29" relationshipRef="id-854eab2f9d8446708ff00fc216fd026e" xsi:type="Relationship" source="id-1d5f92607c6c4b11857cca8bad7201e6" target="id-55cdea38e5b14b0e881c2ad60e63fbaf">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-3ebed73aa80b45e78d091f1695bbc9fe" relationshipRef="id-8b5f76ead5464ebdace7dd4ffaacae91" xsi:type="Relationship" source="id-fd15ffae70104b618173fb345daa279b" target="id-55cdea38e5b14b0e881c2ad60e63fbaf">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-309334a50a4d42f4a190f00df31a97b3" relationshipRef="id-eafcc2e35d494c069d65233cc5431572" xsi:type="Relationship" source="id-11d0a1bfe041471c837eeade87c29a09" target="id-55cdea38e5b14b0e881c2ad60e63fbaf">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-13914e8a6d5c4f8b8f12c6077ad62d18" relationshipRef="id-a8ef868842644973850d7f8f8570bdd5" xsi:type="Relationship" source="id-85539905108a466d96ba68abf54d18f1" target="id-bffa623e285341f18649eb6c2795cac7">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-bc9ec9b5b80d4f3da69eb551e94f2945" relationshipRef="id-3ca88c32f00441349bd9aca0dd67f7c2" xsi:type="Relationship" source="id-bffa623e285341f18649eb6c2795cac7" target="id-236e1e921ba84c75b8889a321f0fa470">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-82be4d5be046439ab9795a4f31a92fd4" xsi:type="Diagram">
+        <name xml:lang="es">Figure19_New-Application-Landscape</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/5/27</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-05c0ded6dbf74f55ab1d2e4a6fec5fe8" xsi:type="Label" x="228" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-e81ffe25a9c14ca78882dac95e588234" xsi:type="Label" x="708" y="492" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-e061e9a018c64681ad7aad0042152e4f" elementRef="id-93c74e2f4b8b4b0491164e6d79c445d6" xsi:type="Element" x="499" y="60" w="438" h="205">
+          <style>
+            <fillColor r="237" g="207" b="226" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-bd4cf0a488634f4c91cbf570b3282ca4" elementRef="id-51d42a1da36a42c2811e84ff8952cb58" xsi:type="Element" x="550" y="96" w="109" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-dea5c7c401d241e6957c8f4c46a1dfef" elementRef="id-3dfec7838acb47f588677d6e8f948fd9" xsi:type="Element" x="676" y="95" w="109" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-1b4f1516506f442293474550efd12489" elementRef="id-09b37e64a61d4c4183f49930d1237509" xsi:type="Element" x="799" y="96" w="109" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-4f9735eab5e44960899098a04e04e78f" elementRef="id-26586078852645d59ea8b14781701c65" xsi:type="Element" x="499" y="276" w="438" h="205">
+          <style>
+            <fillColor r="237" g="207" b="226" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-7f328fb368b44d8c99f1d6f1a9e1b670" elementRef="id-3eb0685faebf42cfa81567c6a4e7db24" xsi:type="Element" x="799" y="384" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-773361d0b9ef4795a5c87052479b8dd7" elementRef="id-4e06ee45db904a88aa46e9dce611528e" xsi:type="Element" x="523" y="384" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Segoe UI" size="9" style="bold">
+                <color r="255" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-729e4c6996c14d95ad033990edaea605" elementRef="id-e26375257d8440228f37158ecf5b8524" xsi:type="Element" x="655" y="384" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Segoe UI" size="9" style="bold">
+                <color r="255" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-fb88467b91554fee9785e5a6e33d9ba7" elementRef="id-8b75218115db49b9aecd0501d04d5545" xsi:type="Element" x="36" y="60" w="433" h="421">
+          <style>
+            <fillColor r="237" g="207" b="226" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-c101227b630e4c34a324648aee1a4fc1" elementRef="id-c728f7f622be468380062354ffbf4f57" xsi:type="Element" x="193" y="288" w="157" h="73">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-9564db47f9cb4a8b9bf71244837a251c" elementRef="id-5538d8de4e6c4918a62221922988c957" xsi:type="Element" x="212" y="396" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-ceb92b06d0a34e46a342a8f4ad0def4a" elementRef="id-68903f066cfc4959a4e940405e47f6cd" xsi:type="Element" x="331" y="96" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-99cf1916145342d1ae036d608e429aab" elementRef="id-132442dad80345129362408c87cdde9b" xsi:type="Element" x="48" y="96" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-c543a31bb72d4fad94cc066e9516488f" elementRef="id-641d335281ca4b53932f250e695f1f94" xsi:type="Element" x="193" y="96" w="120" h="55">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-845d0270a0404b3e90b208ac6f677c96" elementRef="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Element" x="48" y="180" w="877" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="9" style="bold">
+              <color r="255" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-f04a7f8a5b4e44d4bc4623325b5d73ad" relationshipRef="id-ebebf195ec63472980382dab9e91ddac" xsi:type="Relationship" source="id-bd4cf0a488634f4c91cbf570b3282ca4" target="id-845d0270a0404b3e90b208ac6f677c96">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="593" y="160" />
+        </connection>
+        <connection identifier="id-98dfcfef3a074c6b96b8206a51a22379" relationshipRef="id-8b7fdcbb1fb446b6a168bc53550a2842" xsi:type="Relationship" source="id-dea5c7c401d241e6957c8f4c46a1dfef" target="id-845d0270a0404b3e90b208ac6f677c96">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="719" y="160" />
+        </connection>
+        <connection identifier="id-fd29de1b5b2e4e5cb558a7627843721a" relationshipRef="id-669d682920734511accefa5b2cb7dd1f" xsi:type="Relationship" source="id-1b4f1516506f442293474550efd12489" target="id-845d0270a0404b3e90b208ac6f677c96">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="871" y="170" />
+        </connection>
+        <connection identifier="id-86e4205bbca04ee39e849cdc0c85635b" relationshipRef="id-07a1defae2014e9d855c59525c19c7b7" xsi:type="Relationship" source="id-7f328fb368b44d8c99f1d6f1a9e1b670" target="id-845d0270a0404b3e90b208ac6f677c96">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="843" y="299" />
+        </connection>
+        <connection identifier="id-1a410c795a184714a7698bd0c9e982b5" relationshipRef="id-61ebdc87de474e20a879a30a1c99fc82" xsi:type="Relationship" source="id-773361d0b9ef4795a5c87052479b8dd7" target="id-845d0270a0404b3e90b208ac6f677c96">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="567" y="299" />
+        </connection>
+        <connection identifier="id-50a9c376cb8746ca9a8cede30f30ccd4" relationshipRef="id-8f2a9b3e59a347b682191c6cb2cd6971" xsi:type="Relationship" source="id-729e4c6996c14d95ad033990edaea605" target="id-845d0270a0404b3e90b208ac6f677c96">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="699" y="299" />
+        </connection>
+        <connection identifier="id-78375ad8d4cc4d63ba7deb7a7e59a7d6" relationshipRef="id-2523d00aed2d4d008634b25bde995ecb" xsi:type="Relationship" source="id-c101227b630e4c34a324648aee1a4fc1" target="id-9564db47f9cb4a8b9bf71244837a251c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="286" y="384" />
+        </connection>
+        <connection identifier="id-00990155464e4acea4e1f588fe339d60" relationshipRef="id-9a3a3d96c2344514b644e1fdb8cdb8c7" xsi:type="Relationship" source="id-c101227b630e4c34a324648aee1a4fc1" target="id-845d0270a0404b3e90b208ac6f677c96">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="256" y="252" />
+        </connection>
+        <connection identifier="id-d8abf786cad2481ab2fe7b5db0b91c56" relationshipRef="id-a5ca972c87a1493c969ab24a5404318f" xsi:type="Relationship" source="id-9564db47f9cb4a8b9bf71244837a251c" target="id-c101227b630e4c34a324648aee1a4fc1">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="256" y="372" />
+        </connection>
+        <connection identifier="id-3cabba75364b4dceb519926589a66838" relationshipRef="id-84d40daec2984878ba7febd33358735a" xsi:type="Relationship" source="id-ceb92b06d0a34e46a342a8f4ad0def4a" target="id-845d0270a0404b3e90b208ac6f677c96">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="378" y="155" />
+        </connection>
+        <connection identifier="id-9f7f8ee3bd1d4d7c83d2d2c5052b4576" relationshipRef="id-855abfcab77b4399b9124ede0c28f1c1" xsi:type="Relationship" source="id-99cf1916145342d1ae036d608e429aab" target="id-845d0270a0404b3e90b208ac6f677c96">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="122" y="170" />
+        </connection>
+        <connection identifier="id-6608093be3584310856c8d7a2cbcf52c" relationshipRef="id-33409723619341ddac60e2901c77a9a2" xsi:type="Relationship" source="id-c543a31bb72d4fad94cc066e9516488f" target="id-845d0270a0404b3e90b208ac6f677c96">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="237" y="160" />
+        </connection>
+        <connection identifier="id-d501f481c8c541b7adb481ada7456dfc" relationshipRef="id-15eaf22bbd514661a6986b679bf7bb5a" xsi:type="Relationship" source="id-845d0270a0404b3e90b208ac6f677c96" target="id-99cf1916145342d1ae036d608e429aab">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="92" y="160" />
+        </connection>
+        <connection identifier="id-35a1e90cc7c643dfa06eda630d67137a" relationshipRef="id-3cc58aba3d844d8783f78300e809ac35" xsi:type="Relationship" source="id-845d0270a0404b3e90b208ac6f677c96" target="id-c543a31bb72d4fad94cc066e9516488f">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="267" y="170" />
+        </connection>
+        <connection identifier="id-7b337017a82c4a7284a4f57b1052d349" relationshipRef="id-7482a60e92cc4f4a8de0d8aca202cd2a" xsi:type="Relationship" source="id-845d0270a0404b3e90b208ac6f677c96" target="id-1b4f1516506f442293474550efd12489">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="842" y="160" />
+        </connection>
+        <connection identifier="id-08e29d0101064508856c100703a80b75" relationshipRef="id-9701ef25128c4149b850331677749aa1" xsi:type="Relationship" source="id-845d0270a0404b3e90b208ac6f677c96" target="id-dea5c7c401d241e6957c8f4c46a1dfef">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="748" y="169" />
+        </connection>
+        <connection identifier="id-3cd8cb20790f4ee08457941affac3b8d" relationshipRef="id-eb71dae724ab4a6a9fad0e61d194eb26" xsi:type="Relationship" source="id-845d0270a0404b3e90b208ac6f677c96" target="id-bd4cf0a488634f4c91cbf570b3282ca4">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="622" y="170" />
+        </connection>
+        <connection identifier="id-a57fcc9f73554636bd1678af5d2f88d0" relationshipRef="id-44f95fe75c464b19a14a81609cd421db" xsi:type="Relationship" source="id-845d0270a0404b3e90b208ac6f677c96" target="id-7f328fb368b44d8c99f1d6f1a9e1b670">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="873" y="319" />
+        </connection>
+        <connection identifier="id-35e7a2b50a914f90a2fd29fb304d2222" relationshipRef="id-9a48df866be44d569b3ad2db9fb24086" xsi:type="Relationship" source="id-845d0270a0404b3e90b208ac6f677c96" target="id-ceb92b06d0a34e46a342a8f4ad0def4a">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="408" y="175" />
+        </connection>
+        <connection identifier="id-e9ad3b73e9e74bc5bda86fb51de08ced" relationshipRef="id-1cb615feba4d41df9c417602872a99ed" xsi:type="Relationship" source="id-845d0270a0404b3e90b208ac6f677c96" target="id-c101227b630e4c34a324648aee1a4fc1">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="285" y="270" />
+        </connection>
+        <connection identifier="id-68049da99a474d99937b006b703b52b7" relationshipRef="id-9984fc4756e9471db662ba12b8aa4d83" xsi:type="Relationship" source="id-845d0270a0404b3e90b208ac6f677c96" target="id-773361d0b9ef4795a5c87052479b8dd7">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="597" y="319" />
+        </connection>
+        <connection identifier="id-f1a9b7c10f9b4aaf8b5d44409ea6c1c9" relationshipRef="id-a70f6ec37cf34a3c88adf7404a93aa5b" xsi:type="Relationship" source="id-845d0270a0404b3e90b208ac6f677c96" target="id-729e4c6996c14d95ad033990edaea605">
+          <style lineWidth="2">
+            <lineColor r="255" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="729" y="319" />
+        </connection>
+      </view>
+      <view identifier="id-640a2982a91e4056bb99356476dad35f" xsi:type="Diagram">
+        <name xml:lang="es">Figure20_Implementation-and-Migration</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/5/27</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-efe9dbee275a457fb7d9ebed78c0e124" xsi:type="Label" x="240" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-099448207e484568a024855f9d643115" xsi:type="Label" x="759" y="576" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-a7382306f0a54692a6f78b4d55320883" elementRef="id-fbc7c240895b4e0397b9aea45e0618bf" xsi:type="Element" x="156" y="504" w="817" h="55">
+          <style>
+            <fillColor r="255" g="224" b="224" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-d78ff6c82f65427cb14b1bbbd18de284" elementRef="id-4d7f4fc0971947f787ba6b4fa2ff3fa0" xsi:type="Element" x="228" y="405" w="265" h="55">
+          <style>
+            <fillColor r="255" g="224" b="224" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-dca8d6437be54b6fbb539f2e37e54f62" elementRef="id-4cf5ebcb7c0b4c01bfb2c6934504ba8f" xsi:type="Element" x="719" y="405" w="265" h="55">
+          <style>
+            <fillColor r="255" g="224" b="224" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-610810ec3798411ca7e12c66611e8014" elementRef="id-2f8dd2120d55460896baf324b937dfd6" xsi:type="Element" x="144" y="309" w="229" h="55">
+          <style>
+            <fillColor r="255" g="224" b="224" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-4680787e8da24daab4f331b96fb7a7f0" elementRef="id-8e83c502c9924312923992e8b255bff1" xsi:type="Element" x="444" y="309" w="120" h="55">
+          <style>
+            <fillColor r="255" g="224" b="224" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-c396ebf226054a678921824f887bebb4" elementRef="id-d81bb5d2f5274f239d10b8a210a2fa8b" xsi:type="Element" x="600" y="309" w="229" h="55">
+          <style>
+            <fillColor r="255" g="224" b="224" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-e59e895e2024497185426ff609d4bd69" elementRef="id-e429c90e3c69458f9131f11c48669677" xsi:type="Element" x="852" y="309" w="150" h="55">
+          <style>
+            <fillColor r="255" g="224" b="224" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-7ec885a9fcc64f2daf65bfc4180f7c9d" elementRef="id-58761ca77a6d49818b06fd0021959839" xsi:type="Element" x="0" y="96" w="120" h="55">
+          <style>
+            <fillColor r="255" g="224" b="224" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-2cf77610fc3345b381604a30b3d78c39" elementRef="id-be22e5fb2b804f32b1087966af591ec4" xsi:type="Element" x="156" y="96" w="337" h="55">
+          <style>
+            <fillColor r="255" g="224" b="224" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-29331661bc1041009a1b0b5a2344a684" elementRef="id-faeb172be6704b9d992fe8646d3028f0" xsi:type="Element" x="696" y="96" w="277" h="55">
+          <style>
+            <fillColor r="255" g="224" b="224" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-6be7d95f1a4d488eabe95ec365ce273d" elementRef="id-322294a1d3b441b2a55c57b8dca6e7ff" xsi:type="Element" x="66" y="211" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-4b43ac20418f4bea882df76bd7968da7" elementRef="id-16a56de036194eb79b44068f44ee244d" xsi:type="Element" x="198" y="212" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-b185b319c2f848dea2a2be3109232a27" elementRef="id-8108cbbc4ed64abbbe5b87014468f35b" xsi:type="Element" x="330" y="211" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-ba4c41c944d749a58dd770b1d09fe3a7" elementRef="id-4e06ee45db904a88aa46e9dce611528e" xsi:type="Element" x="466" y="209" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-56a61007ff02416d8d5055be4d5f5e8b" elementRef="id-590b2196df43475cb4e2cd018686ea66" xsi:type="Element" x="624" y="210" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-a9e7da18d540458491fd5be153e54f68" elementRef="id-633f46a9f9f84bbda07115037faf71eb" xsi:type="Element" x="759" y="210" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-74c58a8fcec34d05b3399bc43f0c62b5" elementRef="id-e26375257d8440228f37158ecf5b8524" xsi:type="Element" x="899" y="209" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-78c080f1ae504c95933220b4133d4be0" relationshipRef="id-b0e1f724270049b8ab6861a45b2a9d3a" xsi:type="Relationship" source="id-a7382306f0a54692a6f78b4d55320883" target="id-d78ff6c82f65427cb14b1bbbd18de284">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-3146ed496c8243c59eada960cecf40b5" relationshipRef="id-b6fb2f69c7b84d36a9d7d44488f5dff3" xsi:type="Relationship" source="id-a7382306f0a54692a6f78b4d55320883" target="id-dca8d6437be54b6fbb539f2e37e54f62">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-bc79d9b185a64acd9c91a53b3fcde9b2" relationshipRef="id-a42603dd1d294eedab1ca39175719926" xsi:type="Relationship" source="id-d78ff6c82f65427cb14b1bbbd18de284" target="id-610810ec3798411ca7e12c66611e8014">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-1bf8605e33e0472a8b1eb2cb86281fd5" relationshipRef="id-f666ddf925cb4a699663144ace30837f" xsi:type="Relationship" source="id-d78ff6c82f65427cb14b1bbbd18de284" target="id-4680787e8da24daab4f331b96fb7a7f0">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-4980045259c64e8aa8058b95734c64d5" relationshipRef="id-62bec07ee1c24eea904e7bcd21dfedfc" xsi:type="Relationship" source="id-dca8d6437be54b6fbb539f2e37e54f62" target="id-c396ebf226054a678921824f887bebb4">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-24e05272f90241458d5ec13127cf555a" relationshipRef="id-c9f7575d9f0d454faf830c50662e129d" xsi:type="Relationship" source="id-dca8d6437be54b6fbb539f2e37e54f62" target="id-e59e895e2024497185426ff609d4bd69">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-0eae192f9e1649588b50d0d3caf41c3b" relationshipRef="id-dca3f4be1a224856a5a9bdce91e6e892" xsi:type="Relationship" source="id-610810ec3798411ca7e12c66611e8014" target="id-6be7d95f1a4d488eabe95ec365ce273d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-548fe9a47ccb41ffa233c78d5004746a" relationshipRef="id-601b1f6d053448549c198ec1264de387" xsi:type="Relationship" source="id-610810ec3798411ca7e12c66611e8014" target="id-4b43ac20418f4bea882df76bd7968da7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-f4395d9fcea54aca8678609db473716a" relationshipRef="id-920e152199a945a3a39f2a6baf73d5ee" xsi:type="Relationship" source="id-610810ec3798411ca7e12c66611e8014" target="id-b185b319c2f848dea2a2be3109232a27">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a5af45bfca21449cb14e841417ba8b9c" relationshipRef="id-e9ca401699e64d1ab329ab087245094e" xsi:type="Relationship" source="id-4680787e8da24daab4f331b96fb7a7f0" target="id-ba4c41c944d749a58dd770b1d09fe3a7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-3b3a2d10081b4d958852a39cf67f4294" relationshipRef="id-1adb0aeeade143828ceb938596c1c7e1" xsi:type="Relationship" source="id-c396ebf226054a678921824f887bebb4" target="id-56a61007ff02416d8d5055be4d5f5e8b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-7cfbc37298e344b4b58a3dbb26e1c868" relationshipRef="id-c976a84c39b64f528e354ab055af02c8" xsi:type="Relationship" source="id-c396ebf226054a678921824f887bebb4" target="id-a9e7da18d540458491fd5be153e54f68">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-6c7361d97cf4423cacabb9be3183311c" relationshipRef="id-67444b25581244038c95eea3e02a0e32" xsi:type="Relationship" source="id-e59e895e2024497185426ff609d4bd69" target="id-74c58a8fcec34d05b3399bc43f0c62b5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-bfe8dd6121674291adeb11cb5e82836c" relationshipRef="id-3a7a20f9ddee4102aa2a1009dda0f8d4" xsi:type="Relationship" source="id-7ec885a9fcc64f2daf65bfc4180f7c9d" target="id-2cf77610fc3345b381604a30b3d78c39">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-505ecd1308a444f281e206a744fc044c" relationshipRef="id-1a34c59912404e6ba82f8454bdaf6524" xsi:type="Relationship" source="id-2cf77610fc3345b381604a30b3d78c39" target="id-29331661bc1041009a1b0b5a2344a684">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a41ee85563fd4bea948d0d9be61fcaa8" relationshipRef="id-11c12e1b44674be8a92ab3a1966d0dfa" xsi:type="Relationship" source="id-2cf77610fc3345b381604a30b3d78c39" target="id-ba4c41c944d749a58dd770b1d09fe3a7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a0ad1ac71cac4260b24ad5c1d1772e1d" relationshipRef="id-4acfc130f7c6410abd76bb415ab5eac8" xsi:type="Relationship" source="id-2cf77610fc3345b381604a30b3d78c39" target="id-b185b319c2f848dea2a2be3109232a27">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-0182b123873446e58c9784cd7fce6ebe" relationshipRef="id-37c41ebe851b4039a5c4a39602348b1e" xsi:type="Relationship" source="id-2cf77610fc3345b381604a30b3d78c39" target="id-4b43ac20418f4bea882df76bd7968da7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-1057095ce3bd464e9f3e7d9f0d8d476f" relationshipRef="id-cdf011fb0eab4d9bb00ffc06d99b9596" xsi:type="Relationship" source="id-2cf77610fc3345b381604a30b3d78c39" target="id-6be7d95f1a4d488eabe95ec365ce273d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-7da71ea67f124b029d67320bf3f2f3ae" relationshipRef="id-81d5cfc6f19b4154b4873315635856b2" xsi:type="Relationship" source="id-29331661bc1041009a1b0b5a2344a684" target="id-56a61007ff02416d8d5055be4d5f5e8b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-54a761042e7d427ebc698712eefc9d79" relationshipRef="id-a12883009a84471f8b0a29ab1bcd1c1e" xsi:type="Relationship" source="id-29331661bc1041009a1b0b5a2344a684" target="id-a9e7da18d540458491fd5be153e54f68">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-942c72b5fe32418fb79a050361ffd91b" relationshipRef="id-e474ee3e3cb34846930f6d40e9ff420b" xsi:type="Relationship" source="id-29331661bc1041009a1b0b5a2344a684" target="id-74c58a8fcec34d05b3399bc43f0c62b5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-4c416cf02fca460ab93ad4b3936f63c9" xsi:type="Diagram">
+        <name xml:lang="es">Figure21_Registraton of a New Customer</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/6/4</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-be02c26f588b4856a926bc12fe911deb" xsi:type="Label" x="305" y="4" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-ffaac2686c494a5caa46dc489c25088e" xsi:type="Label" x="108" y="503" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-34b55ad3fcce4a7693b2071025077729" elementRef="id-56a4ef970d314200bc4e95d8ea928093" xsi:type="Element" x="156" y="180" w="901" h="126">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-f3722ae4f3244d00bd38b4612e24da20" elementRef="id-16a56de036194eb79b44068f44ee244d" xsi:type="Element" x="336" y="224" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-6f23d94e581c4d9b97a54fe98b925807" elementRef="id-b0f8301b5a2744279cb027be12751c25" xsi:type="Element" x="480" y="224" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-419b25a64a504c738238736b68061f0d" elementRef="id-2372f409993a4d7c943255a5277337b1" xsi:type="Element" x="912" y="224" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-9ad99e859b3e4dbf92535aed35a262af" elementRef="id-6ce3b2f185874049ad30f4b5d7a1491d" xsi:type="Element" x="192" y="224" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-6426320640524a13a9d3ebd5067d5a50" elementRef="id-66ed398ab28e442ea5516dd44cdc0a49" xsi:type="Element" x="768" y="224" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-8195d4e808b9498ea5897652df274cbe" elementRef="id-c4b62300152b4eab912ff382a166ce9f" xsi:type="Element" x="627" y="224" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-3637808568e945c6b52afa211c5b715d" elementRef="id-bbd25ba605ba4eafaa1ab945552f0449" xsi:type="Element" x="0" y="224" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-5583d9ade6a744b59bc0597c00ebbb4c" elementRef="id-8108cbbc4ed64abbbe5b87014468f35b" xsi:type="Element" x="336" y="114" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-dd9272756aaf439d905bcea31a7c8229" elementRef="id-86d6a2f695b74347a264354315c8656f" xsi:type="Element" x="156" y="80" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-57742af17f5d462d985b2e6b8824feea" elementRef="id-5f7aebddd3ad4a0593301978fca34bab" xsi:type="Element" x="468" y="48" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-c33e42fd3e0940c68ca4c298b8ec43c0" elementRef="id-73d6be570bd344aeb933d06b9566af35" xsi:type="Element" x="636" y="80" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-9da973d6bdea472da322c8b7b55bb684" elementRef="id-3bc7d428ccea48739c4d442f9f2364e7" xsi:type="Element" x="913" y="84" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-008808338db64f08be4065ba408a013c" elementRef="id-260c70cf6aad4a17b0d321e5674b57c4" xsi:type="Element" x="186" y="349" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-c62edb36f2254dccb3c40beeb273b968" elementRef="id-b56b5c461fc94c06b00ed6d33955fcb2" xsi:type="Element" x="492" y="349" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-4cd9ed5d00fe404f8a82249fd1211e21" elementRef="id-b184c5661a354a80a26061333635c927" xsi:type="Element" x="336" y="349" w="120" h="102">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-f7d034b0b9ae404aa78756172696b35e" elementRef="id-2b87582d36d143db98c8e258b24655f1" xsi:type="Element" x="663" y="349" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-32f47c3b3ba24deb8bd8fe4ebbc1f43f" elementRef="id-0bed0f0876c6428fa25879de80d47208" xsi:type="Element" x="913" y="396" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-bb8ea39112e146269a43b911c4df302f" elementRef="id-51c3a5a5d0c343df91c73e182a373148" xsi:type="Element" x="914" y="496" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-0bfde5b70c7c479aa9ad4138bf1641f0" relationshipRef="id-6e814dc25573414a8051b8d98d9ea3cb" xsi:type="Relationship" source="id-34b55ad3fcce4a7693b2071025077729" target="id-c33e42fd3e0940c68ca4c298b8ec43c0">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-6eb67453beba45a583a7d94134b9f07f" relationshipRef="id-77780f3d08b54989978885c4044a2752" xsi:type="Relationship" source="id-f3722ae4f3244d00bd38b4612e24da20" target="id-6f23d94e581c4d9b97a54fe98b925807">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-575ad7d2028941fb9cf9e83c368f6ace" relationshipRef="id-8ad312451dd041db8dc813902ff0de4f" xsi:type="Relationship" source="id-f3722ae4f3244d00bd38b4612e24da20" target="id-4cd9ed5d00fe404f8a82249fd1211e21">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-6dd4a7a2b87a47518d1c52790cc35dcd" relationshipRef="id-f388e19e59cb4d7bbb6fad4581eeb779" xsi:type="Relationship" source="id-6f23d94e581c4d9b97a54fe98b925807" target="id-8195d4e808b9498ea5897652df274cbe">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-93fde1c7dea24cb4a2da7fbbf6b87e2c" relationshipRef="id-7440ad3b9c58469db7c876199c9cfb59" xsi:type="Relationship" source="id-6f23d94e581c4d9b97a54fe98b925807" target="id-c62edb36f2254dccb3c40beeb273b968">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-f8226d62008b4313949d4346b962c8b6" relationshipRef="id-02b422a2cf694522ada32c1e044d3e73" xsi:type="Relationship" source="id-419b25a64a504c738238736b68061f0d" target="id-32f47c3b3ba24deb8bd8fe4ebbc1f43f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-71343daf2bfa4060ada9983761e55487" relationshipRef="id-d45cb8e279204268b0ca24d0525501e6" xsi:type="Relationship" source="id-9ad99e859b3e4dbf92535aed35a262af" target="id-f3722ae4f3244d00bd38b4612e24da20">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-d8de6d1909184f7da1b8b17af28f0879" relationshipRef="id-7f22df0afd51491d92d3a3e2b60078b3" xsi:type="Relationship" source="id-6426320640524a13a9d3ebd5067d5a50" target="id-419b25a64a504c738238736b68061f0d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-e91fb70485db43b3ba97b58650d779a8" relationshipRef="id-678b5212401e4f29b871752259798af5" xsi:type="Relationship" source="id-6426320640524a13a9d3ebd5067d5a50" target="id-4cd9ed5d00fe404f8a82249fd1211e21">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-6c64ae69a06c4842a994b0a2105b2b59" relationshipRef="id-0b0135218f6e4ecb86c1ae2b90c30f56" xsi:type="Relationship" source="id-8195d4e808b9498ea5897652df274cbe" target="id-6426320640524a13a9d3ebd5067d5a50">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-062516041f844226b803823cb63c63d5" relationshipRef="id-13866b172b4646acad8eecb024a962cb" xsi:type="Relationship" source="id-8195d4e808b9498ea5897652df274cbe" target="id-f7d034b0b9ae404aa78756172696b35e">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-7dcc80ff6858402986b9ec4dd8979cfb" relationshipRef="id-839b8489c8be4f9b8c112979ed16c902" xsi:type="Relationship" source="id-8195d4e808b9498ea5897652df274cbe" target="id-4cd9ed5d00fe404f8a82249fd1211e21">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-54023e3f820c44b9a08cb67de0a6ad1d" relationshipRef="id-a4a42b824a5b4a5c80af81efaecd1f8d" xsi:type="Relationship" source="id-3637808568e945c6b52afa211c5b715d" target="id-34b55ad3fcce4a7693b2071025077729">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-868c4d74fa2b49558f6670992a18a226" relationshipRef="id-4108ed11a3b745c195ae42ea4e5874c2" xsi:type="Relationship" source="id-5583d9ade6a744b59bc0597c00ebbb4c" target="id-f3722ae4f3244d00bd38b4612e24da20">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-b19afee5f3784ba18ee974b6b9b7537f" relationshipRef="id-776b3dbb68a64026ae7e78f71246fda9" xsi:type="Relationship" source="id-5583d9ade6a744b59bc0597c00ebbb4c" target="id-c33e42fd3e0940c68ca4c298b8ec43c0">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-efd8541901ec42488b85cce3f36374b6" relationshipRef="id-f171221fa5d748fbbb70b55e74865a22" xsi:type="Relationship" source="id-dd9272756aaf439d905bcea31a7c8229" target="id-5583d9ade6a744b59bc0597c00ebbb4c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a230396b6a0f4aa08dec1602120a070f" relationshipRef="id-7aa6c18eab5943e7ae0816a82cec4e51" xsi:type="Relationship" source="id-dd9272756aaf439d905bcea31a7c8229" target="id-57742af17f5d462d985b2e6b8824feea">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-f68457d979de46519fbba4371497443d" relationshipRef="id-906ff6c00cce4a389d7c02c541a49522" xsi:type="Relationship" source="id-57742af17f5d462d985b2e6b8824feea" target="id-34b55ad3fcce4a7693b2071025077729">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-570020c03398494da89f82438e603378" relationshipRef="id-49b9afec4b8c47c9983c215c1266b051" xsi:type="Relationship" source="id-57742af17f5d462d985b2e6b8824feea" target="id-6f23d94e581c4d9b97a54fe98b925807">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-34174d28e6bb4f5ba2f015d4075f2cad" relationshipRef="id-00a2122c13fa4a5380523eaa404c8894" xsi:type="Relationship" source="id-57742af17f5d462d985b2e6b8824feea" target="id-c33e42fd3e0940c68ca4c298b8ec43c0">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-07ce489c052a4da6b8535ef0e1e9bd8b" relationshipRef="id-2d8ad9219a084314b9f6b34f0bbcb2ab" xsi:type="Relationship" source="id-9da973d6bdea472da322c8b7b55bb684" target="id-34b55ad3fcce4a7693b2071025077729">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-97bbbf93e5a84231989ddac20c735dca" relationshipRef="id-5199875c53ef4161be35819c68faee1b" xsi:type="Relationship" source="id-4cd9ed5d00fe404f8a82249fd1211e21" target="id-c62edb36f2254dccb3c40beeb273b968">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-6f568a8d9ee543298973a11232629b2c" relationshipRef="id-69ffc5d95d864033870d64dd6f2cd029" xsi:type="Relationship" source="id-4cd9ed5d00fe404f8a82249fd1211e21" target="id-32f47c3b3ba24deb8bd8fe4ebbc1f43f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-814b6489718d4406a65d8027d195316a" relationshipRef="id-71ae997cd5d14ebb8e8f99cb8e23df0d" xsi:type="Relationship" source="id-bb8ea39112e146269a43b911c4df302f" target="id-32f47c3b3ba24deb8bd8fe4ebbc1f43f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-845fa04712f144059ca8c3c5447f7a2f" xsi:type="Diagram">
+        <name xml:lang="es">Figure22_Support-for-Develop-Contract-Process</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/6/4</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-beb44c447d1d46009a758e1312a8a297" xsi:type="Label" x="348" y="16" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-26e6a9282d6f4cbc8578e0d65302230f" xsi:type="Label" x="842" y="516" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-e21892cd1a0c411b8ce6c42eb91b8267" elementRef="id-56a4ef970d314200bc4e95d8ea928093" xsi:type="Element" x="156" y="148" w="901" h="126">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-a3d9eb3982ba492ea56912ee0985c252" elementRef="id-16a56de036194eb79b44068f44ee244d" xsi:type="Element" x="336" y="192" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-49bb5a551c2b4000a5a653d36b6c0b7f" elementRef="id-b0f8301b5a2744279cb027be12751c25" xsi:type="Element" x="480" y="192" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-3581eca8b53b4e12875170bb4c06f8c9" elementRef="id-2372f409993a4d7c943255a5277337b1" xsi:type="Element" x="912" y="192" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-b3e8541152674d0c8903f2305ae93920" elementRef="id-6ce3b2f185874049ad30f4b5d7a1491d" xsi:type="Element" x="192" y="192" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-dfa820dae3c64bc58418362219b20b87" elementRef="id-66ed398ab28e442ea5516dd44cdc0a49" xsi:type="Element" x="768" y="192" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-de6147bf8e34467ca016bb0f12af9a60" elementRef="id-c4b62300152b4eab912ff382a166ce9f" xsi:type="Element" x="627" y="192" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-8189da415e534fe68084b2eb83f77c38" elementRef="id-bbd25ba605ba4eafaa1ab945552f0449" xsi:type="Element" x="0" y="192" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-0ffbacee7b524eff858ff3c6f600f8dd" elementRef="id-3bc7d428ccea48739c4d442f9f2364e7" xsi:type="Element" x="913" y="52" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-4751fd924183489fa2aa3294e78417df" elementRef="id-0d58563f7c7647b8a9eb8d050ec6034b" xsi:type="Element" x="648" y="336" w="137" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-9a9beabf8fde4da189d4bfff0f851fbd" elementRef="id-eed49dfc6a754e3fbbcff474c2ee1b8d" xsi:type="Element" x="864" y="336" w="137" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-614c1993a34846a889739f192494832f" elementRef="id-3e0c53acd20e49d491f78cf0d33475d6" xsi:type="Element" x="192" y="336" w="137" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-57372ef526e54e58abd076d35d73767b" elementRef="id-deab2ec93baa49a28e95cb01ae59f7c3" xsi:type="Element" x="420" y="336" w="137" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-670374cc84c846db829fda99038e7d0c" elementRef="id-4e06ee45db904a88aa46e9dce611528e" xsi:type="Element" x="192" y="444" w="809" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-272d765d7f85429a8c96ee1d31123680" relationshipRef="id-77780f3d08b54989978885c4044a2752" xsi:type="Relationship" source="id-a3d9eb3982ba492ea56912ee0985c252" target="id-49bb5a551c2b4000a5a653d36b6c0b7f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-b5a7a97227944154aa99b93decd4b743" relationshipRef="id-f388e19e59cb4d7bbb6fad4581eeb779" xsi:type="Relationship" source="id-49bb5a551c2b4000a5a653d36b6c0b7f" target="id-de6147bf8e34467ca016bb0f12af9a60">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-638cd6be5d024b05867d712a4eac0f1e" relationshipRef="id-d45cb8e279204268b0ca24d0525501e6" xsi:type="Relationship" source="id-b3e8541152674d0c8903f2305ae93920" target="id-a3d9eb3982ba492ea56912ee0985c252">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-14276c2670a6472eacccdb91e04d470e" relationshipRef="id-7f22df0afd51491d92d3a3e2b60078b3" xsi:type="Relationship" source="id-dfa820dae3c64bc58418362219b20b87" target="id-3581eca8b53b4e12875170bb4c06f8c9">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-4cc2ea8db80d4a6687ff2c01a31558c4" relationshipRef="id-0b0135218f6e4ecb86c1ae2b90c30f56" xsi:type="Relationship" source="id-de6147bf8e34467ca016bb0f12af9a60" target="id-dfa820dae3c64bc58418362219b20b87">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-f86cd2d9745e4472ab987839310736a8" relationshipRef="id-a4a42b824a5b4a5c80af81efaecd1f8d" xsi:type="Relationship" source="id-8189da415e534fe68084b2eb83f77c38" target="id-e21892cd1a0c411b8ce6c42eb91b8267">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-3573ee0fcbe8454ab758457a4f0da8bd" relationshipRef="id-2d8ad9219a084314b9f6b34f0bbcb2ab" xsi:type="Relationship" source="id-0ffbacee7b524eff858ff3c6f600f8dd" target="id-e21892cd1a0c411b8ce6c42eb91b8267">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-af03cf4430df478683e7d910ef606f07" relationshipRef="id-6068459dcf664ad5a7b0d37937524430" xsi:type="Relationship" source="id-4751fd924183489fa2aa3294e78417df" target="id-dfa820dae3c64bc58418362219b20b87">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-d104c35092a3489eab9593ce0776bd6a" relationshipRef="id-bda70888878c4491b39b4af4ee18f458" xsi:type="Relationship" source="id-9a9beabf8fde4da189d4bfff0f851fbd" target="id-3581eca8b53b4e12875170bb4c06f8c9">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-747db70daa81412290f092caf82e6e69" relationshipRef="id-0723603c90374bc2b94bb7865d59e89d" xsi:type="Relationship" source="id-614c1993a34846a889739f192494832f" target="id-b3e8541152674d0c8903f2305ae93920">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-bca4d5193475416fb8defbd7736de5b4" relationshipRef="id-9acacc74a46e4d8f90a07de7f6c40295" xsi:type="Relationship" source="id-614c1993a34846a889739f192494832f" target="id-a3d9eb3982ba492ea56912ee0985c252">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-24387605651b466f9781dd5261d52fe3" relationshipRef="id-4dacd8a214d044b5aaf9d1f1b152f6c3" xsi:type="Relationship" source="id-614c1993a34846a889739f192494832f" target="id-de6147bf8e34467ca016bb0f12af9a60">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-4af7e0a9c7544876b1dadcb2ca798671" relationshipRef="id-d2657cf7dbd3498bafce917d4b08cfd0" xsi:type="Relationship" source="id-57372ef526e54e58abd076d35d73767b" target="id-49bb5a551c2b4000a5a653d36b6c0b7f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-5c7f7340b650453f8dacdb47f1d22b73" relationshipRef="id-2f0d63ae8ea84153b6062fdd0dd312ba" xsi:type="Relationship" source="id-670374cc84c846db829fda99038e7d0c" target="id-614c1993a34846a889739f192494832f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a0ad11ebe45e438d94c13cb753974355" relationshipRef="id-e03267e87a984283a7ab52ca7a5d9a8c" xsi:type="Relationship" source="id-670374cc84c846db829fda99038e7d0c" target="id-57372ef526e54e58abd076d35d73767b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a652a348417446fab3e504c9c2769041" relationshipRef="id-d274fbfebd7a44e6b7b0c4fd7fd4df14" xsi:type="Relationship" source="id-670374cc84c846db829fda99038e7d0c" target="id-4751fd924183489fa2aa3294e78417df">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-e3b547a8da844fe09ba9d2a0aa47b716" relationshipRef="id-8ca6a7dfae9d4e619287374aea2c4126" xsi:type="Relationship" source="id-670374cc84c846db829fda99038e7d0c" target="id-9a9beabf8fde4da189d4bfff0f851fbd">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-c89990a2bdbe4fc191a37a5cf9d18855" xsi:type="Diagram">
+        <name xml:lang="es">Figure23_Registration of Customer Order</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/6/4</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-c3a8c88a0340471182a6908070af668f" xsi:type="Label" x="204" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-0361a9ecbed84c3db29330438ae1c51b" xsi:type="Label" x="648" y="427" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-a58d857bd5a94e468466df92b9937893" elementRef="id-eb6681ab4dd94ce3996ade5875bdf3ef" xsi:type="Element" x="228" y="144" w="471" h="128">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-d7a61254ec9042e0b05f1333e3784466" elementRef="id-d17a14d6490b493590904eee8473936c" xsi:type="Element" x="252" y="180" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-60d008c8f12245488917f990434459cf" elementRef="id-9331a6d1c1f54746841c1c6908d8b9e8" xsi:type="Element" x="552" y="180" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-6223381553ed4046b97465b3585c5122" elementRef="id-3a3aa1f975794029b3d192f1dcefc361" xsi:type="Element" x="402" y="180" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-ed22a5e5c1bf4de494e5d9d7f5147df4" elementRef="id-c578fa3dcee04225a0144fa71920eeb6" xsi:type="Element" x="48" y="180" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-45aad72defb5452b9db7938b6e551b95" elementRef="id-6191979d2f304476ab02f638d4ece684" xsi:type="Element" x="778" y="204" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-a862edf62a3748ea85267cbdd9a156eb" elementRef="id-590b2196df43475cb4e2cd018686ea66" xsi:type="Element" x="780" y="300" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-652f6aa8adcf4d2a917e02aafa2acadb" elementRef="id-3bc7d428ccea48739c4d442f9f2364e7" xsi:type="Element" x="575" y="59" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-4db168f98f9a42739b325562bca7c89c" elementRef="id-c160bb04a89643a880d79a2dce37bd38" xsi:type="Element" x="384" y="59" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-3096c336db5443e9b24ec82828c0a11b" elementRef="id-d527ba03811741ebb7569d1b04442a25" xsi:type="Element" x="204" y="330" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-bafd0e005a51477589e241b43f2e9830" elementRef="id-86a95bbd46c448b4ad517306a911c2e9" xsi:type="Element" x="59" y="330" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-a14e6933ab0c4b5eaee1b9a7616ba0ed" elementRef="id-b184c5661a354a80a26061333635c927" xsi:type="Element" x="468" y="330" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-dd85469d14624b239fe6a8ae7a412c10" elementRef="id-b56b5c461fc94c06b00ed6d33955fcb2" xsi:type="Element" x="469" y="420" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-81124785f3a94a9a865ff35b20feaa66" elementRef="id-260c70cf6aad4a17b0d321e5674b57c4" xsi:type="Element" x="302" y="406" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-1e67855c577141b6a5a519448e550e22" elementRef="id-5f42eca753994b2eb284dd75b26a7cb2" xsi:type="Element" x="612" y="330" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-29af1a3aedc4494e8f12cee66d62ed5c" relationshipRef="id-b2f6b889474f475d9e537bc7767dc572" xsi:type="Relationship" source="id-a58d857bd5a94e468466df92b9937893" target="id-4db168f98f9a42739b325562bca7c89c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-46c34eefd0c44ded9087285c28a0241d" relationshipRef="id-9e76c169badb45cf9ef8550ac376cf63" xsi:type="Relationship" source="id-d7a61254ec9042e0b05f1333e3784466" target="id-6223381553ed4046b97465b3585c5122">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-1b764e9493bb480db9d263e4fbe60c3d" relationshipRef="id-5f77215fb5c94ff89c5c29f09aeb4cd2" xsi:type="Relationship" source="id-d7a61254ec9042e0b05f1333e3784466" target="id-bafd0e005a51477589e241b43f2e9830">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-1051a89200244dc8b670bfbb41416d37" relationshipRef="id-21ccfc64299947cf84608184faa689b8" xsi:type="Relationship" source="id-d7a61254ec9042e0b05f1333e3784466" target="id-3096c336db5443e9b24ec82828c0a11b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-9d222079c84b4ec8bed211042bf3f247" relationshipRef="id-d4c54ab4367246f1b8911ebd052c73c3" xsi:type="Relationship" source="id-d7a61254ec9042e0b05f1333e3784466" target="id-a14e6933ab0c4b5eaee1b9a7616ba0ed">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-56cac86307f143efb1ca3cd4e2b880e2" relationshipRef="id-359fe6f134a24f009c18dc19b1432e82" xsi:type="Relationship" source="id-60d008c8f12245488917f990434459cf" target="id-45aad72defb5452b9db7938b6e551b95">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-97912ef1eb744a889040281a6d4f22b6" relationshipRef="id-4cf36345fa4849de86160e994cf9a29f" xsi:type="Relationship" source="id-60d008c8f12245488917f990434459cf" target="id-1e67855c577141b6a5a519448e550e22">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-f57852607b344539864c25cea9d307b7" relationshipRef="id-a5b4193a7da54c0882e995bc050cdc32" xsi:type="Relationship" source="id-60d008c8f12245488917f990434459cf" target="id-3096c336db5443e9b24ec82828c0a11b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a7a4d1654048480aad165a7acf2e306a" relationshipRef="id-91d310907d1f45ea83ab0bd401f3f8da" xsi:type="Relationship" source="id-6223381553ed4046b97465b3585c5122" target="id-60d008c8f12245488917f990434459cf">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-8f9cec06d3f44ddc9bde772359310f21" relationshipRef="id-9f6bf9cce0914a0c90e8aed50db56eb6" xsi:type="Relationship" source="id-6223381553ed4046b97465b3585c5122" target="id-81124785f3a94a9a865ff35b20feaa66">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-ee9f87b9cfff4ac4adb2b67e37a338c3" relationshipRef="id-f7564b50863d46339f8ecdde808e9711" xsi:type="Relationship" source="id-6223381553ed4046b97465b3585c5122" target="id-a14e6933ab0c4b5eaee1b9a7616ba0ed">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-1efaeca03744439ab78f2fc71d66309b" relationshipRef="id-d400f395329743d6a210542f0a7d07a6" xsi:type="Relationship" source="id-ed22a5e5c1bf4de494e5d9d7f5147df4" target="id-a58d857bd5a94e468466df92b9937893">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-4000721fc316403c8752d6bff1c8d5e7" relationshipRef="id-ea02ec226e9e44eabc67e3de952542ad" xsi:type="Relationship" source="id-45aad72defb5452b9db7938b6e551b95" target="id-a862edf62a3748ea85267cbdd9a156eb">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-095ed345ef8e47f6af908c29832ca03f" relationshipRef="id-3037bdfa443f472588e0f4233a423eec" xsi:type="Relationship" source="id-652f6aa8adcf4d2a917e02aafa2acadb" target="id-a58d857bd5a94e468466df92b9937893">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-d23fa75d881f441e88a001491fbef4ba" relationshipRef="id-5199875c53ef4161be35819c68faee1b" xsi:type="Relationship" source="id-a14e6933ab0c4b5eaee1b9a7616ba0ed" target="id-dd85469d14624b239fe6a8ae7a412c10">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-0ee2e2bb25134094bbfb9ff204140f31" xsi:type="Diagram">
+        <name xml:lang="es">Figure24_Support for Registration of Customer Order</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/6/4</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-be584eeccd2c401a8008908af2188a03" xsi:type="Label" x="204" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-c4d14a08a6ea49c4a5567573ae54777f" xsi:type="Label" x="768" y="571" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-44e9be0636b749ef9e456d51c4c9cf56" elementRef="id-eb6681ab4dd94ce3996ade5875bdf3ef" xsi:type="Element" x="228" y="144" w="471" h="128">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-153ddc4a0d2c43e09c46898037c34d30" elementRef="id-d17a14d6490b493590904eee8473936c" xsi:type="Element" x="252" y="180" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-e13585fcbe46451e9dfe81fd590caefd" elementRef="id-9331a6d1c1f54746841c1c6908d8b9e8" xsi:type="Element" x="552" y="180" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-0e13dfe56d354e6f9d68e1773e0d7530" elementRef="id-3a3aa1f975794029b3d192f1dcefc361" xsi:type="Element" x="402" y="180" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-d010d7925017405cb4d8305338a47728" elementRef="id-c578fa3dcee04225a0144fa71920eeb6" xsi:type="Element" x="48" y="180" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-e9661596ceb443db9cd432b013fe5a22" elementRef="id-6191979d2f304476ab02f638d4ece684" xsi:type="Element" x="778" y="204" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-523802289c7b48efb4a0db0fb44e5b45" elementRef="id-590b2196df43475cb4e2cd018686ea66" xsi:type="Element" x="780" y="300" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-4e54386ca1604bc3a588f678f6a48e4f" elementRef="id-3bc7d428ccea48739c4d442f9f2364e7" xsi:type="Element" x="575" y="59" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-767c4e7a9c8c44e28686bd5a8c9fb688" elementRef="id-c160bb04a89643a880d79a2dce37bd38" xsi:type="Element" x="384" y="59" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-831300b34daf4c5faefe893859566a60" elementRef="id-815c2b316d7848279b068a86a0a2ddea" xsi:type="Element" x="503" y="300" w="158" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-e25eac43b9954289a373396eb48b61eb" elementRef="id-65db965489624a89893068173a39cf59" xsi:type="Element" x="276" y="300" w="158" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-5c4194942ea04401abf2fbc3e4a9bf38" elementRef="id-4e06ee45db904a88aa46e9dce611528e" xsi:type="Element" x="276" y="396" w="385" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-bb3951d4f471467c86a16defb82edc68" elementRef="id-c9eb53d707564096a8727df622f078bb" xsi:type="Element" x="373" y="480" w="181" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-98f00ac5c4f0457590bcf098d2b6e544" elementRef="id-3eb0685faebf42cfa81567c6a4e7db24" xsi:type="Element" x="204" y="564" w="135" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-96c54f4faeb3439e9f6e26ca2afb2d70" elementRef="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Element" x="588" y="564" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-e6ef4f492e8d46388a2922b9f4315465" elementRef="id-b8ba463d96e7480e8099014269c938e8" xsi:type="Element" x="400" y="563" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-d826d284c8c94ce5af0fff5344770708" relationshipRef="id-b2f6b889474f475d9e537bc7767dc572" xsi:type="Relationship" source="id-44e9be0636b749ef9e456d51c4c9cf56" target="id-767c4e7a9c8c44e28686bd5a8c9fb688">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-e149d32bb70942abb96f381bb3c56e07" relationshipRef="id-9e76c169badb45cf9ef8550ac376cf63" xsi:type="Relationship" source="id-153ddc4a0d2c43e09c46898037c34d30" target="id-0e13dfe56d354e6f9d68e1773e0d7530">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-4e1cec18e01048c3a7881242f8ebac2a" relationshipRef="id-359fe6f134a24f009c18dc19b1432e82" xsi:type="Relationship" source="id-e13585fcbe46451e9dfe81fd590caefd" target="id-e9661596ceb443db9cd432b013fe5a22">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-7f452ad3916b4feb8fa87ff7064872fd" relationshipRef="id-91d310907d1f45ea83ab0bd401f3f8da" xsi:type="Relationship" source="id-0e13dfe56d354e6f9d68e1773e0d7530" target="id-e13585fcbe46451e9dfe81fd590caefd">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-674687dba2024371930613f17805e77b" relationshipRef="id-d400f395329743d6a210542f0a7d07a6" xsi:type="Relationship" source="id-d010d7925017405cb4d8305338a47728" target="id-44e9be0636b749ef9e456d51c4c9cf56">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-57a3e37c16184597961d45da16fc6395" relationshipRef="id-ea02ec226e9e44eabc67e3de952542ad" xsi:type="Relationship" source="id-e9661596ceb443db9cd432b013fe5a22" target="id-523802289c7b48efb4a0db0fb44e5b45">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-9d48d4af845c447ea2491dded0e3fa0e" relationshipRef="id-3037bdfa443f472588e0f4233a423eec" xsi:type="Relationship" source="id-4e54386ca1604bc3a588f678f6a48e4f" target="id-44e9be0636b749ef9e456d51c4c9cf56">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-9d772109830148e89c1200045629dce5" relationshipRef="id-f3a7d86ac3a14acfa7c8d670c69e43bf" xsi:type="Relationship" source="id-831300b34daf4c5faefe893859566a60" target="id-153ddc4a0d2c43e09c46898037c34d30">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-246892b09dc04834bebc9eb2cb3ba0c1" relationshipRef="id-61e2ba8b92744d6697758aa50794d893" xsi:type="Relationship" source="id-831300b34daf4c5faefe893859566a60" target="id-e13585fcbe46451e9dfe81fd590caefd">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a4afb41ffc9247eea4d7c21482220f41" relationshipRef="id-fe7b3c77e211485ebee8f59032c1da09" xsi:type="Relationship" source="id-e25eac43b9954289a373396eb48b61eb" target="id-0e13dfe56d354e6f9d68e1773e0d7530">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-964ea8cc79c8426aab4bfee203258f95" relationshipRef="id-0445695e9fec438e9a5ef43857ccb243" xsi:type="Relationship" source="id-5c4194942ea04401abf2fbc3e4a9bf38" target="id-831300b34daf4c5faefe893859566a60">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-8728e553e0d344a891e5bb16f0f2d6c8" relationshipRef="id-d0a04647b05b48adb59e216cbbc5b46f" xsi:type="Relationship" source="id-5c4194942ea04401abf2fbc3e4a9bf38" target="id-e25eac43b9954289a373396eb48b61eb">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-92410dd516ec4e0c8f29b913dbdd133c" relationshipRef="id-a268ca16d2f74427a688fc6d65599df2" xsi:type="Relationship" source="id-bb3951d4f471467c86a16defb82edc68" target="id-5c4194942ea04401abf2fbc3e4a9bf38">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-b1843fe99f864fb7b7636c1dc19d86ef" relationshipRef="id-6e1154ae7e1b42f8a587d4207ff79bad" xsi:type="Relationship" source="id-e6ef4f492e8d46388a2922b9f4315465" target="id-98f00ac5c4f0457590bcf098d2b6e544">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-6f99ec0894ef4013a6a0729769204e57" relationshipRef="id-95dccab6d18e4a35a29bf5f251eb16cc" xsi:type="Relationship" source="id-e6ef4f492e8d46388a2922b9f4315465" target="id-96c54f4faeb3439e9f6e26ca2afb2d70">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-30ca06689ec54aa3b93cfe136a1f19ce" relationshipRef="id-0fb8c568ca7b465184f2d76486832e0b" xsi:type="Relationship" source="id-e6ef4f492e8d46388a2922b9f4315465" target="id-bb3951d4f471467c86a16defb82edc68">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-43f43fbb0b7f48b8ac861037cb5c046c" xsi:type="Diagram">
+        <name xml:lang="es">Figure25_Track Customer Order Process</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/6/4</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-8445727043e0458cabb95329f500af59" xsi:type="Label" x="204" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-90f462c30e234ba4a4906c66d8f9f9fe" xsi:type="Label" x="120" y="461" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-6a39995b70c5449ab6d1217f81dd883b" elementRef="id-590b2196df43475cb4e2cd018686ea66" xsi:type="Element" x="288" y="146" w="336" h="115">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-dfa19d6e20994ef8b34d60829dedafa1" elementRef="id-f7bd6d6664424100b329cb8b0ed40510" xsi:type="Element" x="324" y="182" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-d6fea9627a30440095584dc55b3edf27" elementRef="id-a9bbb7a79a9b4d568f6f66917f0b40d1" xsi:type="Element" x="474" y="182" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-a45a5fab9c0d4d03ba11997c231a165a" elementRef="id-633f46a9f9f84bbda07115037faf71eb" xsi:type="Element" x="396" y="60" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-c30d92a1bef14315a30b7fab82d5971c" elementRef="id-86d6a2f695b74347a264354315c8656f" xsi:type="Element" x="684" y="176" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-30f2ceb759e04eff8e180ea40adffbd7" elementRef="id-6191979d2f304476ab02f638d4ece684" xsi:type="Element" x="108" y="176" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-25e71c4f6fdf44f5805664cd49497bac" elementRef="id-1cd9ba40fb81440b89ca6b9b81264bf4" xsi:type="Element" x="371" y="288" w="169" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-e3b702e356014a1982e17bf6b4b9f134" elementRef="id-e26375257d8440228f37158ecf5b8524" xsi:type="Element" x="374" y="372" w="163" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-8e3ebfd261184c37987033ad42476e36" elementRef="id-c521cb12763d4ab3993c3c45b66dc5d4" xsi:type="Element" x="577" y="371" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-484b74314f61482193535dc2d9d9890d" elementRef="id-4c50a5c4b84a49128b53481ac94f3430" xsi:type="Element" x="577" y="456" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-90d7877afc2e4a64b5a0e77c0bec8559" elementRef="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Element" x="743" y="454" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-0ce419acd1d54b39b84560521117d8e4" elementRef="id-4e06ee45db904a88aa46e9dce611528e" xsi:type="Element" x="420" y="454" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-91f595ce62d74665a0e1b6a0b481d7f3" relationshipRef="id-b0dbd0952d7e4c7a9db21298a3cd27af" xsi:type="Relationship" source="id-6a39995b70c5449ab6d1217f81dd883b" target="id-a45a5fab9c0d4d03ba11997c231a165a">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-45883030d56b45e7975ddfb807005e45" relationshipRef="id-65ef28d914c74e039bb9a406b2ac91b1" xsi:type="Relationship" source="id-dfa19d6e20994ef8b34d60829dedafa1" target="id-d6fea9627a30440095584dc55b3edf27">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-7eebe320c394498e91ef29cadeb995be" relationshipRef="id-76fd4032523f4952837124c227ea1b4e" xsi:type="Relationship" source="id-c30d92a1bef14315a30b7fab82d5971c" target="id-6a39995b70c5449ab6d1217f81dd883b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-70fc347438e842639eb67ba0db7ce027" relationshipRef="id-ea02ec226e9e44eabc67e3de952542ad" xsi:type="Relationship" source="id-30f2ceb759e04eff8e180ea40adffbd7" target="id-6a39995b70c5449ab6d1217f81dd883b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-ddc9744a266d45d98716b294ca298be3" relationshipRef="id-1f0d849706644335bfb100282c445c7f" xsi:type="Relationship" source="id-25e71c4f6fdf44f5805664cd49497bac" target="id-6a39995b70c5449ab6d1217f81dd883b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-6b3547f62f14427d83387b348bc5a3e0" relationshipRef="id-10298aab69d64ad8a69e63cf794357c5" xsi:type="Relationship" source="id-e3b702e356014a1982e17bf6b4b9f134" target="id-25e71c4f6fdf44f5805664cd49497bac">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-3eac51194a1b4d9c948b52651a394bd4" relationshipRef="id-82012bdf7ac544d9822b2546c3b861ca" xsi:type="Relationship" source="id-8e3ebfd261184c37987033ad42476e36" target="id-e3b702e356014a1982e17bf6b4b9f134">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-25da94061a1a4af58ab07567538d22ab" relationshipRef="id-4a8d31f88d574a9089e90deee7ff98c9" xsi:type="Relationship" source="id-484b74314f61482193535dc2d9d9890d" target="id-8e3ebfd261184c37987033ad42476e36">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a4bf6ca304294583be1b842a47d96d14" relationshipRef="id-67d03a22a57c4b9ca3536f514a2511a0" xsi:type="Relationship" source="id-484b74314f61482193535dc2d9d9890d" target="id-90d7877afc2e4a64b5a0e77c0bec8559">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-51b124d5f3d74494842b1f560ad82e41" relationshipRef="id-ee27f10dc39d47598d4911480a093e90" xsi:type="Relationship" source="id-484b74314f61482193535dc2d9d9890d" target="id-0ce419acd1d54b39b84560521117d8e4">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-3a7130b63e8f40daad3e73435484ee95" xsi:type="Diagram">
+        <name xml:lang="es">Figure26_Process Customer Order Process</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/6/4</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-ee77c2117691494e9b8b74cb514a7b5a" xsi:type="Label" x="240" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-419c2e69578b48139b82e28da9c76481" xsi:type="Label" x="671" y="315" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-b599e444b30f424aa393f97b78ca550f" elementRef="id-322294a1d3b441b2a55c57b8dca6e7ff" xsi:type="Element" x="155" y="88" w="601" h="96">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-70203bbe161c47d6958dc6b811fe95d3" elementRef="id-458d93fe1e2f4c51a43bae8e26b96aa4" xsi:type="Element" x="167" y="112" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-9825f464d0b74075bbcede0f4c313f0e" elementRef="id-cef7496ae5d84bfa8b4de2882dbbb248" xsi:type="Element" x="317" y="112" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-5f9668741ec94185aca3c26f0c31ff20" elementRef="id-26bb007b0934471f9c05d188e9589372" xsi:type="Element" x="467" y="112" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-3a2810558ed14ff3bc8e59adb8ae12aa" elementRef="id-c4d0ce61237a4b03a3f27f9d1b009e55" xsi:type="Element" x="623" y="112" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-0cc657df55844afb88d41ad79a263f20" elementRef="id-8fa16f9c69894e46ba236ae0230911bc" xsi:type="Element" x="0" y="108" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-5f89b95b61854a2e886a67c254b52c8b" elementRef="id-ca35f8df80974169b04c1ffd58c12493" xsi:type="Element" x="803" y="63" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-48171683c3f844ecbcfb13e021a405ed" elementRef="id-6191979d2f304476ab02f638d4ece684" xsi:type="Element" x="803" y="147" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-792ec9cd85ae4aa28ee2c1cd9b060fa2" elementRef="id-b1b2c63ef02c42eb88310f21fe662e87" xsi:type="Element" x="395" y="231" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-20de9188396143bfb51a344e452e37d3" elementRef="id-201410bdce59449d817eda936fc5ef57" xsi:type="Element" x="539" y="231" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-5d212a067c7946f3baddad130bbfdec5" elementRef="id-17b8b5467ec44bb3be416b7d71bd2a07" xsi:type="Element" x="107" y="231" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-23a29d1fb9ea4ba89902a282fe125ab6" elementRef="id-86819b7c2aef41b2b13dc893c50ea3ec" xsi:type="Element" x="251" y="231" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-aaae8e0a05704cea87f2bbb99606f629" elementRef="id-8d9a138abbbd49248dda77330d209ac2" xsi:type="Element" x="683" y="231" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-8e3d6da24cf4440fa124f968554d6eb3" relationshipRef="id-4d3664323e0548c5b2581f6f082dbc24" xsi:type="Relationship" source="id-70203bbe161c47d6958dc6b811fe95d3" target="id-9825f464d0b74075bbcede0f4c313f0e">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-2fbaf5c205814306aae552523bbb59bc" relationshipRef="id-fc4152c18e8141b9808ff58527e8fb0e" xsi:type="Relationship" source="id-70203bbe161c47d6958dc6b811fe95d3" target="id-5d212a067c7946f3baddad130bbfdec5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-fad5179c58fe458399c815016e297356" relationshipRef="id-56dcf3e0644c40dfa2e34e43094b5f79" xsi:type="Relationship" source="id-70203bbe161c47d6958dc6b811fe95d3" target="id-792ec9cd85ae4aa28ee2c1cd9b060fa2">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-aa6f5607f833445b8dab32208b4a024f" relationshipRef="id-f0d55a3a939041ef8bcefb5254a0c77e" xsi:type="Relationship" source="id-9825f464d0b74075bbcede0f4c313f0e" target="id-5f9668741ec94185aca3c26f0c31ff20">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-63dfba05fb1944298f845fb456917de4" relationshipRef="id-3be81b3c59e54b4796ac2eb5caabb242" xsi:type="Relationship" source="id-9825f464d0b74075bbcede0f4c313f0e" target="id-23a29d1fb9ea4ba89902a282fe125ab6">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-5f7ca378b7b64fe19308366bba047ba1" relationshipRef="id-50568a62ff514fd9aabad89e255830ed" xsi:type="Relationship" source="id-9825f464d0b74075bbcede0f4c313f0e" target="id-792ec9cd85ae4aa28ee2c1cd9b060fa2">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-2a5a29d78aa24c85b909b0683960c71b" relationshipRef="id-e72a2f5f97524207bd87ddc2d36996a5" xsi:type="Relationship" source="id-5f9668741ec94185aca3c26f0c31ff20" target="id-3a2810558ed14ff3bc8e59adb8ae12aa">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-86044f0821a344aea201695ce3c1608e" relationshipRef="id-4a1f0e7f101248ec9e553b8b6690cd60" xsi:type="Relationship" source="id-5f9668741ec94185aca3c26f0c31ff20" target="id-792ec9cd85ae4aa28ee2c1cd9b060fa2">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-95a5e9c3ecda416fade9235996674e37" relationshipRef="id-4cce7fe2273e4cbfa269d34993272379" xsi:type="Relationship" source="id-5f9668741ec94185aca3c26f0c31ff20" target="id-20de9188396143bfb51a344e452e37d3">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-0d42ddfda89d46b8884d347f237ff5ad" relationshipRef="id-16a3c76c26154a59939c26b16ea0ee47" xsi:type="Relationship" source="id-5f9668741ec94185aca3c26f0c31ff20" target="id-aaae8e0a05704cea87f2bbb99606f629">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-12aa5c22d5514afa9607c08c1d7af966" relationshipRef="id-910409c3681c46ec8fcf2be89b91c5ca" xsi:type="Relationship" source="id-3a2810558ed14ff3bc8e59adb8ae12aa" target="id-48171683c3f844ecbcfb13e021a405ed">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-abb1509d2bd845d28a83043d61ebc999" relationshipRef="id-646eb2e3201c49f38c068d2f54c8097b" xsi:type="Relationship" source="id-3a2810558ed14ff3bc8e59adb8ae12aa" target="id-792ec9cd85ae4aa28ee2c1cd9b060fa2">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-15eec2a30c724344975fd3319f33e76b" relationshipRef="id-937bbcf4bfaf45a498c651052fd04b47" xsi:type="Relationship" source="id-0cc657df55844afb88d41ad79a263f20" target="id-b599e444b30f424aa393f97b78ca550f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a313038c363b46429d14085dbb1c538e" relationshipRef="id-a8ef868842644973850d7f8f8570bdd5" xsi:type="Relationship" source="id-5f89b95b61854a2e886a67c254b52c8b" target="id-b599e444b30f424aa393f97b78ca550f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-76d85ee971ad4c8cba88b078993ef583" xsi:type="Diagram">
+        <name xml:lang="es">Figure27_Support for Process Customer Order Process (copy)</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/6/4</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-5d6e6a35d9de464cb846ea093c64f4e5" xsi:type="Label" x="204" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-5bc7db97f2734d8685c8fcb37ec0c66e" xsi:type="Label" x="684" y="588" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-d20fa14e729b426da951d94f0f647064" elementRef="id-322294a1d3b441b2a55c57b8dca6e7ff" xsi:type="Element" x="180" y="72" w="601" h="96">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-94919eb529984b0bb67d7327647fa624" elementRef="id-458d93fe1e2f4c51a43bae8e26b96aa4" xsi:type="Element" x="192" y="96" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-f51b844460744edab3472ece326297c7" elementRef="id-cef7496ae5d84bfa8b4de2882dbbb248" xsi:type="Element" x="342" y="96" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-0992d694744e414fa3b821e956021a5b" elementRef="id-26bb007b0934471f9c05d188e9589372" xsi:type="Element" x="492" y="96" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-eeba4a23354f48979d58e4f960e8e214" elementRef="id-c4d0ce61237a4b03a3f27f9d1b009e55" xsi:type="Element" x="648" y="96" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-6ad79f028b744e2b9471f52436bad869" elementRef="id-8fa16f9c69894e46ba236ae0230911bc" xsi:type="Element" x="25" y="92" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-bf79f1681b2541ab97237f4f294a963b" elementRef="id-ca35f8df80974169b04c1ffd58c12493" xsi:type="Element" x="827" y="92" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-80e2ac63de744906af30a68b5ceb7a64" elementRef="id-cb9b699fb1fc478c8a8f436b20038f0f" xsi:type="Element" x="180" y="197" w="136" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-2dd3b7f2d97644a3b40faf0087934d60" elementRef="id-06fe133456074678b8f6a19e6aa5906b" xsi:type="Element" x="332" y="198" w="136" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-8dfd3fce4c1f4180aa538039c4595eb8" elementRef="id-c1d7e78cb9a8486cb0365b0c3eafdbd9" xsi:type="Element" x="490" y="197" w="136" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-15cce186eebd4709976b72c8c1465bbe" elementRef="id-cfa3f50f73694f23a2ef50c482a320b9" xsi:type="Element" x="643" y="195" w="136" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-94471e3c94dc4082b417c108c42b018a" elementRef="id-c728f7f622be468380062354ffbf4f57" xsi:type="Element" x="188" y="300" w="280" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-ca6dde9808a94146ba0a4983b03ce091" elementRef="id-4e06ee45db904a88aa46e9dce611528e" xsi:type="Element" x="651" y="300" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-5623d8fd3ad54159bdceb029ed84b146" elementRef="id-b67b02752ebc4b929c9a9fc76211cff9" xsi:type="Element" x="188" y="392" w="583" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-a60cbb618fd94f818c5c5e05ad880f2f" relationshipRef="id-4d3664323e0548c5b2581f6f082dbc24" xsi:type="Relationship" source="id-94919eb529984b0bb67d7327647fa624" target="id-f51b844460744edab3472ece326297c7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-c88e8b9e10784beeb06d9b2b17aed076" relationshipRef="id-f0d55a3a939041ef8bcefb5254a0c77e" xsi:type="Relationship" source="id-f51b844460744edab3472ece326297c7" target="id-0992d694744e414fa3b821e956021a5b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-c5eb4eee2927436ba017b296d14884ab" relationshipRef="id-e72a2f5f97524207bd87ddc2d36996a5" xsi:type="Relationship" source="id-0992d694744e414fa3b821e956021a5b" target="id-eeba4a23354f48979d58e4f960e8e214">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-1b127e1e2f9d4ce28d9c06478347397e" relationshipRef="id-937bbcf4bfaf45a498c651052fd04b47" xsi:type="Relationship" source="id-6ad79f028b744e2b9471f52436bad869" target="id-d20fa14e729b426da951d94f0f647064">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-614bd0b3b8374909bc2a4fd7629c7aad" relationshipRef="id-a8ef868842644973850d7f8f8570bdd5" xsi:type="Relationship" source="id-bf79f1681b2541ab97237f4f294a963b" target="id-d20fa14e729b426da951d94f0f647064">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-8e34649834184b5d9ddf74263b9c6bf6" relationshipRef="id-09c9d7ae76044d66b5b9a408aa6154a0" xsi:type="Relationship" source="id-80e2ac63de744906af30a68b5ceb7a64" target="id-94919eb529984b0bb67d7327647fa624">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-e91fea32f2b44d7fa33fdbccde390ece" relationshipRef="id-f6b2077e6187458280a345de367c7af1" xsi:type="Relationship" source="id-2dd3b7f2d97644a3b40faf0087934d60" target="id-f51b844460744edab3472ece326297c7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-85a676f494334de8b91608409db24b0f" relationshipRef="id-f96548e2bd6d4f508502d5f1dcb11b51" xsi:type="Relationship" source="id-8dfd3fce4c1f4180aa538039c4595eb8" target="id-0992d694744e414fa3b821e956021a5b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-31e8f5b67a034f50ab9abf544435188f" relationshipRef="id-830d0d07355a40b18354ca1be8f60e20" xsi:type="Relationship" source="id-15cce186eebd4709976b72c8c1465bbe" target="id-eeba4a23354f48979d58e4f960e8e214">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-653730e10e3c49c997756da25ad45dfb" relationshipRef="id-8da91a3bad204d0dac78fdd9c4444bf2" xsi:type="Relationship" source="id-15cce186eebd4709976b72c8c1465bbe" target="id-f51b844460744edab3472ece326297c7">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-55341fc4e85f4265be6f704b6580d793" relationshipRef="id-e2b70f6020004bd08a615b2d4e2b5fd0" xsi:type="Relationship" source="id-94471e3c94dc4082b417c108c42b018a" target="id-80e2ac63de744906af30a68b5ceb7a64">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-79e2d4cdf7024655a4acd45b74d71324" relationshipRef="id-6bb180a4e44c4ca4b34b1fe8176c124a" xsi:type="Relationship" source="id-94471e3c94dc4082b417c108c42b018a" target="id-2dd3b7f2d97644a3b40faf0087934d60">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-78c4542af6c1404e91929d61f24e3b62" relationshipRef="id-9a3a3d96c2344514b644e1fdb8cdb8c7" xsi:type="Relationship" source="id-94471e3c94dc4082b417c108c42b018a" target="id-5623d8fd3ad54159bdceb029ed84b146">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="312" y="367" />
+        </connection>
+        <connection identifier="id-422a607073054e8ba02128ce773ceedf" relationshipRef="id-bf60141d36f64c88b276fa4e759e2cf7" xsi:type="Relationship" source="id-ca6dde9808a94146ba0a4983b03ce091" target="id-15cce186eebd4709976b72c8c1465bbe">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-769fde916d7542adacea7b2987c68218" relationshipRef="id-61ebdc87de474e20a879a30a1c99fc82" xsi:type="Relationship" source="id-ca6dde9808a94146ba0a4983b03ce091" target="id-5623d8fd3ad54159bdceb029ed84b146">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="725" y="379" />
+        </connection>
+        <connection identifier="id-36a39f6a90324a85a08d45f940ee22bd" relationshipRef="id-9984fc4756e9471db662ba12b8aa4d83" xsi:type="Relationship" source="id-5623d8fd3ad54159bdceb029ed84b146" target="id-ca6dde9808a94146ba0a4983b03ce091">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="695" y="367" />
+        </connection>
+        <connection identifier="id-5e687a1f70a74b00b4cdce18f6b7eb2d" relationshipRef="id-1cb615feba4d41df9c417602872a99ed" xsi:type="Relationship" source="id-5623d8fd3ad54159bdceb029ed84b146" target="id-94471e3c94dc4082b417c108c42b018a">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="342" y="379" />
+        </connection>
+        <connection identifier="id-2e8416d3cd774a67b426fdb90cf478b8" relationshipRef="id-e16526d578e447fc82921dc99dec9332" xsi:type="Relationship" source="id-5623d8fd3ad54159bdceb029ed84b146" target="id-8dfd3fce4c1f4180aa538039c4595eb8">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-8509079b3dcf499ba671c54e7f7712b6" xsi:type="Diagram">
+        <name xml:lang="es">Figure28 Stakeholder View</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023-05-19</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-c3842dbd3385452693ed70cb39ac7704" xsi:type="Label" x="252" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-4b31723785bf408bbd88e5ea5d30cfe4" xsi:type="Label" x="684" y="373" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-cc898766f37649dfb311b18271daf3fa" elementRef="id-8939bfb16933425c952bd4ca553d90e2" xsi:type="Element" x="192" y="60" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-75c497137e9a4ce3b373fda7bfc46880" elementRef="id-f31166117d504940a2268fb1dcb0bbc7" xsi:type="Element" x="652" y="60" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-c133de1cf1944b82a8a7c02194036137" elementRef="id-877622cb13a744b1baa7d9e94576aa25" xsi:type="Element" x="195" y="161" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-c47f7cb9d7a04b8d875137981867ffc9" elementRef="id-f11c2b0d08c44572995ce0a180edc174" xsi:type="Element" x="195" y="262" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-febd18f896d94b3ca0bef16cf2c6e620" elementRef="id-d676a607a130483a961a4a1de0179094" xsi:type="Element" x="652" y="161" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-c0862728d96b44709551ec42c90d1806" elementRef="id-3fe71c490fc64bf3bb22c73bff890b38" xsi:type="Element" x="432" y="161" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-26a9379879b549cca32ef32408afe698" elementRef="id-58df809904fa4baf8b5b7c28c53d20b0" xsi:type="Element" x="433" y="262" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-205d362d23ed4b86a688b7b4ccc7e1a7" elementRef="id-4aee877b6bfd42619217ccb2547b68ba" xsi:type="Element" x="364" y="360" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-f55b9b27c8954307ba8feaef1719e2e4" elementRef="id-3fd6818a449e46559476e24456f63196" xsi:type="Element" x="509" y="360" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-530162ef31cf478c8ae6bfdc8236706f" relationshipRef="id-7a139d573c7c4a9e8e7ee3c1e4f0da15" xsi:type="Relationship" source="id-cc898766f37649dfb311b18271daf3fa" target="id-c133de1cf1944b82a8a7c02194036137">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-fd8e7abd29ef4fdcb4c2ab0bd52e138c" relationshipRef="id-c270926850164f48b17d088aeb65730c" xsi:type="Relationship" source="id-cc898766f37649dfb311b18271daf3fa" target="id-c0862728d96b44709551ec42c90d1806">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-6c7914b013d746dda70591605bd7c4b5" relationshipRef="id-43d49ff09883433d9e841aab36a0c9c2" xsi:type="Relationship" source="id-75c497137e9a4ce3b373fda7bfc46880" target="id-febd18f896d94b3ca0bef16cf2c6e620">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a41bfac7d0604007acd86297d76a9492" relationshipRef="id-0392078f67334640b8dfed5f54dd9c78" xsi:type="Relationship" source="id-75c497137e9a4ce3b373fda7bfc46880" target="id-c0862728d96b44709551ec42c90d1806">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a094ec30774f4d4ab5393c16bf229fac" relationshipRef="id-53953760b2a44842adf5d843032c638a" xsi:type="Relationship" source="id-c133de1cf1944b82a8a7c02194036137" target="id-c47f7cb9d7a04b8d875137981867ffc9">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-5bd31e827e824e5b9f50d1dbc730ec97" relationshipRef="id-382214250efd4231a02756416f05fcec" xsi:type="Relationship" source="id-c133de1cf1944b82a8a7c02194036137" target="id-c0862728d96b44709551ec42c90d1806">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-ac8d20de9fca463ea672e129931ae38e" relationshipRef="id-d0fc1d4dc3864dfb8336c6a37a243d47" xsi:type="Relationship" source="id-c47f7cb9d7a04b8d875137981867ffc9" target="id-26a9379879b549cca32ef32408afe698">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-5dd6bd984e5f49b490358d881ee9bed5" relationshipRef="id-d47baa395fed460db6421a2aded17de2" xsi:type="Relationship" source="id-febd18f896d94b3ca0bef16cf2c6e620" target="id-c0862728d96b44709551ec42c90d1806">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-c84d543a8c1d47e68751da00def2697c" relationshipRef="id-3d55bc711a11449592ef575f1bac55f9" xsi:type="Relationship" source="id-c0862728d96b44709551ec42c90d1806" target="id-26a9379879b549cca32ef32408afe698">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-0285476970684f0d8873083448acdac8" relationshipRef="id-fc89fbdf1b2e4d8884dbcca370d01424" xsi:type="Relationship" source="id-205d362d23ed4b86a688b7b4ccc7e1a7" target="id-26a9379879b549cca32ef32408afe698">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-00b3b89c60814619891afc5a9603fae9" relationshipRef="id-a32f1e7d20d848c0b265b46c8f372f24" xsi:type="Relationship" source="id-f55b9b27c8954307ba8feaef1719e2e4" target="id-26a9379879b549cca32ef32408afe698">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-f03808781d6040b7989085a534b8eab4" xsi:type="Diagram">
+        <name xml:lang="es">Figure29_BusinessProcessCooperation_Convering-Order-to-Contract</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/6/4</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-a5f4fe69afa24dbf965134b14e637803" xsi:type="Label" x="276" y="12" w="589" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-6a20a06781194d36a007fe6e711c2c86" xsi:type="Label" x="815" y="564" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-260462d8293b448ba91081a554320a30" elementRef="id-1ddb1228062a4a1997ec7e977f7f4e3d" xsi:type="Element" x="1116" y="315" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-628dbe7ad5634533acf72f45ede4cec6" elementRef="id-185e92e049434c4f954cc9b68957879f" xsi:type="Element" x="0" y="315" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-f519565a9111430d94a20f4bb5739fdb" elementRef="id-66ed398ab28e442ea5516dd44cdc0a49" xsi:type="Element" x="948" y="315" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-edcb8c426cd84ef9b665cac2a7b97b26" elementRef="id-b0f8301b5a2744279cb027be12751c25" xsi:type="Element" x="439" y="252" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-dc5a8e852edd40cebf39cf76595e0bcb" elementRef="id-2ec461c4dfd9428985b462c120b0fb79" xsi:type="Element" x="696" y="315" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-416b7291ff034bcbb2073e34328b9424" elementRef="id-53efc358b55540f0a4d75652777c457d" xsi:type="Element" x="168" y="315" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-6aaff88986e044b6a9a3a4ad86debb98" elementRef="id-dfc0afa8475c4f559f13403e85a7f08e" xsi:type="Element" x="420" y="336" w="157" h="217">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-35945b483a804ce49df79422e4c63a13" elementRef="id-5f2f67e939914b59905c8b33282320ef" xsi:type="Element" x="444" y="367" w="91" h="30">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-c4e5478cdcf741d58d012a5acba23fa1" elementRef="id-ffae0a20ba5a4960b55d50ff0b15dd68" xsi:type="Element" x="444" y="492" w="91" h="30">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-72570bd6ec09476e881bf075f6a4873f" elementRef="id-5360e04f3f2b4d858aaaf6229e79b09a" xsi:type="Element" x="444" y="432" w="91" h="30">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-8b741bf161ba4e2abc3a06e3fe69f62d" elementRef="id-0c7864041e1546d38b8f0cef3bb638ab" xsi:type="Element" x="358" y="335" w="15" h="15">
+          <style>
+            <fillColor r="0" g="0" b="0" a="100" />
+            <lineColor r="0" g="0" b="0" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-8e24137f94464dc9bd84324a3a7717fe" elementRef="id-72b88e880fe74bc1b6c30caa12640289" xsi:type="Element" x="629" y="335" w="15" h="15">
+          <style>
+            <fillColor r="0" g="0" b="0" a="100" />
+            <lineColor r="0" g="0" b="0" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-7c69fc0122204a8eb3c141fb4c1eaa18" elementRef="id-e0af5fde22f148fd830c3b8f62c44038" xsi:type="Element" x="439" y="96" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-ffef8900005444c0a621becde50b5ef8" elementRef="id-5af8778d34c44cac8d30b4736484ff53" xsi:type="Element" x="948" y="96" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-e95b3d6e27bd46cdb7d882e16555197a" elementRef="id-569bfe90e09e4c4ea87799bb9cf23274" xsi:type="Element" x="264" y="432" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-56b625f50169428785190a123e33254e" elementRef="id-d15443baa07a4291a075f402917fe007" xsi:type="Element" x="168" y="96" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-22d076e1730b4392be52671cbe653a27" elementRef="id-8737a76acd9c4d1fbb2a4ffc86cb2993" xsi:type="Element" x="624" y="84" w="277" h="154">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-58ccd932521b4fb1b7defdaef78815fe" elementRef="id-0cedc365b4d4417f9d2a45c1f7cd5e12" xsi:type="Element" x="636" y="108" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-cc17ee1c9fd54b03bc71de259170a19d" elementRef="id-946bfea9e17e42aa8f0184f2ef94b6f1" xsi:type="Element" x="636" y="168" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-0e715b7a6bbf4008b7339322de24f741" elementRef="id-1ae1d77701f5419eae23f0ce50730604" xsi:type="Element" x="767" y="168" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-22de1a52c8504677901d349599116bf5" elementRef="id-cdda390a32864677a1dfe234de530add" xsi:type="Element" x="767" y="108" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-0ff5b577415a489cb692757bd6fcc511" elementRef="id-9a865b3c106b4c5cb4800029ac3d54a7" xsi:type="Element" x="168" y="576" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-77aec1ff7fe1439ab5e4885848de01e0" elementRef="id-8dd7f9e048c54837a99fdc6dc101ff29" xsi:type="Element" x="439" y="576" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-bf1732df31864bc696107d97cda3e46c" relationshipRef="id-646d97276df34c37b377c908186bd107" xsi:type="Relationship" source="id-628dbe7ad5634533acf72f45ede4cec6" target="id-416b7291ff034bcbb2073e34328b9424">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-1bb34dc6e69946ed9dcc483ba709962a" relationshipRef="id-ad1e7e9f59954f18bf4803a1a0027669" xsi:type="Relationship" source="id-f519565a9111430d94a20f4bb5739fdb" target="id-260462d8293b448ba91081a554320a30">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-e533b7d5efae4dd8888de6da383c0316" relationshipRef="id-404aaef8afbd4c8cac91b3e7ce7e87fe" xsi:type="Relationship" source="id-edcb8c426cd84ef9b665cac2a7b97b26" target="id-8e24137f94464dc9bd84324a3a7717fe">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="636" y="288" />
+        </connection>
+        <connection identifier="id-2265abed38604555aec15aefac4cd1dc" relationshipRef="id-f2cd0f5cead94ed68cd27bf318a265a5" xsi:type="Relationship" source="id-dc5a8e852edd40cebf39cf76595e0bcb" target="id-f519565a9111430d94a20f4bb5739fdb">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-3c3c69109390452094844e3f72661809" relationshipRef="id-3c25d67261064ea28e199fe9a0b85f85" xsi:type="Relationship" source="id-416b7291ff034bcbb2073e34328b9424" target="id-8b741bf161ba4e2abc3a06e3fe69f62d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-cf444542338d4902bec17441a107ac52" relationshipRef="id-d416fcebaa42472d9eb4fbcbd17d6a56" xsi:type="Relationship" source="id-6aaff88986e044b6a9a3a4ad86debb98" target="id-8e24137f94464dc9bd84324a3a7717fe">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="636" y="480" />
+        </connection>
+        <connection identifier="id-d00d6f4a9fd34ef98d0545ed915659ce" relationshipRef="id-c2a8d9d9318d41549037025d71599ee7" xsi:type="Relationship" source="id-35945b483a804ce49df79422e4c63a13" target="id-72570bd6ec09476e881bf075f6a4873f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a0bb5bfe9708451aa7fb87c61bb27473" relationshipRef="id-c8a8d78b65a84ccbb6dfbfafb7b1d8d2" xsi:type="Relationship" source="id-35945b483a804ce49df79422e4c63a13" target="id-c4e5478cdcf741d58d012a5acba23fa1">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="552" y="384" />
+          <bendpoint x="552" y="504" />
+        </connection>
+        <connection identifier="id-523a9a75f4704fa9b1401186030c8795" relationshipRef="id-d22a15e338ce4844866d59025d1bd167" xsi:type="Relationship" source="id-c4e5478cdcf741d58d012a5acba23fa1" target="id-72570bd6ec09476e881bf075f6a4873f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-0db91bcb96fe4807bc35f584237307ab" relationshipRef="id-dcd4c81485474c4a8a58d0bc320d56fe" xsi:type="Relationship" source="id-8b741bf161ba4e2abc3a06e3fe69f62d" target="id-6aaff88986e044b6a9a3a4ad86debb98">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="372" y="408" />
+        </connection>
+        <connection identifier="id-8cc6c24081844fe3beea94d0ca479788" relationshipRef="id-a74df18bcb2747a4a9e879dcb6b0820e" xsi:type="Relationship" source="id-8b741bf161ba4e2abc3a06e3fe69f62d" target="id-edcb8c426cd84ef9b665cac2a7b97b26">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <bendpoint x="372" y="288" />
+        </connection>
+        <connection identifier="id-6a90e4f659244b3eb16c8c7f21af45ab" relationshipRef="id-17e42d417d1f4e609a0b754630811877" xsi:type="Relationship" source="id-8e24137f94464dc9bd84324a3a7717fe" target="id-dc5a8e852edd40cebf39cf76595e0bcb">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-1db6f24e655443539286b76bec53edc3" relationshipRef="id-1d71a1527dbe4fb5b8a2eb3365ace3b0" xsi:type="Relationship" source="id-7c69fc0122204a8eb3c141fb4c1eaa18" target="id-edcb8c426cd84ef9b665cac2a7b97b26">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-398dd9e8e47b433ba79faf9c17d2faf1" relationshipRef="id-4d22767cc0e74f62b7ea0425e51bb1b7" xsi:type="Relationship" source="id-ffef8900005444c0a621becde50b5ef8" target="id-f519565a9111430d94a20f4bb5739fdb">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-2a63b11668854167ab24f64b485a85e1" relationshipRef="id-3cb2acbc8d374c47879d879a27ec69e6" xsi:type="Relationship" source="id-e95b3d6e27bd46cdb7d882e16555197a" target="id-6aaff88986e044b6a9a3a4ad86debb98">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-b523709085dc48daa7a3c7996bbba78d" relationshipRef="id-f6989aa63ab24e2bb69cb321699de3af" xsi:type="Relationship" source="id-56b625f50169428785190a123e33254e" target="id-416b7291ff034bcbb2073e34328b9424">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-d0da3c111f484ee09a7e20277b6157c5" relationshipRef="id-13bca28e98274e7787dab6fbff0b7fcc" xsi:type="Relationship" source="id-22d076e1730b4392be52671cbe653a27" target="id-dc5a8e852edd40cebf39cf76595e0bcb">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-45bf74a8ce024823ad2963e4ca727d05" relationshipRef="id-0b96fb0d0e9941529d2f6c18b3561dec" xsi:type="Relationship" source="id-0ff5b577415a489cb692757bd6fcc511" target="id-416b7291ff034bcbb2073e34328b9424">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a46faeee863246ffac129438882644ea" relationshipRef="id-f4cf9ae4b5b04c83b7ac68e8a7499459" xsi:type="Relationship" source="id-77aec1ff7fe1439ab5e4885848de01e0" target="id-6aaff88986e044b6a9a3a4ad86debb98">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a2787ce3f15647cd9c5936298f760108" relationshipRef="id-ffce88df12ee4b758bf1850598c844b0" xsi:type="Relationship" source="id-77aec1ff7fe1439ab5e4885848de01e0" target="id-0ff5b577415a489cb692757bd6fcc511">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-06ed635edfdf43a1af8d9c037507258c" xsi:type="Diagram">
+        <name xml:lang="es">Figure30_BusinessProcessCooperation_Fulfill-Order</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/6/4</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-b2b36b195fed44a6bbfc04381d555464" xsi:type="Label" x="204" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-589d14f9f1fd4c08ba1114fd10c1085e" xsi:type="Label" x="564" y="348" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-f24ed6ddb97248e49f6561b9bb563810" elementRef="id-1ddb1228062a4a1997ec7e977f7f4e3d" xsi:type="Element" x="24" y="168" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-f5e4290d256d4698924d5694ac03c61f" elementRef="id-4b13dd7b55374db8846d4660064beefd" xsi:type="Element" x="377" y="264" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-67b576e61f6b48238725ddb5fff6873d" elementRef="id-434f18b593744f43914399d59d52b4e2" xsi:type="Element" x="344" y="168" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-b6e7dc0459914b4395006b7fe969134c" elementRef="id-d6fd3df3ae0b4a56b96f5d22d1293f91" xsi:type="Element" x="180" y="168" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-4b9cfba910474d9d81f97987e3be216c" elementRef="id-a33fd073b4ba4e508cbe3ab2dd3ebc6a" xsi:type="Element" x="684" y="168" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-f82617923a5e4b0089468c46d50bed24" elementRef="id-e09baac983c64a8abf359b5ead3f2b26" xsi:type="Element" x="516" y="168" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-c1c36fa4322248a18d60e13b67510e32" elementRef="id-8dd7f9e048c54837a99fdc6dc101ff29" xsi:type="Element" x="180" y="264" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-1ec2955b688a4cc1ab100e276bde4e13" elementRef="id-ad64cacb19e34896829b2a462615fd7b" xsi:type="Element" x="178" y="76" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-7a9ffd5cf24d47fb894ab32b934639a5" elementRef="id-3b89b7e81d7d4052affd44601b6e7a83" xsi:type="Element" x="346" y="76" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-c7264224ffca4355a5ed6545ab724ddd" elementRef="id-569bfe90e09e4c4ea87799bb9cf23274" xsi:type="Element" x="516" y="76" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-23cf5048097d480eb630d5a9c7edf04d" relationshipRef="id-e4fca00046234778adc85086d0dae34c" xsi:type="Relationship" source="id-f24ed6ddb97248e49f6561b9bb563810" target="id-b6e7dc0459914b4395006b7fe969134c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-515bf561ac2a4e348c474e9ac79af467" relationshipRef="id-cd2051d687f246eb88bd29a38cc4d43d" xsi:type="Relationship" source="id-67b576e61f6b48238725ddb5fff6873d" target="id-f5e4290d256d4698924d5694ac03c61f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-6133e9babf0447a4840d28de325dc2bb" relationshipRef="id-4dc192fea4d348b0a4011f793a5a83ba" xsi:type="Relationship" source="id-67b576e61f6b48238725ddb5fff6873d" target="id-f82617923a5e4b0089468c46d50bed24">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-751ba889584f4fd5b1f04095ae3e4f04" relationshipRef="id-5ef40b745ffe400cbe17fc3086b8179b" xsi:type="Relationship" source="id-b6e7dc0459914b4395006b7fe969134c" target="id-67b576e61f6b48238725ddb5fff6873d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-60aab6095b874605b5567ca484d914d2" relationshipRef="id-d771d69f102e4b0e9f2fcb044a0a2910" xsi:type="Relationship" source="id-f82617923a5e4b0089468c46d50bed24" target="id-4b9cfba910474d9d81f97987e3be216c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-d4b1d49121ef4de08abf59b132e2b4dc" relationshipRef="id-592d5a0e9516450baefeb2fb60880cdf" xsi:type="Relationship" source="id-c1c36fa4322248a18d60e13b67510e32" target="id-b6e7dc0459914b4395006b7fe969134c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-5f08e0d75dbc4e379ed0b7efc83e3122" relationshipRef="id-56c77f2ad63746b8a4462aab26b0828a" xsi:type="Relationship" source="id-c1c36fa4322248a18d60e13b67510e32" target="id-67b576e61f6b48238725ddb5fff6873d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-71732f7965584990ba248a7c5a3c78b1" relationshipRef="id-8383478607a84e87a7f1ce4e435c7665" xsi:type="Relationship" source="id-1ec2955b688a4cc1ab100e276bde4e13" target="id-b6e7dc0459914b4395006b7fe969134c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-c658fd9100784132a2adbbc34297a2e9" relationshipRef="id-e7bcaba7d8e8473e8d9274c6819e6831" xsi:type="Relationship" source="id-7a9ffd5cf24d47fb894ab32b934639a5" target="id-67b576e61f6b48238725ddb5fff6873d">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-fac6b7333f2e4824967fdce60d4c1573" relationshipRef="id-f33b67e9b6d6410fb7ecf59859619c44" xsi:type="Relationship" source="id-c7264224ffca4355a5ed6545ab724ddd" target="id-f82617923a5e4b0089468c46d50bed24">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-184871b742bc4757b24d2d07c016d702" xsi:type="Diagram">
+        <name xml:lang="es">Figure31_Business-Process-View</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/6/4</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-068cb51a01944be4b953d93c370ac748" xsi:type="Label" x="240" y="24" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-9acd4699f5e94fa4a4f3f1c52818786f" xsi:type="Label" x="725" y="372" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-519ca1094ebe4e659aad2027074f56fe" elementRef="id-d750071fabad4b9498b391c0439ad8a9" xsi:type="Element" x="816" y="192" w="120" h="71">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-d127bc43ebfd448abaa9112cb35734ab" elementRef="id-d004969cca104c28b670b1df84895480" xsi:type="Element" x="228" y="192" w="120" h="71">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-719cff44b277407d8840e1db7317e6bb" elementRef="id-abb6ad8f13864cdd9a545391293aac2f" xsi:type="Element" x="24" y="192" w="120" h="71">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-96437c9c9e054a3d8636305e355cd158" elementRef="id-6bff6aab31d24eafb56cc8d19c39a349" xsi:type="Element" x="624" y="192" w="120" h="71">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-d238886bb0da43369c34573a5d749d06" elementRef="id-7f6504f22c8341f98fbb7a8f2040fb86" xsi:type="Element" x="432" y="192" w="120" h="71">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-4a06305e89484ab898c035a088442e23" elementRef="id-fde9a2a74e544857bcdcd5c127214475" xsi:type="Element" x="127" y="81" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-d643f2e5368c4ef0bf2c6db875f91ef5" elementRef="id-6547822784014590b1f6ce403d11dab6" xsi:type="Element" x="341" y="81" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-bb22c6cbb8f645e9a0964b682128fac8" elementRef="id-76fccb108cf0417894987ca3241ac9da" xsi:type="Element" x="540" y="81" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-c1d753a169ac4a6b99201a895eec43c4" elementRef="id-2915da9943da4ffd8ce7db5f564b8560" xsi:type="Element" x="732" y="81" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-7e6d05746dd342eb98d2dbcf93f846c5" elementRef="id-41f5b1884333497abc39d31394864829" xsi:type="Element" x="120" y="300" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-8d12d72e3275414e906d7a99ce039ba5" elementRef="id-c70aca3eba1040fc8561439d8b0f4bc5" xsi:type="Element" x="341" y="300" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-af293b4c16ed4c84809cb834d90d2b6f" elementRef="id-251afb2b14b44e369b91879e8be1a7b2" xsi:type="Element" x="521" y="300" w="170" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-c329543253874867992dcb5e6b12a5e8" elementRef="id-c5ae1afc36664d8c8b6f17c160aa6369" xsi:type="Element" x="725" y="300" w="170" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <connection identifier="id-88341440593244068bc49606a62ba3ed" relationshipRef="id-f885506aa5544949910befeb7b8102c0" xsi:type="Relationship" source="id-519ca1094ebe4e659aad2027074f56fe" target="id-c329543253874867992dcb5e6b12a5e8">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-57d4d8e3d9a4403ebc610db6e1a2f1fc" relationshipRef="id-e0fcfbc217c14d4fafb63d2d585286a2" xsi:type="Relationship" source="id-519ca1094ebe4e659aad2027074f56fe" target="id-c1d753a169ac4a6b99201a895eec43c4">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-4279581e83af4107991cf1b519a583bc" relationshipRef="id-dfcfc71085c744dbab682a888185d405" xsi:type="Relationship" source="id-d127bc43ebfd448abaa9112cb35734ab" target="id-7e6d05746dd342eb98d2dbcf93f846c5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-1608bd60b25e4b13b4abd3698e13080b" relationshipRef="id-bf5d0980823b459582f7b7f2ca9ff866" xsi:type="Relationship" source="id-d127bc43ebfd448abaa9112cb35734ab" target="id-8d12d72e3275414e906d7a99ce039ba5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a0a69a7cb4484508adf8334851e81044" relationshipRef="id-e9086fe91ef3456fae5053977c81b421" xsi:type="Relationship" source="id-d127bc43ebfd448abaa9112cb35734ab" target="id-d643f2e5368c4ef0bf2c6db875f91ef5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-35702889d42a4a0a97c7d067c9267717" relationshipRef="id-07c3811485f74e0491fb790e4fae8639" xsi:type="Relationship" source="id-d127bc43ebfd448abaa9112cb35734ab" target="id-4a06305e89484ab898c035a088442e23">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-994df2d454934dd4b9bb58f4ba5ea450" relationshipRef="id-2b49f5e3aa1f4a33b2bf2d4da8d1ecc0" xsi:type="Relationship" source="id-719cff44b277407d8840e1db7317e6bb" target="id-7e6d05746dd342eb98d2dbcf93f846c5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-2b87ea0351504babb4ac8144d734b1b1" relationshipRef="id-c72cba963ef54e938eaa447bc2a20577" xsi:type="Relationship" source="id-719cff44b277407d8840e1db7317e6bb" target="id-4a06305e89484ab898c035a088442e23">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-1a24dadca3c445dbaba573560daf088a" relationshipRef="id-1c200b633efb4e7c849cb0b24a16d656" xsi:type="Relationship" source="id-96437c9c9e054a3d8636305e355cd158" target="id-af293b4c16ed4c84809cb834d90d2b6f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-6906294c845849178dc17c2470c6a34d" relationshipRef="id-99869d8bdfac48688f90c48d7148b4b2" xsi:type="Relationship" source="id-96437c9c9e054a3d8636305e355cd158" target="id-c329543253874867992dcb5e6b12a5e8">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-172bceba7a3f430684337f69c34405bd" relationshipRef="id-19891cec3a20492d8f877fb5bae3dbb9" xsi:type="Relationship" source="id-96437c9c9e054a3d8636305e355cd158" target="id-c1d753a169ac4a6b99201a895eec43c4">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-eed21fbd6b51400bb59599786268e88a" relationshipRef="id-740a7f4e522a452c948d454e0a811794" xsi:type="Relationship" source="id-96437c9c9e054a3d8636305e355cd158" target="id-bb22c6cbb8f645e9a0964b682128fac8">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-005d44ae62c34aeebae20113e4b040ce" relationshipRef="id-541d8ad87ec54da8b06ddbdb6ff32e15" xsi:type="Relationship" source="id-d238886bb0da43369c34573a5d749d06" target="id-8d12d72e3275414e906d7a99ce039ba5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-74862be1f26e4752aee7f2bf57aef9ee" relationshipRef="id-58641959b27249948876585f234324fa" xsi:type="Relationship" source="id-d238886bb0da43369c34573a5d749d06" target="id-af293b4c16ed4c84809cb834d90d2b6f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-f9ba2c98096e47eaa6047ed42ff75441" relationshipRef="id-e81b2399c4e64971be60ada42c619c0f" xsi:type="Relationship" source="id-d238886bb0da43369c34573a5d749d06" target="id-bb22c6cbb8f645e9a0964b682128fac8">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-dc1487b34dce43e19c3919004812b336" relationshipRef="id-0739c23ade8a4fdf99d727faae31b258" xsi:type="Relationship" source="id-d238886bb0da43369c34573a5d749d06" target="id-d643f2e5368c4ef0bf2c6db875f91ef5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-d395811f0d8647d185cd5be13cdd916f" xsi:type="Diagram">
+        <name xml:lang="es">Figure32_Information-Structure-View</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023/6/5</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-1443d07b6841453888a7faed9d58c04b" xsi:type="Label" x="156" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-64a8c0360a66456687a1d6edfd76b2a2" xsi:type="Label" x="708" y="19" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-8ba41157677741d0b62bb923e78934ab" x="108" y="60" w="217" h="920" xsi:type="Container">
+          <label xml:lang="es">Instructions from ERP System</label>
+          <style>
+            <fillColor r="210" g="215" b="215" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-0b70b759dfcf4fba8c058b99d55d885e" elementRef="id-d908916d313d4fac9b2a6cd132eaf4c6" xsi:type="Element" x="152" y="320" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-93775a833470411abecade4ccf980d27" elementRef="id-3e585eea23014b888f64de613fe21d3c" xsi:type="Element" x="133" y="632" w="158" h="97">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+            <node identifier="id-9f90d44219ce4f90ac862c1a5f8ee3b4" elementRef="id-cf388ea8144942eeb6a7d23d2fc9d9e5" xsi:type="Element" x="155" y="654" w="120" h="55">
+              <style>
+                <fillColor r="181" g="255" b="255" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+          </node>
+          <node identifier="id-6e0e8c15d67144ffac31c7930a3ffb15" elementRef="id-1c00d69a990445f7a53257a2b8a185b6" xsi:type="Element" x="130" y="831" w="158" h="97">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+            <node identifier="id-47cbee7032e54f1883d90225cf7a7cdf" elementRef="id-f32c66917de74091bdd5a9624452f2c3" xsi:type="Element" x="148" y="855" w="120" h="55">
+              <style>
+                <fillColor r="181" g="255" b="255" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+          </node>
+          <node identifier="id-4284c3cfd76a41b09002571782dade0c" elementRef="id-1c00d69a990445f7a53257a2b8a185b6" xsi:type="Element" x="133" y="200" w="158" h="97">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+            <node identifier="id-88b19c72618b437ca3b3287983f9aa9e" elementRef="id-e127038f87cb42959f5a9be4c63ac400" xsi:type="Element" x="156" y="230" w="120" h="55">
+              <style>
+                <fillColor r="181" g="255" b="255" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+          </node>
+          <node identifier="id-675232e90cbb4c8184d338be5f9085d4" elementRef="id-770e063936e4428c8107dae96d3d3cc7" xsi:type="Element" x="144" y="108" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-217fb3f892bc4cd593837cab16bf8c0f" elementRef="id-85f3e58459cf4566a8984eb0261305df" xsi:type="Element" x="133" y="410" w="158" h="97">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+            <node identifier="id-fb62db1c70434db99dfcc99c209b829e" elementRef="id-de3928a8ce2d4a0c8777d3c53213e57e" xsi:type="Element" x="151" y="439" w="120" h="55">
+              <style>
+                <fillColor r="181" g="255" b="255" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+          </node>
+          <node identifier="id-602d76a91d2748f29e9d50ac6d6074ff" elementRef="id-d3f6658ad824487fadc62b80a9709b5c" xsi:type="Element" x="160" y="547" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-3abcfbf378c64675bd1da02da99212e9" elementRef="id-d3d12d7b7e494f32a29a96499f6f66b1" xsi:type="Element" x="160" y="751" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+        </node>
+        <node identifier="id-f81e53434cb24dfaa22643c87841ab4d" x="444" y="60" w="217" h="920" xsi:type="Container">
+          <label xml:lang="es">Response from MES</label>
+          <style>
+            <fillColor r="210" g="215" b="215" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+          <node identifier="id-7c11edf7ec4341d5a685b33ba430570c" elementRef="id-e27c7d476c4f4facb9f78e3d7edd041d" xsi:type="Element" x="493" y="320" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-cbc3b4d8421d45d294236489361f448c" elementRef="id-20aa4381e31143b697919991db4db30b" xsi:type="Element" x="463" y="632" w="158" h="97">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+            <node identifier="id-8c1bf91eec6c4488bff0fff704f315f0" elementRef="id-d40e8b39852a401db024c671bc95209d" xsi:type="Element" x="485" y="658" w="120" h="55">
+              <style>
+                <fillColor r="181" g="255" b="255" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+          </node>
+          <node identifier="id-3325f6956ee847ecabd77e016f6c84bc" elementRef="id-11ccd99fca024f548aa717079047a2d6" xsi:type="Element" x="504" y="108" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-960d71ac2cbd45fb940c7c178299e1f4" elementRef="id-08c08f4c8e6a4a50b14e523530a5c14f" xsi:type="Element" x="484" y="747" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-ca7920a8ae854e8d8092d58292325ad1" elementRef="id-f1f36d4abf914d598a9b032762310b30" xsi:type="Element" x="474" y="200" w="158" h="97">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+            <node identifier="id-3c9772ff43144f8fa08779dd95b6be14" elementRef="id-8e6db4ddae3a41c2a7fe819cb7c140db" xsi:type="Element" x="492" y="232" w="120" h="55">
+              <style>
+                <fillColor r="181" g="255" b="255" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+          </node>
+          <node identifier="id-1af9b1c68aff463fb31b73275538148e" elementRef="id-0b43aa7ad1e34ecfac49e9107b204ed6" xsi:type="Element" x="463" y="410" w="158" h="97">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+            <node identifier="id-65ceda64feb141e6a1cd149b82efcdb7" elementRef="id-54d1145720594f2784b21ce4e4ca0ed0" xsi:type="Element" x="487" y="434" w="120" h="55">
+              <style>
+                <fillColor r="181" g="255" b="255" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+          </node>
+          <node identifier="id-86efacb528584d59bf85194279b7c6f5" elementRef="id-3748eb9ccc5844c8832b299b26ce3eea" xsi:type="Element" x="482" y="547" w="120" h="55">
+            <style>
+              <fillColor r="255" g="255" b="181" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+          </node>
+          <node identifier="id-5d483708e3a541f8a36f33607e7973ac" elementRef="id-f1f36d4abf914d598a9b032762310b30" xsi:type="Element" x="460" y="832" w="158" h="97">
+            <style>
+              <fillColor r="181" g="255" b="255" a="100" />
+              <lineColor r="92" g="92" b="92" a="100" />
+              <font name="Lucida Grande" size="12">
+                <color r="0" g="0" b="0" />
+              </font>
+            </style>
+            <node identifier="id-982297590a464f95b5d956223cfea06d" elementRef="id-89f4b36253eb49fcbf5f75119cf5ff24" xsi:type="Element" x="481" y="861" w="120" h="55">
+              <style>
+                <fillColor r="181" g="255" b="255" a="100" />
+                <lineColor r="92" g="92" b="92" a="100" />
+                <font name="Lucida Grande" size="12">
+                  <color r="0" g="0" b="0" />
+                </font>
+              </style>
+            </node>
+          </node>
+        </node>
+        <connection identifier="id-307d41370c49486492bffff06e5f444e" relationshipRef="id-9804e1a77131460abc8ea27bc843599e" xsi:type="Relationship" source="id-0b70b759dfcf4fba8c058b99d55d885e" target="id-7c11edf7ec4341d5a685b33ba430570c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-10a10c768c1a40b6b141ec6187248b1a" relationshipRef="id-179a424cd7c742fe80ed7b2c9f2c941b" xsi:type="Relationship" source="id-93775a833470411abecade4ccf980d27" target="id-602d76a91d2748f29e9d50ac6d6074ff">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-e7e4316af2224937aa831c53410313d6" relationshipRef="id-653a6be49b1f4b3e80dc7899b44bf46e" xsi:type="Relationship" source="id-6e0e8c15d67144ffac31c7930a3ffb15" target="id-3abcfbf378c64675bd1da02da99212e9">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-636746134b6b44e2b82da666ac0fecba" relationshipRef="id-2027668953494b6daf40f1f55cbc8cf5" xsi:type="Relationship" source="id-4284c3cfd76a41b09002571782dade0c" target="id-675232e90cbb4c8184d338be5f9085d4">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-4a55137852b048f4812c91724954346e" relationshipRef="id-d7bd0e004f454d72a881e2390fe30424" xsi:type="Relationship" source="id-675232e90cbb4c8184d338be5f9085d4" target="id-3325f6956ee847ecabd77e016f6c84bc">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-a9a96b988e5b4ba394c4f0142ed51443" relationshipRef="id-f9fdf0fb20234c39949eed2dbe14ca39" xsi:type="Relationship" source="id-217fb3f892bc4cd593837cab16bf8c0f" target="id-0b70b759dfcf4fba8c058b99d55d885e">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-899e826b50a74ec1bcfd5704a5eb41ed" relationshipRef="id-e3f67792b2554a57b680763dfdea4f2e" xsi:type="Relationship" source="id-602d76a91d2748f29e9d50ac6d6074ff" target="id-86efacb528584d59bf85194279b7c6f5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-9641a4b706574ce59782e3ad6244fb20" relationshipRef="id-301460d307144c8faa0bbf2d5b49910a" xsi:type="Relationship" source="id-3abcfbf378c64675bd1da02da99212e9" target="id-960d71ac2cbd45fb940c7c178299e1f4">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-efa691e0eb5c4690bdc9ed6c4af137c4" relationshipRef="id-aab4f269e6854079a2702641a2eef4b4" xsi:type="Relationship" source="id-cbc3b4d8421d45d294236489361f448c" target="id-86efacb528584d59bf85194279b7c6f5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-823ef275ce90479886103bb093f2753e" relationshipRef="id-c15f7da617cc4414b798c92b65e0f219" xsi:type="Relationship" source="id-ca7920a8ae854e8d8092d58292325ad1" target="id-3325f6956ee847ecabd77e016f6c84bc">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-5fbb4eed44b74e49b1d57529065697c5" relationshipRef="id-d0e38b9cc8ab452883a8e1382493b148" xsi:type="Relationship" source="id-1af9b1c68aff463fb31b73275538148e" target="id-7c11edf7ec4341d5a685b33ba430570c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+        <connection identifier="id-d0c1b4605a3c4b96b73a020a6115e10b" relationshipRef="id-0809459150ae416a80b97004e2c1918d" xsi:type="Relationship" source="id-5d483708e3a541f8a36f33607e7973ac" target="id-960d71ac2cbd45fb940c7c178299e1f4">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-8ad6c4933f22487281a2e3a873c32dee" xsi:type="Diagram">
+        <name xml:lang="es">Default View</name>
+        <properties>
+          <property propertyDefinitionRef="propid-1">
+            <value xml:lang="es">2023-05-19</value>
+          </property>
+          <property propertyDefinitionRef="propid-2">
+            <value xml:lang="es">Xiaoqi Zhao</value>
+          </property>
+        </properties>
+        <node identifier="id-c1cfb014a27c423d98a0c7127a60c480" xsi:type="Label" x="204" y="12" w="466" h="37">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Segoe UI" size="12" style="bold">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-a80601ad36b44c0d8ff64f668496834e" xsi:type="Label" x="612" y="588" w="215" h="42">
+          <style>
+            <fillColor r="255" g="255" b="255" a="100" />
+            <lineColor r="92" g="92" b="92" a="100" />
+            <font name="Lucida Grande" size="12">
+              <color r="0" g="0" b="0" />
+            </font>
+          </style>
+        </node>
+      </view>
+    </diagrams>
+  </views>
+</model>

--- a/internal/auth/enforcer.go
+++ b/internal/auth/enforcer.go
@@ -43,9 +43,12 @@ func NewEnforcer(db *sql.DB, cfg *Config) (*Enforcer, error) {
 	return &Enforcer{e: e}, nil
 }
 
-// seedPolicy writes the default role hierarchy and resource policies.
-// It is idempotent — Casbin skips duplicates automatically.
+// seedPolicy rewrites the complete policy set from scratch on every startup.
+// This ensures stale policies (e.g. from a previous matcher syntax) are removed.
 func seedPolicy(e *casbinv2.Enforcer) error {
+	// Wipe everything stored, then rebuild from the canonical definition below.
+	e.ClearPolicy()
+
 	// Role hierarchy: admin > architect > viewer
 	roleHierarchy := [][2]string{
 		{"admin", "architect"},
@@ -57,18 +60,28 @@ func seedPolicy(e *casbinv2.Enforcer) error {
 		}
 	}
 
-	// Policies: (role, resource_glob, action)
+	// Policies: (role, resource_pattern, action)
+	// Uses keyMatch2 syntax: :param matches exactly one path segment.
+	// Multiple patterns cover varying nesting depths.
 	policies := [][3]string{
-		// admin can do everything
-		{"admin", "/api/v1/*", "*"},
+		// admin can do everything under /api/v1 (up to 4 segments deep)
+		{"admin", "/api/v1/:p1", "*"},
+		{"admin", "/api/v1/:p1/:p2", "*"},
+		{"admin", "/api/v1/:p1/:p2/:p3", "*"},
+		{"admin", "/api/v1/:p1/:p2/:p3/:p4", "*"},
 
-		// architect: full read+write on workspace resources, no user mgmt
+		// architect: full read+write on workspace resources, no user management
 		{"architect", "/api/v1/workspaces", "GET"},
-		{"architect", "/api/v1/workspaces/*", "*"},
+		{"architect", "/api/v1/workspaces/:id", "*"},
+		{"architect", "/api/v1/workspaces/:id/:sub", "*"},
+		{"architect", "/api/v1/workspaces/:id/:sub/:p1", "*"},
+		{"architect", "/api/v1/workspaces/:id/:sub/:p1/:p2", "*"},
 
 		// viewer: read-only on workspaces
 		{"viewer", "/api/v1/workspaces", "GET"},
-		{"viewer", "/api/v1/workspaces/*", "GET"},
+		{"viewer", "/api/v1/workspaces/:id", "GET"},
+		{"viewer", "/api/v1/workspaces/:id/:sub", "GET"},
+		{"viewer", "/api/v1/workspaces/:id/:sub/:p1", "GET"},
 	}
 	for _, p := range policies {
 		if _, err := e.AddPolicy(p[0], p[1], p[2]); err != nil {

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -143,12 +143,25 @@ func (svc *Service) handleOIDCCallback(oidc *OIDCProvider) http.HandlerFunc {
 
 		u, err := svc.Users.GetByEmail(email)
 		if err == ErrNotFound {
-			// First OIDC login — provision with viewer role.
-			u, err = svc.Users.Create(email, "", "viewer")
+			// First OIDC login — assign admin if email matches bootstrap config,
+			// otherwise provision as viewer.
+			role := "viewer"
+			if svc.Cfg.BootstrapEmail != "" && email == svc.Cfg.BootstrapEmail {
+				role = "admin"
+			}
+			u, err = svc.Users.Create(email, "", role)
 		}
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "user lookup failed")
 			return
+		}
+
+		// If the bootstrap admin logs in via OIDC and was previously provisioned
+		// as viewer (e.g. before bootstrap config was set), promote to admin.
+		if svc.Cfg.BootstrapEmail != "" && email == svc.Cfg.BootstrapEmail && u.Role != "admin" {
+			if err := svc.Users.UpdateRole(u.ID.String(), "admin"); err == nil {
+				u.Role = "admin"
+			}
 		}
 
 		token, err := IssueToken(svc.Cfg, u.ID.String(), u.Email, u.Role)

--- a/internal/auth/rbac_model.conf
+++ b/internal/auth/rbac_model.conf
@@ -11,4 +11,4 @@ g = _, _
 e = some(where (p.eft == allow))
 
 [matchers]
-m = g(r.sub, p.sub) && keyMatch(r.obj, p.obj) && (r.act == p.act || p.act == "*")
+m = g(r.sub, p.sub) && keyMatch2(r.obj, p.obj) && (r.act == p.act || p.act == "*")

--- a/internal/diagram/diagram.go
+++ b/internal/diagram/diagram.go
@@ -114,13 +114,14 @@ func (s *Store) Update(id uuid.UUID, name, documentation string, layout json.Raw
 
 // RenderNode is a node enriched with element metadata for rendering.
 type RenderNode struct {
-	ElementID   string `json:"element_id"`
-	ElementName string `json:"element_name"`
-	ElementType string `json:"element_type"`
-	X           int    `json:"x"`
-	Y           int    `json:"y"`
-	W           int    `json:"w"`
-	H           int    `json:"h"`
+	ElementID       string `json:"element_id"`
+	ParentElementID string `json:"parent_element_id,omitempty"`
+	ElementName     string `json:"element_name"`
+	ElementType     string `json:"element_type"`
+	X               int    `json:"x"`
+	Y               int    `json:"y"`
+	W               int    `json:"w"`
+	H               int    `json:"h"`
 }
 
 // RenderConnection is a connection enriched with relationship metadata.
@@ -157,11 +158,12 @@ func (s *Store) Render(diagramID uuid.UUID) (*RenderData, error) {
 	// Parse the stored layout JSON.
 	var layout struct {
 		Nodes []struct {
-			ElementID string `json:"ElementID"`
-			X         int    `json:"X"`
-			Y         int    `json:"Y"`
-			W         int    `json:"W"`
-			H         int    `json:"H"`
+			ElementID       string `json:"ElementID"`
+			ParentElementID string `json:"ParentElementID"`
+			X               int    `json:"X"`
+			Y               int    `json:"Y"`
+			W               int    `json:"W"`
+			H               int    `json:"H"`
 		} `json:"Nodes"`
 		Connections []struct {
 			RelationshipID string `json:"RelationshipID"`
@@ -251,13 +253,14 @@ func (s *Store) Render(diagramID uuid.UUID) (*RenderData, error) {
 	for _, n := range layout.Nodes {
 		meta := elemMeta[n.ElementID]
 		rd.Nodes = append(rd.Nodes, RenderNode{
-			ElementID:   n.ElementID,
-			ElementName: meta[0],
-			ElementType: meta[1],
-			X:           n.X,
-			Y:           n.Y,
-			W:           n.W,
-			H:           n.H,
+			ElementID:       n.ElementID,
+			ParentElementID: n.ParentElementID,
+			ElementName:     meta[0],
+			ElementType:     meta[1],
+			X:               n.X,
+			Y:               n.Y,
+			W:               n.W,
+			H:               n.H,
 		})
 	}
 

--- a/internal/parser/aoef.go
+++ b/internal/parser/aoef.go
@@ -119,7 +119,7 @@ func (m *aoefModel) toModel() *Model {
 			Name:          v.Name,
 			Documentation: v.Documentation,
 		}
-		collectNodes(v.Nodes, &d.Layout.Nodes)
+		collectNodes(v.Nodes, "", &d.Layout.Nodes)
 		for _, c := range v.Connections {
 			cl := ConnectionLayout{RelationshipID: c.RelationshipRef}
 			for _, bp := range c.Bendpoints {
@@ -133,18 +133,21 @@ func (m *aoefModel) toModel() *Model {
 	return out
 }
 
-// collectNodes recursively traverses nested AOEF nodes (Containers, Groups)
-// and collects only nodes that reference an element (elementRef != "").
-func collectNodes(nodes []aoefNode, out *[]NodeLayout) {
+// collectNodes recursively traverses nested AOEF nodes and collects all nodes
+// that reference an element (elementRef != ""), preserving the parent-child
+// relationship via ParentElementID.
+func collectNodes(nodes []aoefNode, parentElementID string, out *[]NodeLayout) {
 	for _, n := range nodes {
 		if n.ElementRef != "" {
 			*out = append(*out, NodeLayout{
-				ElementID: n.ElementRef,
-				X:         n.X, Y: n.Y, W: n.W, H: n.H,
+				ElementID:       n.ElementRef,
+				ParentElementID: parentElementID,
+				X:               n.X, Y: n.Y, W: n.W, H: n.H,
 			})
-		}
-		if len(n.Children) > 0 {
-			collectNodes(n.Children, out)
+			collectNodes(n.Children, n.ElementRef, out)
+		} else {
+			// Node without elementRef (pure grouping container) — pass parent through
+			collectNodes(n.Children, parentElementID, out)
 		}
 	}
 }

--- a/internal/parser/model.go
+++ b/internal/parser/model.go
@@ -50,9 +50,10 @@ type DiagramLayout struct {
 
 // NodeLayout holds the position and size of an element within a diagram.
 type NodeLayout struct {
-	ElementID string
-	X, Y      int
-	W, H      int
+	ElementID       string
+	ParentElementID string // empty if top-level node
+	X, Y            int
+	W, H            int
 }
 
 // ConnectionLayout holds the visual path of a relationship within a diagram.


### PR DESCRIPTION
## Summary

- **ArchiMate 3.2 icon set**: ~45 element types with correct shapes per the notation spec (stick figure for Actor, cylinder for Role, lollipop for Interface, notched arrow for Process, open chevron for Function, oval for Service, trigger pentagon for Event, etc.)
- **Layer color palette**: Business/amber, Application/blue, Technology/green, Motivation/violet, Strategy/gold, Implementation/rose, Physical/fuchsia
- **Custom edge rendering**: `ArchiMateEdge` component computes paths from stored bendpoints and node bounds — orthogonal routing when bendpoints are present, diagonal otherwise. Supports all ArchiMate relationship line styles (triggering, flow, association, composition, aggregation, assignment, realization, serving, access, influence, specialization)
- **SVG markers**: Global marker defs for filled-arrow, open-arrow, open-triangle, filled-diamond, open-diamond, filled-circle using `context-stroke` for color inheritance
- **ValueStreamNode**: Dedicated chevron-shaped node component
- **Bug fixes**: Nav.svelte `t.charAt` crash (misuse of `use:push` Svelte action), XY Flow edges not rendering (missing Handle components), RBAC role not assigned on SSO login path
- **Dev UX**: Vite proxy for `/api` → `localhost:8080` enables `npm run dev` against a live backend

## Test plan

- [ ] Open a diagram with Business layer elements — verify amber colors and correct icons (Actor=stick figure, Role=cylinder, Process=notched arrow, Function=open chevron, Service=oval, Event=trigger)
- [ ] Open a diagram with Application and Technology layers — verify blue/green colors and matching icons
- [ ] Verify relationship lines render with correct markers (filled arrow for Triggering, dashed+open-arrow for Access, diamond for Composition, etc.)
- [ ] Verify orthogonal routing on diagrams with bendpoints
- [ ] Verify SSO login correctly assigns user role
- [ ] Verify Nav logo click does not crash with `t.charAt` error