### PR TITLE
feat(diagrams): folder tree from AOEF organizations with split viewer

### DIFF
--- a/cmd/archipulse/ui/src/app.css
+++ b/cmd/archipulse/ui/src/app.css
@@ -123,6 +123,21 @@
     padding: 28px 32px;
     min-width: 0;
   }
+  /* Full-height fill layout — no padding, accounts for fixed sidebar */
+  .content-fill {
+    position: fixed;
+    top: var(--nav-h);
+    left: var(--sidebar-w);
+    right: 0;
+    bottom: 0;
+    display: flex;
+    overflow: hidden;
+  }
+  @media (max-width: 768px) {
+    .content-fill {
+      left: 0;
+    }
+  }
   .content-full {
     flex: 1;
     padding: 32px 28px;

--- a/cmd/archipulse/ui/src/components/diagram/FolderTree.svelte
+++ b/cmd/archipulse/ui/src/components/diagram/FolderTree.svelte
@@ -1,0 +1,51 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+
+  export let folder;
+  export let collapsed;
+  export let selectedDiagram;
+  export let depth = 0;
+
+  const dispatch = createEventDispatcher();
+
+  $: isOpen = !collapsed[folder.id];
+  $: indent = (depth + 1) * 12;
+</script>
+
+<!-- Folder row -->
+<button
+  class="w-full text-left flex items-center gap-1.5 py-1.5 text-[12px] hover:bg-muted/50 transition-colors text-foreground"
+  style="padding-left: {4 + indent}px; padding-right: 8px;"
+  onclick={() => dispatch('toggle', folder.id)}
+>
+  <span class="text-[9px] opacity-40 flex-shrink-0 transition-transform {isOpen ? '' : '-rotate-90'}">▼</span>
+  <span class="text-amber-500 flex-shrink-0 text-[13px]">📁</span>
+  <span class="truncate font-medium">{folder.name}</span>
+</button>
+
+{#if isOpen}
+  <!-- Child folders (recursive) -->
+  {#each (folder.children || []) as child}
+    <svelte:self
+      folder={child}
+      {collapsed}
+      {selectedDiagram}
+      depth={depth + 1}
+      on:toggle
+      on:select
+    />
+  {/each}
+
+  <!-- Diagrams in this folder -->
+  {#each (folder.diagrams || []) as d}
+    <button
+      class="w-full text-left flex items-center gap-2 py-1.5 text-[12px] hover:bg-muted/50 transition-colors
+        {selectedDiagram?.id === d.id ? 'bg-primary/10 text-primary font-medium' : 'text-foreground'}"
+      style="padding-left: {4 + indent + 12}px; padding-right: 8px;"
+      onclick={() => dispatch('select', d)}
+    >
+      <span class="text-[10px] opacity-40 flex-shrink-0">▪</span>
+      <span class="truncate">{d.name || '(unnamed)'}</span>
+    </button>
+  {/each}
+{/if}

--- a/cmd/archipulse/ui/src/components/views/DiagramView.svelte
+++ b/cmd/archipulse/ui/src/components/views/DiagramView.svelte
@@ -11,6 +11,7 @@
   import { getColor } from '../diagram/archimate-icons.js';
 
   export let params = {};
+  export let embedded = false; // true when used inside DiagramList split layout
 
   $: wsId = params.wsId;
   $: diagId = params.diagId;
@@ -168,25 +169,29 @@
   </defs>
 </svg>
 
-<div class="content h-full flex flex-col">
-  <BackButton onclick={() => push('/ws/' + wsId + '/diagrams')} label="Diagrams" />
+<div class="{embedded ? 'h-full flex flex-col' : 'content h-full flex flex-col'}">
+  {#if !embedded}
+    <BackButton onclick={() => push('/ws/' + wsId + '/diagrams')} label="Diagrams" />
+  {/if}
 
   {#if loading}
-    <div class="flex items-center gap-2 text-muted-foreground py-6">
+    <div class="flex items-center gap-2 text-muted-foreground py-6 {embedded ? 'px-4' : ''}">
       <div class="size-4 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
       Loading diagram…
     </div>
   {:else if error}
-    <div class="mt-4 text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2">
+    <div class="text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2 {embedded ? 'm-4' : 'mt-4'}">
       {error}
     </div>
   {:else if data}
-    <div class="flex items-center justify-between mb-3">
-      <h2 class="text-[15px] font-semibold">{data.name || 'Diagram'}</h2>
-      <span class="text-[11px] text-muted-foreground">{data.nodes?.length ?? 0} elements · {data.connections?.length ?? 0} connections</span>
-    </div>
+    {#if !embedded}
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="text-[15px] font-semibold">{data.name || 'Diagram'}</h2>
+        <span class="text-[11px] text-muted-foreground">{data.nodes?.length ?? 0} elements · {data.connections?.length ?? 0} connections</span>
+      </div>
+    {/if}
 
-    <div class="flex-1 border border-border rounded-lg overflow-hidden" style="background:#F8FAFC;">
+    <div class="flex-1 {embedded ? '' : 'border border-border rounded-lg'} overflow-hidden" style="background:#F8FAFC;">
       <SvelteFlow
         bind:nodes
         bind:edges

--- a/cmd/archipulse/ui/src/routes/DiagramList.svelte
+++ b/cmd/archipulse/ui/src/routes/DiagramList.svelte
@@ -1,106 +1,124 @@
 <script>
   import { onMount } from 'svelte';
-  import { push } from 'svelte-spa-router';
   import { api } from '../lib/api.js';
-  import BackButton from '../components/BackButton.svelte';
+  import DiagramView from '../components/views/DiagramView.svelte';
+  import FolderTree from '../components/diagram/FolderTree.svelte';
 
   export let params = {};
   $: wsId = params.wsId;
 
-  let diagrams = [];
+  let tree = null;   // { folders: [], diagrams: [] }
   let loading = true;
   let error = null;
-  let search = '';
 
-  $: filtered = search.trim()
-    ? diagrams.filter(d => (d.name || '').toLowerCase().includes(search.trim().toLowerCase()))
-    : diagrams;
+  let selectedDiagram = null; // { id, name }
+  let collapsed = {};         // folder.id → bool
 
-  onMount(async () => {
+  $: if (wsId) loadTree();
+
+  async function loadTree() {
+    loading = true;
+    error = null;
+    tree = null;
+    selectedDiagram = null;
+    collapsed = {};
     try {
-      const result = await api.get('/workspaces/' + wsId + '/diagrams');
-      diagrams = result || [];
+      tree = await api.get('/workspaces/' + wsId + '/diagram-tree');
     } catch (e) {
       error = e.message;
     } finally {
       loading = false;
     }
-  });
+  }
+
+  function selectDiagram(d) {
+    selectedDiagram = d;
+  }
+
+  function toggleFolder(id) {
+    collapsed[id] = !collapsed[id];
+    collapsed = { ...collapsed };
+  }
+
+  function totalDiagrams(node) {
+    let count = (node.diagrams || []).length;
+    for (const child of (node.children || [])) count += totalDiagrams(child);
+    return count;
+  }
+
+  $: total = tree ? countAll(tree) : 0;
+  function countAll(t) {
+    let n = (t.diagrams || []).length;
+    for (const f of (t.folders || [])) n += totalDiagrams(f);
+    return n;
+  }
 </script>
 
-<div class="content">
-  <BackButton onclick={() => push('/ws/' + wsId)} label="Overview" />
+<div class="content-fill">
 
-  <div class="flex items-start justify-between gap-4 mb-5">
-    <div>
-      <h1 class="text-[18px] font-semibold mb-0.5">Diagrams</h1>
-      <p class="text-[13px] text-muted-foreground">ArchiMate views imported from the model file</p>
-    </div>
-    {#if !loading && !error && diagrams.length > 0}
-      <span class="text-[12px] text-muted-foreground bg-muted border border-border rounded-full px-2.5 py-0.5 mt-1 flex-shrink-0">
-        {filtered.length} / {diagrams.length}
-      </span>
-    {/if}
-  </div>
-
-  {#if loading}
-    <div class="flex items-center gap-2 text-muted-foreground py-6">
-      <div class="size-4 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
-      Loading…
-    </div>
-  {:else if error}
-    <div class="text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2">{error}</div>
-  {:else if diagrams.length === 0}
-    <div class="text-center py-16 text-muted-foreground">
-      <div class="text-[40px] mb-3">🗂️</div>
-      <p class="text-[14px]">No diagrams found.<br>Import a model with views to see them here.</p>
-    </div>
-  {:else}
-    <div class="relative mb-4">
-      <span class="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-[14px] pointer-events-none">⌕</span>
-      <input
-        type="text"
-        bind:value={search}
-        placeholder="Search diagrams…"
-        class="w-full bg-card border border-border rounded-lg pl-8 pr-3 py-2 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-primary transition-colors"
-      />
-      {#if search}
-        <button
-          class="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground text-[16px] leading-none"
-          onclick={() => search = ''}
-        >×</button>
+  <!-- ── Left: folder tree ── -->
+  <div class="flex-shrink-0 w-72 border-r border-border flex flex-col overflow-hidden bg-card">
+    <div class="px-4 py-3 border-b border-border flex-shrink-0">
+      <h2 class="text-[13px] font-semibold text-foreground">Diagrams</h2>
+      {#if !loading && !error && tree}
+        <p class="text-[11px] text-muted-foreground mt-0.5">{total} views</p>
       {/if}
     </div>
 
-    {#if filtered.length === 0}
-      <div class="text-center py-10 text-muted-foreground">
-        <p class="text-[13px]">No diagrams match "<span class="text-foreground">{search}</span>"</p>
-      </div>
+    <div class="flex-1 overflow-y-auto py-1">
+      {#if loading}
+        <div class="flex items-center gap-2 text-muted-foreground text-[12px] px-4 py-4">
+          <div class="size-3 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
+          Loading…
+        </div>
+      {:else if error}
+        <div class="text-[12px] text-destructive px-4 py-3">{error}</div>
+      {:else if tree}
+        <!-- Root-level loose diagrams (no folder) -->
+        {#each (tree.diagrams || []) as d}
+          <button
+            class="w-full text-left flex items-center gap-2 px-4 py-1.5 text-[12px] hover:bg-muted/50 transition-colors
+              {selectedDiagram?.id === d.id ? 'bg-primary/10 text-primary font-medium' : 'text-foreground'}"
+            onclick={() => selectDiagram(d)}
+          >
+            <span class="text-[10px] opacity-40 flex-shrink-0">▪</span>
+            <span class="truncate">{d.name || '(unnamed)'}</span>
+          </button>
+        {/each}
+
+        <!-- Root-level folders -->
+        {#each (tree.folders || []) as folder}
+          <FolderTree
+            {folder}
+            {collapsed}
+            {selectedDiagram}
+            depth={0}
+            on:toggle={e => toggleFolder(e.detail)}
+            on:select={e => selectDiagram(e.detail)}
+          />
+        {/each}
+
+        {#if total === 0}
+          <div class="text-center py-8 text-muted-foreground text-[12px] px-4">
+            No diagrams found.<br>Import a model to see them here.
+          </div>
+        {/if}
+      {/if}
+    </div>
+  </div>
+
+  <!-- ── Right: diagram viewer ── -->
+  <div class="flex-1 flex flex-col overflow-hidden">
+    {#if selectedDiagram}
+      <DiagramView params={{ wsId, diagId: selectedDiagram.id }} embedded={true} />
     {:else}
-      <div class="border border-border rounded-lg overflow-hidden">
-        <table class="w-full text-[13px]">
-          <thead>
-            <tr class="border-b border-border bg-muted/40">
-              <th class="text-left px-4 py-2.5 font-medium text-muted-foreground">Name</th>
-              <th class="text-left px-4 py-2.5 font-medium text-muted-foreground w-40 hidden sm:table-cell">Source ID</th>
-            </tr>
-          </thead>
-          <tbody>
-            {#each filtered as d}
-              <tr
-                class="border-b border-border last:border-0 hover:bg-muted/30 cursor-pointer transition-colors"
-                onclick={() => push('/ws/' + wsId + '/diagrams/' + d.id)}
-                role="button"
-                tabindex="0"
-                onkeydown={e => e.key === 'Enter' && push('/ws/' + wsId + '/diagrams/' + d.id)}
-              >
-                <td class="px-4 py-3 font-medium">{d.name || '(unnamed)'}</td>
-                <td class="px-4 py-3 text-muted-foreground font-mono text-[11px] truncate max-w-[160px] hidden sm:table-cell">{d.source_id}</td>
-              </tr>
-            {/each}
-          </tbody>
-        </table>
+      <div class="flex-1 flex flex-col items-center justify-center text-muted-foreground gap-3">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" opacity="0.3">
+          <rect x="3" y="3" width="18" height="18" rx="2"/>
+          <path d="M3 9h18M9 21V9"/>
+        </svg>
+        <p class="text-[13px]">Select a diagram to view it</p>
       </div>
     {/if}
-  {/if}
+  </div>
 </div>

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -36,6 +36,7 @@ func NewRouter(db *sql.DB, svc *auth.Service, oidc *auth.OIDCProvider, static ..
 			registerElementRoutes(r, db)
 			registerRelationshipRoutes(r, db)
 			registerDiagramRoutes(r, db)
+			registerFolderRoutes(r, db)
 			registerExportRoutes(r, db)
 			registerImportRoutes(r, db)
 			registerViewerRoutes(r, db)

--- a/internal/api/folder_handler.go
+++ b/internal/api/folder_handler.go
@@ -53,7 +53,7 @@ func (h *folderHandler) diagramTree(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusInternalServerError, errorf("list folders: %w", err))
 		return
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	folders := map[string]*FolderNode{}
 	var rootFolderIDs []string
@@ -79,14 +79,14 @@ func (h *folderHandler) diagramTree(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Re-query to wire parent→child relationships (need parentID per row).
+	// Re-query to wire parent→child relationships.
 	rows2, err := h.db.Query(`
 		SELECT id, parent_id FROM diagram_folders WHERE workspace_id = $1`, wsID)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return
 	}
-	defer rows2.Close()
+	defer func() { _ = rows2.Close() }()
 	for rows2.Next() {
 		var id string
 		var parentID sql.NullString
@@ -100,7 +100,10 @@ func (h *folderHandler) diagramTree(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	_ = rows2.Close()
+	if err := rows2.Close(); err != nil {
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
 
 	// Load all diagrams with their folder assignment.
 	dRows, err := h.db.Query(`
@@ -112,7 +115,7 @@ func (h *folderHandler) diagramTree(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusInternalServerError, errorf("list diagrams: %w", err))
 		return
 	}
-	defer dRows.Close()
+	defer func() { _ = dRows.Close() }()
 
 	var rootDiagrams []DiagramLeaf
 
@@ -134,9 +137,11 @@ func (h *folderHandler) diagramTree(w http.ResponseWriter, r *http.Request) {
 			rootDiagrams = append(rootDiagrams, leaf)
 		}
 	}
-	_ = dRows.Close()
+	if err := dRows.Close(); err != nil {
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
 
-	// Build root-level response.
 	type treeResponse struct {
 		Folders  []*FolderNode `json:"folders"`
 		Diagrams []DiagramLeaf `json:"diagrams"`

--- a/internal/api/folder_handler.go
+++ b/internal/api/folder_handler.go
@@ -1,0 +1,159 @@
+package api
+
+import (
+	"database/sql"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// FolderNode is a folder in the diagram tree response.
+type FolderNode struct {
+	ID       string        `json:"id"`
+	Name     string        `json:"name"`
+	SourceID string        `json:"source_id"`
+	Children []*FolderNode `json:"children,omitempty"`
+	Diagrams []DiagramLeaf `json:"diagrams,omitempty"`
+}
+
+// DiagramLeaf is a diagram entry inside a folder.
+type DiagramLeaf struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	SourceID string `json:"source_id"`
+}
+
+type folderHandler struct {
+	db *sql.DB
+}
+
+// diagramTree returns the full folder+diagram tree for a workspace.
+func (h *folderHandler) diagramTree(w http.ResponseWriter, r *http.Request) {
+	wsID, err := uuid.Parse(chi.URLParam(r, "wsID"))
+	if err != nil {
+		respondError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	// Load all folders.
+	type dbFolder struct {
+		id       string
+		parentID *string
+		name     string
+		sourceID string
+		position int
+	}
+	rows, err := h.db.Query(`
+		SELECT id, parent_id, name, source_id, position
+		FROM diagram_folders
+		WHERE workspace_id = $1
+		ORDER BY position`, wsID)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, errorf("list folders: %w", err))
+		return
+	}
+	defer rows.Close()
+
+	folders := map[string]*FolderNode{}
+	var rootFolderIDs []string
+
+	for rows.Next() {
+		var f dbFolder
+		var parentID sql.NullString
+		if err := rows.Scan(&f.id, &parentID, &f.name, &f.sourceID, &f.position); err != nil {
+			respondError(w, http.StatusInternalServerError, err)
+			return
+		}
+		if parentID.Valid {
+			f.parentID = &parentID.String
+		}
+		node := &FolderNode{ID: f.id, Name: f.name, SourceID: f.sourceID}
+		folders[f.id] = node
+		if f.parentID == nil {
+			rootFolderIDs = append(rootFolderIDs, f.id)
+		}
+	}
+	if err := rows.Close(); err != nil {
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	// Re-query to wire parent→child relationships (need parentID per row).
+	rows2, err := h.db.Query(`
+		SELECT id, parent_id FROM diagram_folders WHERE workspace_id = $1`, wsID)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
+	defer rows2.Close()
+	for rows2.Next() {
+		var id string
+		var parentID sql.NullString
+		if err := rows2.Scan(&id, &parentID); err != nil {
+			respondError(w, http.StatusInternalServerError, err)
+			return
+		}
+		if parentID.Valid {
+			if parent, ok := folders[parentID.String]; ok {
+				parent.Children = append(parent.Children, folders[id])
+			}
+		}
+	}
+	_ = rows2.Close()
+
+	// Load all diagrams with their folder assignment.
+	dRows, err := h.db.Query(`
+		SELECT id, name, source_id, folder_id
+		FROM diagrams
+		WHERE workspace_id = $1
+		ORDER BY name`, wsID)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, errorf("list diagrams: %w", err))
+		return
+	}
+	defer dRows.Close()
+
+	var rootDiagrams []DiagramLeaf
+
+	for dRows.Next() {
+		var id, name, sourceID string
+		var folderID sql.NullString
+		if err := dRows.Scan(&id, &name, &sourceID, &folderID); err != nil {
+			respondError(w, http.StatusInternalServerError, err)
+			return
+		}
+		leaf := DiagramLeaf{ID: id, Name: name, SourceID: sourceID}
+		if folderID.Valid {
+			if folder, ok := folders[folderID.String]; ok {
+				folder.Diagrams = append(folder.Diagrams, leaf)
+			} else {
+				rootDiagrams = append(rootDiagrams, leaf)
+			}
+		} else {
+			rootDiagrams = append(rootDiagrams, leaf)
+		}
+	}
+	_ = dRows.Close()
+
+	// Build root-level response.
+	type treeResponse struct {
+		Folders  []*FolderNode `json:"folders"`
+		Diagrams []DiagramLeaf `json:"diagrams"`
+	}
+
+	roots := make([]*FolderNode, 0, len(rootFolderIDs))
+	for _, id := range rootFolderIDs {
+		roots = append(roots, folders[id])
+	}
+
+	respondJSON(w, http.StatusOK, treeResponse{
+		Folders:  roots,
+		Diagrams: rootDiagrams,
+	})
+}
+
+func registerFolderRoutes(r chi.Router, db *sql.DB) {
+	h := &folderHandler{db: db}
+	r.Get("/workspaces/{wsID}/diagram-tree", h.diagramTree)
+}

--- a/internal/api/import_handler.go
+++ b/internal/api/import_handler.go
@@ -27,6 +27,7 @@ type ImportResult struct {
 	Elements      int    `json:"elements"`
 	Relationships int    `json:"relationships"`
 	Diagrams      int    `json:"diagrams"`
+	Folders       int    `json:"folders"`
 }
 
 func (h *importHandler) importModel(w http.ResponseWriter, r *http.Request) {
@@ -157,19 +158,61 @@ func importInTx(db *sql.DB, wsID uuid.UUID, m *parser.Model) (*ImportResult, err
 		result.Relationships++
 	}
 
+	// Upsert diagram folders (parser returns them parent-first).
+	// Build a map from source_id → DB UUID for assigning folder_id to diagrams.
+	folderUUIDs := make(map[string]uuid.UUID, len(m.ViewFolders))
+	for _, f := range m.ViewFolders {
+		var parentID *uuid.UUID
+		if f.ParentID != "" {
+			if pid, ok := folderUUIDs[f.ParentID]; ok {
+				parentID = &pid
+			}
+		}
+		var id uuid.UUID
+		err := tx.QueryRow(`
+			INSERT INTO diagram_folders (workspace_id, parent_id, name, source_id, position)
+			VALUES ($1, $2, $3, $4, $5)
+			ON CONFLICT (workspace_id, source_id) DO UPDATE
+			  SET parent_id = EXCLUDED.parent_id,
+			      name      = EXCLUDED.name,
+			      position  = EXCLUDED.position
+			RETURNING id`,
+			wsID, parentID, f.Name, f.SourceID, f.Position,
+		).Scan(&id)
+		if err != nil {
+			return nil, errorf("upsert folder %q: %w", f.SourceID, err)
+		}
+		folderUUIDs[f.SourceID] = id
+		result.Folders++
+	}
+
+	// Build diagram source_id → folder_id lookup from DiagramFolders.
+	diagFolderID := make(map[string]*uuid.UUID, len(m.DiagramFolders))
+	for _, df := range m.DiagramFolders {
+		if df.FolderSourceID == "" {
+			diagFolderID[df.DiagramSourceID] = nil
+			continue
+		}
+		if fid, ok := folderUUIDs[df.FolderSourceID]; ok {
+			id := fid
+			diagFolderID[df.DiagramSourceID] = &id
+		}
+	}
+
 	for _, d := range m.Diagrams {
 		layoutJSON, err := json.Marshal(d.Layout)
 		if err != nil {
 			return nil, errorf("marshal layout for diagram %q: %w", d.ID, err)
 		}
+		folderID := diagFolderID[d.ID] // nil if no folder
 		_, err = tx.Exec(`
-			INSERT INTO diagrams (workspace_id, source_id, name, documentation, layout)
-			VALUES ($1, $2, $3, $4, $5)
+			INSERT INTO diagrams (workspace_id, source_id, name, documentation, layout, folder_id)
+			VALUES ($1, $2, $3, $4, $5, $6)
 			ON CONFLICT (workspace_id, source_id) DO UPDATE
 			  SET name = EXCLUDED.name, documentation = EXCLUDED.documentation,
-			      layout = EXCLUDED.layout,
+			      layout = EXCLUDED.layout, folder_id = EXCLUDED.folder_id,
 			      version = diagrams.version + 1, updated_at = now()`,
-			wsID, d.ID, d.Name, d.Documentation, layoutJSON)
+			wsID, d.ID, d.Name, d.Documentation, layoutJSON, folderID)
 		if err != nil {
 			return nil, errorf("upsert diagram %q: %w", d.ID, err)
 		}

--- a/internal/auth/bootstrap_test.go
+++ b/internal/auth/bootstrap_test.go
@@ -93,8 +93,8 @@ func TestBootstrapDemo_CreatesOrSyncsDemoUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetByEmail after create: %v", err)
 	}
-	if u.Role != "viewer" {
-		t.Errorf("Role: got %q, want viewer", u.Role)
+	if u.Role != "architect" {
+		t.Errorf("Role: got %q, want architect", u.Role)
 	}
 	if !auth.CheckPassword(*u.PasswordHash, "demopass") {
 		t.Error("password hash incorrect after create")

--- a/internal/diagramfolder/folder.go
+++ b/internal/diagramfolder/folder.go
@@ -1,0 +1,85 @@
+// Package diagramfolder manages the folder hierarchy for ArchiMate diagram views.
+package diagramfolder
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+var ErrNotFound = errors.New("folder not found")
+
+// Folder represents a node in the diagram folder tree.
+type Folder struct {
+	ID          uuid.UUID  `json:"id"`
+	WorkspaceID uuid.UUID  `json:"workspace_id"`
+	ParentID    *uuid.UUID `json:"parent_id,omitempty"`
+	Name        string     `json:"name"`
+	SourceID    string     `json:"source_id"`
+	Position    int        `json:"position"`
+}
+
+// Store handles persistence for diagram folders.
+type Store struct {
+	db *sql.DB
+}
+
+func NewStore(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
+// Upsert inserts or updates a folder by (workspace_id, source_id).
+// Returns the folder's UUID.
+func (s *Store) Upsert(workspaceID uuid.UUID, parentID *uuid.UUID, name, sourceID string, position int) (uuid.UUID, error) {
+	var id uuid.UUID
+	err := s.db.QueryRow(`
+		INSERT INTO diagram_folders (workspace_id, parent_id, name, source_id, position)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (workspace_id, source_id) DO UPDATE
+		  SET parent_id = EXCLUDED.parent_id,
+		      name      = EXCLUDED.name,
+		      position  = EXCLUDED.position
+		RETURNING id`,
+		workspaceID, parentID, name, sourceID, position,
+	).Scan(&id)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("upsert folder %q: %w", sourceID, err)
+	}
+	return id, nil
+}
+
+// ListByWorkspace returns all folders for a workspace (unordered — caller builds tree).
+func (s *Store) ListByWorkspace(workspaceID uuid.UUID) ([]Folder, error) {
+	rows, err := s.db.Query(`
+		SELECT id, workspace_id, parent_id, name, source_id, position
+		FROM diagram_folders
+		WHERE workspace_id = $1
+		ORDER BY position`, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("list folders: %w", err)
+	}
+	defer rows.Close()
+
+	var folders []Folder
+	for rows.Next() {
+		var f Folder
+		var parentID sql.NullString
+		if err := rows.Scan(&f.ID, &f.WorkspaceID, &parentID, &f.Name, &f.SourceID, &f.Position); err != nil {
+			return nil, fmt.Errorf("scan folder: %w", err)
+		}
+		if parentID.Valid {
+			id, _ := uuid.Parse(parentID.String)
+			f.ParentID = &id
+		}
+		folders = append(folders, f)
+	}
+	return folders, rows.Err()
+}
+
+// DeleteByWorkspace removes all folders for a workspace (used before re-import).
+func (s *Store) DeleteByWorkspace(workspaceID uuid.UUID) error {
+	_, err := s.db.Exec(`DELETE FROM diagram_folders WHERE workspace_id = $1`, workspaceID)
+	return err
+}

--- a/internal/diagramfolder/folder.go
+++ b/internal/diagramfolder/folder.go
@@ -60,7 +60,7 @@ func (s *Store) ListByWorkspace(workspaceID uuid.UUID) ([]Folder, error) {
 	if err != nil {
 		return nil, fmt.Errorf("list folders: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var folders []Folder
 	for rows.Next() {

--- a/internal/parser/aoef.go
+++ b/internal/parser/aoef.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"strings"
 )
 
 // ParseAOEF parses an ArchiMate Open Exchange Format (XML) document
@@ -25,6 +26,7 @@ type aoefModel struct {
 	Elements      []aoefElement      `xml:"elements>element"`
 	Relationships []aoefRelationship `xml:"relationships>relationship"`
 	Views         []aoefView         `xml:"views>diagrams>view"`
+	Organizations []aoefOrgItem      `xml:"organizations>item"`
 }
 
 type aoefPropertyDef struct {
@@ -81,6 +83,18 @@ type aoefPoint struct {
 	Y int `xml:"y,attr"`
 }
 
+// aoefOrgItem represents a node in <organizations>. Items with identifierRef
+// are leaves (elements or views); items with <label> and children are folders.
+type aoefOrgItem struct {
+	IdentifierRef string           `xml:"identifierRef,attr"`
+	Labels        []aoefLangString `xml:"label"`
+	Children      []aoefOrgItem    `xml:"item"`
+}
+
+type aoefLangString struct {
+	Value string `xml:",chardata"`
+}
+
 func (m *aoefModel) toModel() *Model {
 	out := &Model{Name: m.Name}
 
@@ -130,7 +144,89 @@ func (m *aoefModel) toModel() *Model {
 		out.Diagrams = append(out.Diagrams, d)
 	}
 
+	// Build view ID set for organization traversal.
+	viewIDs := make(map[string]bool, len(m.Views))
+	for _, v := range m.Views {
+		viewIDs[v.ID] = true
+	}
+
+	// Extract view folder hierarchy from <organizations>.
+	for i, org := range m.Organizations {
+		folders, diagFolders, hasViews := collectViewOrg(org, "", viewIDs, i)
+		if hasViews {
+			out.ViewFolders = append(out.ViewFolders, folders...)
+			out.DiagramFolders = append(out.DiagramFolders, diagFolders...)
+		}
+	}
+
 	return out
+}
+
+// collectViewOrg recursively traverses an organization item.
+// Returns (folders, diagramFolderAssignments, containsAnyViewRef).
+// Folders are returned in pre-order (parent before children) for safe DB insertion.
+func collectViewOrg(item aoefOrgItem, parentSourceID string, viewIDs map[string]bool, pos int) ([]ViewFolder, []DiagramFolder, bool) {
+	// Leaf: has identifierRef.
+	if item.IdentifierRef != "" {
+		if viewIDs[item.IdentifierRef] {
+			return nil, []DiagramFolder{{
+				DiagramSourceID: item.IdentifierRef,
+				FolderSourceID:  parentSourceID,
+			}}, true
+		}
+		return nil, nil, false // element ref — skip
+	}
+
+	// Folder item: compute this folder's source ID.
+	label := orgItemLabel(item)
+	sourceID := label
+	if parentSourceID != "" && label != "" {
+		sourceID = parentSourceID + "/" + label
+	} else if parentSourceID != "" {
+		sourceID = parentSourceID
+	}
+
+	var childFolders []ViewFolder
+	var diagFolders []DiagramFolder
+	containsViews := false
+
+	for i, child := range item.Children {
+		childParent := sourceID
+		if label == "" {
+			childParent = parentSourceID
+		}
+		cf, cd, hasViews := collectViewOrg(child, childParent, viewIDs, i)
+		if hasViews {
+			childFolders = append(childFolders, cf...)
+			diagFolders = append(diagFolders, cd...)
+			containsViews = true
+		}
+	}
+
+	if !containsViews || label == "" {
+		// No views here, or anonymous grouping — pass through without creating a folder.
+		return childFolders, diagFolders, containsViews
+	}
+
+	// Prepend this folder so it appears before its children (parent-first order).
+	folder := ViewFolder{
+		SourceID: sourceID,
+		Name:     label,
+		ParentID: parentSourceID,
+		Position: pos,
+	}
+	return append([]ViewFolder{folder}, childFolders...), diagFolders, true
+}
+
+// orgItemLabel returns the first non-empty label from an org item.
+func orgItemLabel(item aoefOrgItem) string {
+	for _, l := range item.Labels {
+		v := strings.TrimSpace(l.Value)
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // collectNodes recursively traverses nested AOEF nodes and collects all nodes

--- a/internal/parser/model.go
+++ b/internal/parser/model.go
@@ -3,10 +3,26 @@ package parser
 // Model is the in-memory representation of a parsed ArchiMate model.
 // It is format-agnostic — produced by both the AOEF and AJX parsers.
 type Model struct {
-	Name          string
-	Elements      []Element
-	Relationships []Relationship
-	Diagrams      []Diagram
+	Name           string
+	Elements       []Element
+	Relationships  []Relationship
+	Diagrams       []Diagram
+	ViewFolders    []ViewFolder    // folder hierarchy from <views> organization
+	DiagramFolders []DiagramFolder // diagram → folder assignments
+}
+
+// ViewFolder represents a folder node in the diagram view hierarchy.
+type ViewFolder struct {
+	SourceID string
+	Name     string
+	ParentID string // empty if root-level
+	Position int
+}
+
+// DiagramFolder links a diagram to its folder.
+type DiagramFolder struct {
+	DiagramSourceID string
+	FolderSourceID  string // empty if diagram is at root (no folder)
 }
 
 // Element represents an ArchiMate element (AOEF <element>).

--- a/migrations/009_create_diagram_folders.sql
+++ b/migrations/009_create_diagram_folders.sql
@@ -1,0 +1,16 @@
+-- Migration 009: diagram_folders
+-- Stores the folder hierarchy from AOEF <views> organization items.
+
+CREATE TABLE diagram_folders (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id    UUID NOT NULL REFERENCES workspaces (id) ON DELETE CASCADE,
+    parent_id       UUID REFERENCES diagram_folders (id) ON DELETE CASCADE,
+    name            TEXT NOT NULL DEFAULT '',
+    source_id       TEXT NOT NULL DEFAULT '',  -- original item label or id from AOEF
+    position        INTEGER NOT NULL DEFAULT 0, -- ordering within parent
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (workspace_id, source_id)
+);
+
+CREATE INDEX diagram_folders_workspace_idx ON diagram_folders (workspace_id);
+CREATE INDEX diagram_folders_parent_idx    ON diagram_folders (parent_id);

--- a/migrations/010_add_folder_to_diagrams.sql
+++ b/migrations/010_add_folder_to_diagrams.sql
@@ -1,0 +1,7 @@
+-- Migration 010: add folder_id to diagrams
+-- Links each diagram to its folder in the hierarchy.
+
+ALTER TABLE diagrams
+    ADD COLUMN folder_id UUID REFERENCES diagram_folders (id) ON DELETE SET NULL;
+
+CREATE INDEX diagrams_folder_idx ON diagrams (folder_id);


### PR DESCRIPTION
## Summary

- **AOEF folder parsing**: extracts the `<organizations>` view hierarchy from OEF standard XML — no Archi-proprietary format needed. Folders and diagram assignments are resolved by matching `identifierRef` to known view IDs
- **DB**: new `diagram_folders` table (self-referential, workspace-scoped) + `folder_id` on `diagrams` (migrations 009, 010)
- **Import**: upserts folders parent-first and assigns `folder_id` to each diagram on import/re-import
- **API**: new `GET /workspaces/{wsID}/diagram-tree` returning full folder+diagram tree in one call
- **Frontend**: replaces flat diagram list with collapsible folder tree (left) + embedded DiagramView (right) in a fixed split layout

## Test plan

- [ ] Import ArchiMetal.xml — verify 9 folders and 33 diagrams with correct hierarchy
- [ ] Folder tree matches Archi's Views tree (1_Challenges → Figure01-07, etc.)
- [ ] Click diagram in tree → renders in right panel
- [ ] Folders collapse/expand correctly, including nested (3_Transformation_Overview > 3.1_Baseline)
- [ ] Re-import updates folder assignments without duplicating folders
- [ ] Models with no folder organization (flat views) show all diagrams at root level
- [ ] DiagramViewer route (/ws/:id/diagrams/:diagId) still works standalone