### PR TITLE
feat(oef): full ArchiMate OEF standard coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,6 +244,8 @@ archipulse/
 
 For the full design rationale see [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md). Read it before opening proposals that affect the schema, API, or core architecture.
 
+For the database schema with an ER diagram see [docs/schema.md](./docs/schema.md).
+
 ---
 
 ## Workflow

--- a/cmd/archipulse/ui/src/components/diagram/ArchiMateEdge.svelte
+++ b/cmd/archipulse/ui/src/components/diagram/ArchiMateEdge.svelte
@@ -13,10 +13,16 @@
 
   export let data;
 
-  $: style     = getRelationshipStyle(data?.relationshipType);
+  $: style     = getRelationshipStyle(data?.relationshipType, {
+    accessType: data?.accessType,
+    isDirected: data?.isDirected,
+  });
   $: bps       = data?.bendpoints || [];
   $: srcBounds = data?.sourceBounds;
   $: tgtBounds = data?.targetBounds;
+
+  // Edge label: prefer explicit label, fall back to modifier (Influence strength).
+  $: edgeLabel = data?.label || data?.modifier || '';
 
   $: srcCenter = srcBounds
     ? { x: srcBounds.x + srcBounds.w / 2, y: srcBounds.y + srcBounds.h / 2 }
@@ -25,8 +31,6 @@
     ? { x: tgtBounds.x + tgtBounds.w / 2, y: tgtBounds.y + tgtBounds.h / 2 }
     : { x: 0, y: 0 };
 
-  // Use orthogonal snapping only when bendpoints define a routing lane.
-  // Direct connections (no bendpoints) use natural diagonal intersection.
   $: hasBps = bps.length > 0;
 
   $: startPt = intersectNodeBoundary(
@@ -44,12 +48,11 @@
 
   $: allPts = [startPt, ...bps, endPt];
 
-  // Build a smooth polyline: straight segments but with small rounded corners
-  // at intermediate bendpoints so the path looks clean rather than jagged.
+  // Build a smooth polyline with small rounded corners at intermediate bendpoints.
   function smoothPath(pts) {
     if (pts.length < 2) return '';
     if (pts.length === 2) return `M${pts[0].x},${pts[0].y} L${pts[1].x},${pts[1].y}`;
-    const r = 8; // corner radius in diagram units
+    const r = 8;
     let d = `M${pts[0].x},${pts[0].y}`;
     for (let i = 1; i < pts.length - 1; i++) {
       const prev = pts[i - 1];
@@ -71,11 +74,20 @@
 
   $: pathD = smoothPath(allPts);
 
+  // Midpoint of the path for label placement.
+  $: midPt = (() => {
+    if (allPts.length < 2) return { x: 0, y: 0 };
+    const mid = Math.floor((allPts.length - 1) / 2);
+    const a = allPts[mid];
+    const b = allPts[mid + 1];
+    return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+  })();
+
   $: markerEnd   = style.end   ? `url(#am-${style.end})`   : undefined;
   $: markerStart = style.start ? `url(#am-${style.start})` : undefined;
 </script>
 
-<!-- Invisible wider stroke for future hover/selection interactions -->
+<!-- Invisible wider stroke for hover/selection interactions -->
 <path d={pathD} fill="none" stroke="transparent" stroke-width="14" />
 
 <!-- Main edge path — stroke color propagates to markers via context-stroke -->
@@ -88,3 +100,21 @@
   marker-end={markerEnd}
   marker-start={markerStart}
 />
+
+<!-- Edge label (relationship label or influence modifier) -->
+{#if edgeLabel}
+  <g transform="translate({midPt.x},{midPt.y})">
+    <rect
+      x="-18" y="-9" width="36" height="16" rx="3"
+      fill="white" fill-opacity="0.88"
+      stroke={style.stroke} stroke-width="0.8" stroke-opacity="0.4"
+    />
+    <text
+      x="0" y="4"
+      text-anchor="middle"
+      font-size="9"
+      font-family="ui-sans-serif,system-ui,sans-serif"
+      fill={style.stroke}
+    >{edgeLabel}</text>
+  </g>
+{/if}

--- a/cmd/archipulse/ui/src/components/diagram/archimate-edges.js
+++ b/cmd/archipulse/ui/src/components/diagram/archimate-edges.js
@@ -3,16 +3,22 @@
 //
 // Marker types:
 //   filled-arrow   — solid filled arrowhead (Triggering, Flow, Assignment)
-//   open-arrow     — open V arrowhead (Association, Serving, Access, Influence)
+//   open-arrow     — open V arrowhead (Association, Serving, Influence)
 //   open-triangle  — hollow closed triangle (Realization, Specialization)
 //   filled-diamond — solid diamond at source (Composition)
 //   open-diamond   — hollow diamond at source (Aggregation)
 //   filled-circle  — solid circle at source (Assignment)
+//
+// Access relationship markers depend on accessType:
+//   Access    → open-arrow at end only
+//   Read      → open-arrow at start (towards source = data flows from target to source)
+//   Write     → open-arrow at end  (towards target = data flows from source to target)
+//   ReadWrite → open-arrow at both ends
 
 export const RELATIONSHIP_STYLES = {
   TriggeringRelationship:     { stroke: '#374151', width: 1.5, dash: null,  end: 'filled-arrow',  start: null },
   FlowRelationship:           { stroke: '#374151', width: 1.5, dash: '8 4', end: 'filled-arrow',  start: null },
-  AssociationRelationship:    { stroke: '#9CA3AF', width: 1.2, dash: null,  end: 'open-arrow',    start: null },
+  AssociationRelationship:    { stroke: '#9CA3AF', width: 1.2, dash: null,  end: null,            start: null },
   CompositionRelationship:    { stroke: '#374151', width: 1.5, dash: null,  end: null,            start: 'filled-diamond' },
   AggregationRelationship:    { stroke: '#374151', width: 1.5, dash: null,  end: null,            start: 'open-diamond' },
   AssignmentRelationship:     { stroke: '#374151', width: 1.5, dash: null,  end: 'filled-arrow',  start: 'filled-circle' },
@@ -26,14 +32,56 @@ export const RELATIONSHIP_STYLES = {
 
 const DEFAULT_STYLE = { stroke: '#6B7280', width: 1.2, dash: null, end: 'filled-arrow', start: null };
 
-export function getRelationshipStyle(relType) {
-  if (!relType) return DEFAULT_STYLE;
-  if (RELATIONSHIP_STYLES[relType]) return RELATIONSHIP_STYLES[relType];
-  // Partial match for truncated type names
-  for (const [key, val] of Object.entries(RELATIONSHIP_STYLES)) {
-    if (relType.includes(key.replace('Relationship', ''))) return val;
+/**
+ * Returns the visual style for a relationship, taking into account type-specific
+ * semantic attributes from the OEF standard:
+ *   - accessType (Access): Access | Read | Write | ReadWrite
+ *   - isDirected (Association): true adds an arrowhead at the target end
+ */
+export function getRelationshipStyle(relType, { accessType, isDirected } = {}) {
+  let base;
+  if (!relType) {
+    base = { ...DEFAULT_STYLE };
+  } else if (RELATIONSHIP_STYLES[relType]) {
+    base = { ...RELATIONSHIP_STYLES[relType] };
+  } else {
+    // Partial match for truncated type names
+    const found = Object.entries(RELATIONSHIP_STYLES).find(([key]) =>
+      relType.includes(key.replace('Relationship', ''))
+    );
+    base = found ? { ...found[1] } : { ...DEFAULT_STYLE };
   }
-  return DEFAULT_STYLE;
+
+  // Access relationship: markers depend on accessType.
+  if (relType === 'AccessRelationship' || relType === 'Access') {
+    switch (accessType) {
+      case 'Read':
+        base.start = 'open-arrow';
+        base.end   = null;
+        break;
+      case 'Write':
+        base.start = null;
+        base.end   = 'open-arrow';
+        break;
+      case 'ReadWrite':
+        base.start = 'open-arrow';
+        base.end   = 'open-arrow';
+        break;
+      default: // 'Access' or unset → arrow at end
+        base.start = null;
+        base.end   = 'open-arrow';
+    }
+  }
+
+  // Association relationship: directed flag adds an arrowhead at the target.
+  if (
+    (relType === 'AssociationRelationship' || relType === 'Association') &&
+    isDirected
+  ) {
+    base.end = 'open-arrow';
+  }
+
+  return base;
 }
 
 // Compute where the edge exits/enters a node boundary toward point (px, py).
@@ -59,7 +107,6 @@ export function intersectNodeBoundary(bounds, px, py, orthogonal = false) {
   const sy = dy !== 0 ? hh / Math.abs(dy) : Infinity;
 
   if (orthogonal) {
-    // Snap exit/entry coordinate to the bendpoint lane
     if (sy <= sx) {
       return {
         x: +(Math.max(left, Math.min(right, px))).toFixed(2),
@@ -72,7 +119,6 @@ export function intersectNodeBoundary(bounds, px, py, orthogonal = false) {
       };
     }
   } else {
-    // Diagonal ray intersection
     const s = Math.min(sx, sy);
     return {
       x: +(cx + dx * s).toFixed(2),

--- a/cmd/archipulse/ui/src/components/views/DiagramView.svelte
+++ b/cmd/archipulse/ui/src/components/views/DiagramView.svelte
@@ -108,6 +108,10 @@
           type: 'archimate',
           data: {
             relationshipType: c.relationship_type,
+            accessType:       c.access_type || null,
+            isDirected:       c.is_directed  || false,
+            label:            c.label        || '',
+            modifier:         c.modifier     || '',
             bendpoints: c.bendpoints || [],
             sourceBounds: src ? { x: src.x, y: src.y, w: src.w, h: src.h } : null,
             targetBounds: tgt ? { x: tgt.x, y: tgt.y, w: tgt.w, h: tgt.h } : null,

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,167 @@
+# Database Schema
+
+ArchiPulse uses PostgreSQL. All tables are created and updated via numbered SQL migrations in [`migrations/`](../migrations/).
+
+## Entity-Relationship Diagram
+
+```mermaid
+erDiagram
+
+    workspaces {
+        uuid    id          PK
+        text    name        UK
+        text    purpose     "as-is|to-be|initiative|other"
+        text    description
+        integer version
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    users {
+        uuid    id    PK
+        text    email UK
+        text    password_hash
+        text    role  "admin|architect|viewer"
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    elements {
+        uuid    id           PK
+        uuid    workspace_id FK
+        text    source_id    "OEF identifier"
+        text    type         "e.g. ApplicationComponent"
+        text    layer        "Business|Application|Technology|..."
+        text    name
+        text    documentation
+        integer version
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    element_properties {
+        uuid    id         PK
+        uuid    element_id FK
+        text    key
+        text    value
+        text    source     "model|extractor"
+        timestamptz collected_at
+        timestamptz created_at
+    }
+
+    property_definitions {
+        uuid    id           PK
+        uuid    workspace_id FK
+        text    source_id    "OEF identifier"
+        text    name
+        text    data_type    "string|boolean|currency|date|time|number"
+        timestamptz created_at
+    }
+
+    relationships {
+        uuid    id             PK
+        uuid    workspace_id   FK
+        text    source_id      "OEF identifier"
+        text    type           "e.g. AssociationRelationship"
+        text    source_element "elements.source_id"
+        text    target_element "elements.source_id"
+        text    name
+        text    documentation
+        text    access_type    "Access|Read|Write|ReadWrite (Access rel only)"
+        boolean is_directed    "false by default (Association rel only)"
+        text    modifier       "influence strength: +|++|-|--|0..10 (Influence rel only)"
+        integer version
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    diagram_folders {
+        uuid    id           PK
+        uuid    workspace_id FK
+        uuid    parent_id    FK "self-ref, nullable"
+        text    name
+        text    source_id    "OEF organization label path"
+        integer position     "ordering within parent"
+        timestamptz created_at
+    }
+
+    diagrams {
+        uuid    id            PK
+        uuid    workspace_id  FK
+        uuid    folder_id     FK "nullable"
+        text    source_id     "OEF identifier"
+        text    name
+        text    documentation
+        jsonb   layout        "nodes + connections with positions and styles"
+        text    viewpoint     "OEF viewpoint name (e.g. Layered)"
+        text    viewpoint_ref "OEF viewpointRef identifier"
+        integer version
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    workspaces    ||--o{ elements            : "contains"
+    workspaces    ||--o{ relationships        : "contains"
+    workspaces    ||--o{ diagrams             : "contains"
+    workspaces    ||--o{ diagram_folders      : "contains"
+    workspaces    ||--o{ property_definitions : "defines"
+
+    elements      ||--o{ element_properties  : "has"
+    diagram_folders ||--o{ diagram_folders   : "parent"
+    diagram_folders ||--o{ diagrams          : "groups"
+```
+
+## Notes
+
+### `layout` JSON structure (diagrams)
+
+The `layout` column is a JSONB blob produced by the parser. Its structure mirrors the OEF diagram visual model:
+
+```json
+{
+  "Nodes": [
+    {
+      "ElementID": "id-app-001",
+      "ParentElementID": "",
+      "NodeType": "Element",
+      "X": 120, "Y": 80, "W": 120, "H": 55,
+      "Style": {
+        "FillColor": { "R": 255, "G": 251, "B": 235, "A": null },
+        "LineColor": { "R": 217, "G": 119, "B": 6 },
+        "Font": { "Name": "Arial", "Size": "9", "Style": "plain", "Color": null },
+        "LineWidth": 1
+      }
+    }
+  ],
+  "Connections": [
+    {
+      "RelationshipID": "id-rel-001",
+      "Label": "",
+      "Bendpoints": [{ "X": 180, "Y": 108 }],
+      "Style": null
+    }
+  ]
+}
+```
+
+- **`Style`** is stored as parsed from the OEF file and is available for future custom rendering. ArchiPulse's current theme uses its own colour palette and ignores `Style.FillColor`/`Style.LineColor` by default.
+- **`NodeType`** reflects the OEF `xsi:type` on each node (`Element`, `Container`, `Label`, etc.).
+
+### Relationship semantic attributes
+
+Three columns capture OEF type-specific semantics that affect how relationships are rendered:
+
+| Column | Applies to | Values |
+|---|---|---|
+| `access_type` | `AccessRelationship` | `Access` (default) · `Read` · `Write` · `ReadWrite` |
+| `is_directed` | `AssociationRelationship` | `false` (default) · `true` |
+| `modifier` | `InfluenceRelationship` | `+` · `++` · `-` · `--` · `0`–`10` |
+
+### Property definitions
+
+OEF `<propertyDefinition>` entries are stored workspace-scoped in `property_definitions`. The `data_type` column records the declared type (`string`, `boolean`, `currency`, `date`, `time`, `number`), enabling typed property editing in a future editor feature.
+
+### `source_id` vs `id`
+
+Every ArchiMate concept table has both an `id` (internal UUID, stable across re-imports) and a `source_id` (the original identifier from the OEF/AJX file). Re-importing the same model is idempotent via `ON CONFLICT (workspace_id, source_id) DO UPDATE`.
+```

--- a/internal/api/import_handler.go
+++ b/internal/api/import_handler.go
@@ -23,11 +23,12 @@ type importHandler struct {
 
 // ImportResult summarises what was imported.
 type ImportResult struct {
-	WorkspaceID   string `json:"workspace_id"`
-	Elements      int    `json:"elements"`
-	Relationships int    `json:"relationships"`
-	Diagrams      int    `json:"diagrams"`
-	Folders       int    `json:"folders"`
+	WorkspaceID         string `json:"workspace_id"`
+	Elements            int    `json:"elements"`
+	Relationships       int    `json:"relationships"`
+	Diagrams            int    `json:"diagrams"`
+	Folders             int    `json:"folders"`
+	PropertyDefinitions int    `json:"property_definitions"`
 }
 
 func (h *importHandler) importModel(w http.ResponseWriter, r *http.Request) {
@@ -110,6 +111,25 @@ func importInTx(db *sql.DB, wsID uuid.UUID, m *parser.Model) (*ImportResult, err
 
 	result := &ImportResult{WorkspaceID: wsID.String()}
 
+	// --- Property definitions ---
+	for _, pd := range m.PropertyDefinitions {
+		dt := pd.DataType
+		if dt == "" {
+			dt = "string"
+		}
+		_, err := tx.Exec(`
+			INSERT INTO property_definitions (workspace_id, source_id, name, data_type)
+			VALUES ($1, $2, $3, $4)
+			ON CONFLICT (workspace_id, source_id) DO UPDATE
+			  SET name = EXCLUDED.name, data_type = EXCLUDED.data_type`,
+			wsID, pd.ID, pd.Name, dt)
+		if err != nil {
+			return nil, errorf("upsert property definition %q: %w", pd.ID, err)
+		}
+		result.PropertyDefinitions++
+	}
+
+	// --- Elements ---
 	for _, e := range m.Elements {
 		layer := parser.ElementLayer(e.Type)
 		var elemID uuid.UUID
@@ -142,23 +162,40 @@ func importInTx(db *sql.DB, wsID uuid.UUID, m *parser.Model) (*ImportResult, err
 		}
 	}
 
+	// --- Relationships ---
 	for _, r := range m.Relationships {
+		// Nullable columns: access_type and modifier are empty strings when not applicable.
+		var accessType, modifier *string
+		if r.AccessType != "" {
+			accessType = &r.AccessType
+		}
+		if r.Modifier != "" {
+			modifier = &r.Modifier
+		}
 		_, err := tx.Exec(`
-			INSERT INTO relationships (workspace_id, source_id, type, source_element, target_element, name, documentation)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			INSERT INTO relationships
+			  (workspace_id, source_id, type, source_element, target_element,
+			   name, documentation, access_type, is_directed, modifier)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 			ON CONFLICT (workspace_id, source_id) DO UPDATE
-			  SET type = EXCLUDED.type, source_element = EXCLUDED.source_element,
-			      target_element = EXCLUDED.target_element, name = EXCLUDED.name,
+			  SET type = EXCLUDED.type,
+			      source_element = EXCLUDED.source_element,
+			      target_element = EXCLUDED.target_element,
+			      name = EXCLUDED.name,
 			      documentation = EXCLUDED.documentation,
+			      access_type = EXCLUDED.access_type,
+			      is_directed = EXCLUDED.is_directed,
+			      modifier = EXCLUDED.modifier,
 			      version = relationships.version + 1, updated_at = now()`,
-			wsID, r.ID, r.Type, r.Source, r.Target, r.Name, r.Documentation)
+			wsID, r.ID, r.Type, r.Source, r.Target,
+			r.Name, r.Documentation, accessType, r.IsDirected, modifier)
 		if err != nil {
 			return nil, errorf("upsert relationship %q: %w", r.ID, err)
 		}
 		result.Relationships++
 	}
 
-	// Upsert diagram folders (parser returns them parent-first).
+	// --- Diagram folders (parser returns them parent-first) ---
 	// Build a map from source_id → DB UUID for assigning folder_id to diagrams.
 	folderUUIDs := make(map[string]uuid.UUID, len(m.ViewFolders))
 	for _, f := range m.ViewFolders {
@@ -199,20 +236,37 @@ func importInTx(db *sql.DB, wsID uuid.UUID, m *parser.Model) (*ImportResult, err
 		}
 	}
 
+	// --- Diagrams ---
 	for _, d := range m.Diagrams {
 		layoutJSON, err := json.Marshal(d.Layout)
 		if err != nil {
 			return nil, errorf("marshal layout for diagram %q: %w", d.ID, err)
 		}
 		folderID := diagFolderID[d.ID] // nil if no folder
+
+		// Nullable viewpoint fields.
+		var viewpoint, viewpointRef *string
+		if d.Viewpoint != "" {
+			viewpoint = &d.Viewpoint
+		}
+		if d.ViewpointRef != "" {
+			viewpointRef = &d.ViewpointRef
+		}
+
 		_, err = tx.Exec(`
-			INSERT INTO diagrams (workspace_id, source_id, name, documentation, layout, folder_id)
-			VALUES ($1, $2, $3, $4, $5, $6)
+			INSERT INTO diagrams
+			  (workspace_id, source_id, name, documentation, layout, folder_id, viewpoint, viewpoint_ref)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 			ON CONFLICT (workspace_id, source_id) DO UPDATE
-			  SET name = EXCLUDED.name, documentation = EXCLUDED.documentation,
-			      layout = EXCLUDED.layout, folder_id = EXCLUDED.folder_id,
+			  SET name = EXCLUDED.name,
+			      documentation = EXCLUDED.documentation,
+			      layout = EXCLUDED.layout,
+			      folder_id = EXCLUDED.folder_id,
+			      viewpoint = EXCLUDED.viewpoint,
+			      viewpoint_ref = EXCLUDED.viewpoint_ref,
 			      version = diagrams.version + 1, updated_at = now()`,
-			wsID, d.ID, d.Name, d.Documentation, layoutJSON, folderID)
+			wsID, d.ID, d.Name, d.Documentation, layoutJSON, folderID,
+			viewpoint, viewpointRef)
 		if err != nil {
 			return nil, errorf("upsert diagram %q: %w", d.ID, err)
 		}

--- a/internal/diagram/diagram.go
+++ b/internal/diagram/diagram.go
@@ -206,8 +206,8 @@ func (s *Store) Render(diagramID uuid.UUID) (*RenderData, error) {
 			Style           *NodeStyle `json:"Style"`
 		} `json:"Nodes"`
 		Connections []struct {
-			RelationshipID string     `json:"RelationshipID"`
-			Label          string     `json:"Label"`
+			RelationshipID string `json:"RelationshipID"`
+			Label          string `json:"Label"`
 			Bendpoints     []struct {
 				X int `json:"X"`
 				Y int `json:"Y"`

--- a/internal/diagram/diagram.go
+++ b/internal/diagram/diagram.go
@@ -112,25 +112,63 @@ func (s *Store) Update(id uuid.UUID, name, documentation string, layout json.Raw
 	return &d, nil
 }
 
+// RGBColor is an RGBA colour value as stored in the layout JSON.
+type RGBColor struct {
+	R int  `json:"r"`
+	G int  `json:"g"`
+	B int  `json:"b"`
+	A *int `json:"a,omitempty"` // 0–100; nil means not set
+}
+
+// FontStyle holds font metadata as stored in the layout JSON.
+type FontStyle struct {
+	Name  string    `json:"name,omitempty"`
+	Size  string    `json:"size,omitempty"`
+	Style string    `json:"style,omitempty"`
+	Color *RGBColor `json:"color,omitempty"`
+}
+
+// NodeStyle holds visual styling for a diagram node.
+type NodeStyle struct {
+	FillColor *RGBColor  `json:"fill_color,omitempty"`
+	LineColor *RGBColor  `json:"line_color,omitempty"`
+	Font      *FontStyle `json:"font,omitempty"`
+	LineWidth int        `json:"line_width,omitempty"`
+}
+
+// ConnStyle holds visual styling for a diagram connection.
+type ConnStyle struct {
+	LineColor *RGBColor  `json:"line_color,omitempty"`
+	Font      *FontStyle `json:"font,omitempty"`
+	LineWidth int        `json:"line_width,omitempty"`
+}
+
 // RenderNode is a node enriched with element metadata for rendering.
 type RenderNode struct {
-	ElementID       string `json:"element_id"`
-	ParentElementID string `json:"parent_element_id,omitempty"`
-	ElementName     string `json:"element_name"`
-	ElementType     string `json:"element_type"`
-	X               int    `json:"x"`
-	Y               int    `json:"y"`
-	W               int    `json:"w"`
-	H               int    `json:"h"`
+	ElementID       string     `json:"element_id"`
+	ParentElementID string     `json:"parent_element_id,omitempty"`
+	NodeType        string     `json:"node_type,omitempty"`
+	ElementName     string     `json:"element_name"`
+	ElementType     string     `json:"element_type"`
+	X               int        `json:"x"`
+	Y               int        `json:"y"`
+	W               int        `json:"w"`
+	H               int        `json:"h"`
+	Style           *NodeStyle `json:"style,omitempty"`
 }
 
 // RenderConnection is a connection enriched with relationship metadata.
 type RenderConnection struct {
-	RelationshipID   string  `json:"relationship_id"`
-	RelationshipType string  `json:"relationship_type"`
-	SourceElementID  string  `json:"source_element_id"`
-	TargetElementID  string  `json:"target_element_id"`
-	Bendpoints       []Point `json:"bendpoints"`
+	RelationshipID   string     `json:"relationship_id"`
+	RelationshipType string     `json:"relationship_type"`
+	SourceElementID  string     `json:"source_element_id"`
+	TargetElementID  string     `json:"target_element_id"`
+	Label            string     `json:"label,omitempty"`
+	AccessType       string     `json:"access_type,omitempty"`
+	IsDirected       bool       `json:"is_directed,omitempty"`
+	Modifier         string     `json:"modifier,omitempty"`
+	Bendpoints       []Point    `json:"bendpoints"`
+	Style            *ConnStyle `json:"style,omitempty"`
 }
 
 // Point is a 2D coordinate.
@@ -158,19 +196,23 @@ func (s *Store) Render(diagramID uuid.UUID) (*RenderData, error) {
 	// Parse the stored layout JSON.
 	var layout struct {
 		Nodes []struct {
-			ElementID       string `json:"ElementID"`
-			ParentElementID string `json:"ParentElementID"`
-			X               int    `json:"X"`
-			Y               int    `json:"Y"`
-			W               int    `json:"W"`
-			H               int    `json:"H"`
+			ElementID       string     `json:"ElementID"`
+			ParentElementID string     `json:"ParentElementID"`
+			NodeType        string     `json:"NodeType"`
+			X               int        `json:"X"`
+			Y               int        `json:"Y"`
+			W               int        `json:"W"`
+			H               int        `json:"H"`
+			Style           *NodeStyle `json:"Style"`
 		} `json:"Nodes"`
 		Connections []struct {
-			RelationshipID string `json:"RelationshipID"`
+			RelationshipID string     `json:"RelationshipID"`
+			Label          string     `json:"Label"`
 			Bendpoints     []struct {
 				X int `json:"X"`
 				Y int `json:"Y"`
 			} `json:"Bendpoints"`
+			Style *ConnStyle `json:"Style"`
 		} `json:"Connections"`
 	}
 	if err := json.Unmarshal(d.Layout, &layout); err != nil {
@@ -207,7 +249,7 @@ func (s *Store) Render(diagramID uuid.UUID) (*RenderData, error) {
 		}
 	}
 
-	// Resolve relationship metadata.
+	// Resolve relationship metadata including semantic attributes.
 	relIDs := make([]string, 0, len(layout.Connections))
 	for _, c := range layout.Connections {
 		if c.RelationshipID != "" {
@@ -216,14 +258,19 @@ func (s *Store) Render(diagramID uuid.UUID) (*RenderData, error) {
 	}
 
 	type relMeta struct {
-		typ    string
-		source string
-		target string
+		typ        string
+		source     string
+		target     string
+		accessType string
+		isDirected bool
+		modifier   string
 	}
 	relMap := map[string]relMeta{}
 	if len(relIDs) > 0 {
 		rows, err := s.db.Query(`
-			SELECT source_id, type, source_element, target_element FROM relationships
+			SELECT source_id, type, source_element, target_element,
+			       COALESCE(access_type, ''), is_directed, COALESCE(modifier, '')
+			FROM relationships
 			WHERE workspace_id = $1 AND source_id = ANY($2)`,
 			d.WorkspaceID, relIDs)
 		if err != nil {
@@ -231,11 +278,15 @@ func (s *Store) Render(diagramID uuid.UUID) (*RenderData, error) {
 		}
 		defer func() { _ = rows.Close() }()
 		for rows.Next() {
-			var sid, typ, src, tgt string
-			if err := rows.Scan(&sid, &typ, &src, &tgt); err != nil {
+			var sid, typ, src, tgt, accessType, modifier string
+			var isDirected bool
+			if err := rows.Scan(&sid, &typ, &src, &tgt, &accessType, &isDirected, &modifier); err != nil {
 				return nil, err
 			}
-			relMap[sid] = relMeta{typ: typ, source: src, target: tgt}
+			relMap[sid] = relMeta{
+				typ: typ, source: src, target: tgt,
+				accessType: accessType, isDirected: isDirected, modifier: modifier,
+			}
 		}
 		if err := rows.Err(); err != nil {
 			return nil, err
@@ -255,12 +306,14 @@ func (s *Store) Render(diagramID uuid.UUID) (*RenderData, error) {
 		rd.Nodes = append(rd.Nodes, RenderNode{
 			ElementID:       n.ElementID,
 			ParentElementID: n.ParentElementID,
+			NodeType:        n.NodeType,
 			ElementName:     meta[0],
 			ElementType:     meta[1],
 			X:               n.X,
 			Y:               n.Y,
 			W:               n.W,
 			H:               n.H,
+			Style:           n.Style,
 		})
 	}
 
@@ -275,7 +328,12 @@ func (s *Store) Render(diagramID uuid.UUID) (*RenderData, error) {
 			RelationshipType: meta.typ,
 			SourceElementID:  meta.source,
 			TargetElementID:  meta.target,
+			Label:            c.Label,
+			AccessType:       meta.accessType,
+			IsDirected:       meta.isDirected,
+			Modifier:         meta.modifier,
 			Bendpoints:       bps,
+			Style:            c.Style,
 		})
 	}
 

--- a/internal/parser/ajx.go
+++ b/internal/parser/ajx.go
@@ -80,7 +80,14 @@ func (m *ajxModel) toModel() *Model {
 	}
 
 	for _, r := range m.Relationships {
-		out.Relationships = append(out.Relationships, Relationship(r))
+		out.Relationships = append(out.Relationships, Relationship{
+			ID:            r.ID,
+			Type:          r.Type,
+			Source:        r.Source,
+			Target:        r.Target,
+			Name:          r.Name,
+			Documentation: r.Documentation,
+		})
 	}
 
 	for _, v := range m.Views {

--- a/internal/parser/aoef.go
+++ b/internal/parser/aoef.go
@@ -21,15 +21,15 @@ func ParseAOEF(r io.Reader) (*Model, error) {
 // ---- raw AOEF XML structs ----
 
 type aoefModel struct {
-	XMLName      xml.Name          `xml:"model"`
-	Identifier   string            `xml:"identifier,attr"`
-	Version      string            `xml:"version,attr"`
-	Names        []aoefLangString  `xml:"name"`
-	PropertyDefs []aoefPropertyDef `xml:"propertyDefinitions>propertyDefinition"`
-	Elements     []aoefElement     `xml:"elements>element"`
+	XMLName       xml.Name           `xml:"model"`
+	Identifier    string             `xml:"identifier,attr"`
+	Version       string             `xml:"version,attr"`
+	Names         []aoefLangString   `xml:"name"`
+	PropertyDefs  []aoefPropertyDef  `xml:"propertyDefinitions>propertyDefinition"`
+	Elements      []aoefElement      `xml:"elements>element"`
 	Relationships []aoefRelationship `xml:"relationships>relationship"`
-	Views        []aoefView        `xml:"views>diagrams>view"`
-	Organizations []aoefOrgItem    `xml:"organizations>item"`
+	Views         []aoefView         `xml:"views>diagrams>view"`
+	Organizations []aoefOrgItem      `xml:"organizations>item"`
 }
 
 type aoefPropertyDef struct {
@@ -99,10 +99,10 @@ type aoefPoint struct {
 }
 
 type aoefStyle struct {
-	LineWidth int            `xml:"lineWidth,attr"`
-	LineColor *aoefRGBColor  `xml:"lineColor"`
-	FillColor *aoefRGBColor  `xml:"fillColor"`
-	Font      *aoefFont      `xml:"font"`
+	LineWidth int           `xml:"lineWidth,attr"`
+	LineColor *aoefRGBColor `xml:"lineColor"`
+	FillColor *aoefRGBColor `xml:"fillColor"`
+	Font      *aoefFont     `xml:"font"`
 }
 
 type aoefRGBColor struct {

--- a/internal/parser/aoef.go
+++ b/internal/parser/aoef.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 )
 
@@ -20,62 +21,76 @@ func ParseAOEF(r io.Reader) (*Model, error) {
 // ---- raw AOEF XML structs ----
 
 type aoefModel struct {
-	XMLName       xml.Name           `xml:"model"`
-	Name          string             `xml:"name"`
-	PropertyDefs  []aoefPropertyDef  `xml:"propertyDefinitions>propertyDefinition"`
-	Elements      []aoefElement      `xml:"elements>element"`
+	XMLName      xml.Name          `xml:"model"`
+	Identifier   string            `xml:"identifier,attr"`
+	Version      string            `xml:"version,attr"`
+	Names        []aoefLangString  `xml:"name"`
+	PropertyDefs []aoefPropertyDef `xml:"propertyDefinitions>propertyDefinition"`
+	Elements     []aoefElement     `xml:"elements>element"`
 	Relationships []aoefRelationship `xml:"relationships>relationship"`
-	Views         []aoefView         `xml:"views>diagrams>view"`
-	Organizations []aoefOrgItem      `xml:"organizations>item"`
+	Views        []aoefView        `xml:"views>diagrams>view"`
+	Organizations []aoefOrgItem    `xml:"organizations>item"`
 }
 
 type aoefPropertyDef struct {
-	ID   string `xml:"identifier,attr"`
-	Name string `xml:"name"`
+	ID       string `xml:"identifier,attr"`
+	DataType string `xml:"type,attr"`
+	Name     string `xml:"name"`
 }
 
 type aoefElement struct {
-	ID            string         `xml:"identifier,attr"`
-	Type          string         `xml:"type,attr"`
-	Name          string         `xml:"name"`
-	Documentation string         `xml:"documentation"`
-	Properties    []aoefProperty `xml:"properties>property"`
+	ID             string           `xml:"identifier,attr"`
+	Type           string           `xml:"type,attr"`
+	Names          []aoefLangString `xml:"name"`
+	Documentations []aoefLangString `xml:"documentation"`
+	Properties     []aoefProperty   `xml:"properties>property"`
 }
 
 type aoefProperty struct {
-	DefinitionRef string `xml:"propertyDefinitionRef,attr"`
-	Value         string `xml:"value"`
+	DefinitionRef string           `xml:"propertyDefinitionRef,attr"`
+	Values        []aoefLangString `xml:"value"`
 }
 
 type aoefRelationship struct {
-	ID            string `xml:"identifier,attr"`
-	Type          string `xml:"type,attr"`
-	Source        string `xml:"source,attr"`
-	Target        string `xml:"target,attr"`
-	Name          string `xml:"name"`
-	Documentation string `xml:"documentation"`
+	ID             string           `xml:"identifier,attr"`
+	Type           string           `xml:"type,attr"`
+	Source         string           `xml:"source,attr"`
+	Target         string           `xml:"target,attr"`
+	Names          []aoefLangString `xml:"name"`
+	Documentations []aoefLangString `xml:"documentation"`
+	// Type-specific attributes.
+	AccessType string `xml:"accessType,attr"` // Access relationship
+	IsDirected string `xml:"isDirected,attr"` // Association relationship ("true"/"false")
+	Modifier   string `xml:"modifier,attr"`   // Influence relationship
 }
 
 type aoefView struct {
-	ID            string     `xml:"identifier,attr"`
-	Name          string     `xml:"name"`
-	Documentation string     `xml:"documentation"`
-	Nodes         []aoefNode `xml:"node"`
-	Connections   []aoefConn `xml:"connection"`
+	ID             string           `xml:"identifier,attr"`
+	Viewpoint      string           `xml:"viewpoint,attr"`
+	ViewpointRef   string           `xml:"viewpointRef,attr"`
+	Names          []aoefLangString `xml:"name"`
+	Documentations []aoefLangString `xml:"documentation"`
+	Nodes          []aoefNode       `xml:"node"`
+	Connections    []aoefConn       `xml:"connection"`
 }
 
 type aoefNode struct {
-	ElementRef string     `xml:"elementRef,attr"`
-	X          int        `xml:"x,attr"`
-	Y          int        `xml:"y,attr"`
-	W          int        `xml:"w,attr"`
-	H          int        `xml:"h,attr"`
-	Children   []aoefNode `xml:"node"` // nested nodes (Container, Group...)
+	NodeType   string           `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr"`
+	ElementRef string           `xml:"elementRef,attr"`
+	X          int              `xml:"x,attr"`
+	Y          int              `xml:"y,attr"`
+	W          int              `xml:"w,attr"`
+	H          int              `xml:"h,attr"`
+	Children   []aoefNode       `xml:"node"`
+	Style      *aoefStyle       `xml:"style"`
+	Labels     []aoefLangString `xml:"label"`
 }
 
 type aoefConn struct {
-	RelationshipRef string      `xml:"relationshipRef,attr"`
-	Bendpoints      []aoefPoint `xml:"bendpoint"`
+	RelationshipRef string           `xml:"relationshipRef,attr"`
+	Bendpoints      []aoefPoint      `xml:"bendpoint"`
+	Style           *aoefStyle       `xml:"style"`
+	Labels          []aoefLangString `xml:"label"`
 }
 
 type aoefPoint struct {
@@ -83,8 +98,30 @@ type aoefPoint struct {
 	Y int `xml:"y,attr"`
 }
 
-// aoefOrgItem represents a node in <organizations>. Items with identifierRef
-// are leaves (elements or views); items with <label> and children are folders.
+type aoefStyle struct {
+	LineWidth int            `xml:"lineWidth,attr"`
+	LineColor *aoefRGBColor  `xml:"lineColor"`
+	FillColor *aoefRGBColor  `xml:"fillColor"`
+	Font      *aoefFont      `xml:"font"`
+}
+
+type aoefRGBColor struct {
+	R int    `xml:"r,attr"`
+	G int    `xml:"g,attr"`
+	B int    `xml:"b,attr"`
+	A string `xml:"a,attr"` // optional 0–100; empty string means not set
+}
+
+type aoefFont struct {
+	Name  string        `xml:"name,attr"`
+	Size  string        `xml:"size,attr"`
+	Style string        `xml:"style,attr"`
+	Color *aoefRGBColor `xml:"color"`
+}
+
+// aoefOrgItem represents a node in <organizations>.
+// Items with identifierRef are leaves (elements or views); items with <label>
+// and children are folders.
 type aoefOrgItem struct {
 	IdentifierRef string           `xml:"identifierRef,attr"`
 	Labels        []aoefLangString `xml:"label"`
@@ -92,50 +129,104 @@ type aoefOrgItem struct {
 }
 
 type aoefLangString struct {
+	Lang  string `xml:"http://www.w3.org/XML/1998/namespace lang,attr"`
 	Value string `xml:",chardata"`
 }
 
-func (m *aoefModel) toModel() *Model {
-	out := &Model{Name: m.Name}
+// firstLang returns the first non-empty value from a slice of lang strings.
+// If lang is specified, it prefers the matching entry, falling back to the first non-empty.
+func firstLang(ss []aoefLangString, prefer string) string {
+	fallback := ""
+	for _, s := range ss {
+		v := strings.TrimSpace(s.Value)
+		if v == "" {
+			continue
+		}
+		if fallback == "" {
+			fallback = v
+		}
+		if prefer == "" || s.Lang == prefer || s.Lang == "" {
+			return v
+		}
+	}
+	return fallback
+}
 
-	// Build property definition ID → name lookup.
-	propNames := make(map[string]string, len(m.PropertyDefs))
+func (m *aoefModel) toModel() *Model {
+	out := &Model{
+		Name:    firstLang(m.Names, ""),
+		Version: m.Version,
+	}
+
+	// Build property definition ID → (name, dataType) lookup and populate output.
+	type propDef struct{ name, dataType string }
+	propDefs := make(map[string]propDef, len(m.PropertyDefs))
 	for _, pd := range m.PropertyDefs {
-		propNames[pd.ID] = pd.Name
+		dt := pd.DataType
+		if dt == "" {
+			dt = "string"
+		}
+		propDefs[pd.ID] = propDef{name: pd.Name, dataType: dt}
+		out.PropertyDefinitions = append(out.PropertyDefinitions, PropertyDefinition{
+			ID:       pd.ID,
+			Name:     pd.Name,
+			DataType: dt,
+		})
 	}
 
 	for _, e := range m.Elements {
 		elem := Element{
 			ID:            e.ID,
 			Type:          e.Type,
-			Name:          e.Name,
-			Documentation: e.Documentation,
+			Name:          firstLang(e.Names, ""),
+			Documentation: firstLang(e.Documentations, ""),
 		}
 		for _, p := range e.Properties {
-			key := propNames[p.DefinitionRef]
+			def := propDefs[p.DefinitionRef]
+			key := def.name
 			if key == "" {
 				key = p.DefinitionRef
 			}
-			if key != "" && p.Value != "" {
-				elem.Properties = append(elem.Properties, Property{Key: key, Value: p.Value})
+			val := firstLang(p.Values, "")
+			if key != "" && val != "" {
+				elem.Properties = append(elem.Properties, Property{Key: key, Value: val})
 			}
 		}
 		out.Elements = append(out.Elements, elem)
 	}
 
 	for _, r := range m.Relationships {
-		out.Relationships = append(out.Relationships, Relationship(r))
+		rel := Relationship{
+			ID:            r.ID,
+			Type:          r.Type,
+			Source:        r.Source,
+			Target:        r.Target,
+			Name:          firstLang(r.Names, ""),
+			Documentation: firstLang(r.Documentations, ""),
+			AccessType:    r.AccessType,
+			Modifier:      r.Modifier,
+		}
+		if strings.EqualFold(r.IsDirected, "true") {
+			rel.IsDirected = true
+		}
+		out.Relationships = append(out.Relationships, rel)
 	}
 
 	for _, v := range m.Views {
 		d := Diagram{
 			ID:            v.ID,
-			Name:          v.Name,
-			Documentation: v.Documentation,
+			Name:          firstLang(v.Names, ""),
+			Documentation: firstLang(v.Documentations, ""),
+			Viewpoint:     v.Viewpoint,
+			ViewpointRef:  v.ViewpointRef,
 		}
 		collectNodes(v.Nodes, "", &d.Layout.Nodes)
 		for _, c := range v.Connections {
-			cl := ConnectionLayout{RelationshipID: c.RelationshipRef}
+			cl := ConnectionLayout{
+				RelationshipID: c.RelationshipRef,
+				Label:          firstLang(c.Labels, ""),
+				Style:          convertConnStyle(c.Style),
+			}
 			for _, bp := range c.Bendpoints {
 				cl.Bendpoints = append(cl.Bendpoints, Point(bp))
 			}
@@ -162,6 +253,68 @@ func (m *aoefModel) toModel() *Model {
 	return out
 }
 
+// convertRGBColor converts an AOEF colour to the model type.
+func convertRGBColor(c *aoefRGBColor) *RGBColor {
+	if c == nil {
+		return nil
+	}
+	col := &RGBColor{R: c.R, G: c.G, B: c.B}
+	if c.A != "" {
+		v, err := strconv.Atoi(c.A)
+		if err == nil {
+			col.A = &v
+		}
+	}
+	return col
+}
+
+// convertFont converts an AOEF font to the model type.
+func convertFont(f *aoefFont) *FontStyle {
+	if f == nil {
+		return nil
+	}
+	return &FontStyle{
+		Name:  f.Name,
+		Size:  f.Size,
+		Style: f.Style,
+		Color: convertRGBColor(f.Color),
+	}
+}
+
+// convertNodeStyle converts an AOEF style to a NodeStyle.
+func convertNodeStyle(s *aoefStyle) *NodeStyle {
+	if s == nil {
+		return nil
+	}
+	ns := &NodeStyle{
+		FillColor: convertRGBColor(s.FillColor),
+		LineColor: convertRGBColor(s.LineColor),
+		Font:      convertFont(s.Font),
+		LineWidth: s.LineWidth,
+	}
+	// Return nil if nothing was set.
+	if ns.FillColor == nil && ns.LineColor == nil && ns.Font == nil && ns.LineWidth == 0 {
+		return nil
+	}
+	return ns
+}
+
+// convertConnStyle converts an AOEF style to a ConnStyle.
+func convertConnStyle(s *aoefStyle) *ConnStyle {
+	if s == nil {
+		return nil
+	}
+	cs := &ConnStyle{
+		LineColor: convertRGBColor(s.LineColor),
+		Font:      convertFont(s.Font),
+		LineWidth: s.LineWidth,
+	}
+	if cs.LineColor == nil && cs.Font == nil && cs.LineWidth == 0 {
+		return nil
+	}
+	return cs
+}
+
 // collectViewOrg recursively traverses an organization item.
 // Returns (folders, diagramFolderAssignments, containsAnyViewRef).
 // Folders are returned in pre-order (parent before children) for safe DB insertion.
@@ -174,7 +327,7 @@ func collectViewOrg(item aoefOrgItem, parentSourceID string, viewIDs map[string]
 				FolderSourceID:  parentSourceID,
 			}}, true
 		}
-		return nil, nil, false // element ref — skip
+		return nil, nil, false // element/relationship ref — skip
 	}
 
 	// Folder item: compute this folder's source ID.
@@ -238,11 +391,13 @@ func collectNodes(nodes []aoefNode, parentElementID string, out *[]NodeLayout) {
 			*out = append(*out, NodeLayout{
 				ElementID:       n.ElementRef,
 				ParentElementID: parentElementID,
+				NodeType:        n.NodeType,
 				X:               n.X, Y: n.Y, W: n.W, H: n.H,
+				Style: convertNodeStyle(n.Style),
 			})
 			collectNodes(n.Children, n.ElementRef, out)
 		} else {
-			// Node without elementRef (pure grouping container) — pass parent through
+			// Node without elementRef (pure grouping container) — pass parent through.
 			collectNodes(n.Children, parentElementID, out)
 		}
 	}

--- a/internal/parser/archimetal_test.go
+++ b/internal/parser/archimetal_test.go
@@ -1,0 +1,103 @@
+package parser_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/DisruptiveWorks/archipulse/internal/parser"
+)
+
+// TestParseAOEF_ArchiMetal validates full OEF coverage using the local ArchiMetal example.
+// It exercises: multi-language names, xsi:type on elements, node styles, viewpoints,
+// property definitions with data types, and relationship semantic attributes.
+func TestParseAOEF_ArchiMetal(t *testing.T) {
+	f, err := os.Open("../../examples/ArchiMetal.xml")
+	if err != nil {
+		t.Skipf("ArchiMetal.xml not found — skipping: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	m, err := parser.ParseAOEF(f)
+	if err != nil {
+		t.Fatalf("ParseAOEF: %v", err)
+	}
+
+	if m.Name == "" {
+		t.Error("model name is empty")
+	}
+	t.Logf("Model: %q  version=%q", m.Name, m.Version)
+
+	if len(m.Elements) == 0 {
+		t.Error("expected elements, got 0")
+	}
+	if len(m.Diagrams) == 0 {
+		t.Error("expected diagrams, got 0")
+	}
+
+	t.Logf("Elements: %d  Relationships: %d  Diagrams: %d",
+		len(m.Elements), len(m.Relationships), len(m.Diagrams))
+	t.Logf("ViewFolders: %d  DiagramFolders: %d  PropertyDefinitions: %d",
+		len(m.ViewFolders), len(m.DiagramFolders), len(m.PropertyDefinitions))
+
+	// All elements must have a non-empty name (multi-lang parsing must work).
+	for _, e := range m.Elements {
+		if e.Name == "" {
+			t.Errorf("element %q has empty name (multi-lang parsing failure)", e.ID)
+		}
+	}
+
+	// Property definitions must carry their data type.
+	for _, pd := range m.PropertyDefinitions {
+		if pd.DataType == "" {
+			t.Errorf("property definition %q has empty data_type", pd.Name)
+		}
+		t.Logf("  PropDef: %-30q  type=%q", pd.Name, pd.DataType)
+	}
+
+	// Count nodes with style information.
+	styledNodes := 0
+	for _, d := range m.Diagrams {
+		for _, n := range d.Layout.Nodes {
+			if n.Style != nil {
+				styledNodes++
+			}
+		}
+	}
+	t.Logf("Nodes with style: %d", styledNodes)
+
+	// Count connections with style.
+	styledConns := 0
+	for _, d := range m.Diagrams {
+		for _, c := range d.Layout.Connections {
+			if c.Style != nil {
+				styledConns++
+			}
+		}
+	}
+	t.Logf("Connections with style: %d", styledConns)
+
+	// Count diagrams with a viewpoint attribute.
+	viewpointed := 0
+	for _, d := range m.Diagrams {
+		if d.Viewpoint != "" {
+			viewpointed++
+		}
+	}
+	t.Logf("Diagrams with viewpoint: %d", viewpointed)
+
+	// Relationship semantic attributes.
+	accessCount, directedCount, influenceCount := 0, 0, 0
+	for _, r := range m.Relationships {
+		if r.AccessType != "" {
+			accessCount++
+		}
+		if r.IsDirected {
+			directedCount++
+		}
+		if r.Modifier != "" {
+			influenceCount++
+		}
+	}
+	t.Logf("Access rels with accessType: %d  Directed assoc: %d  Influence with modifier: %d",
+		accessCount, directedCount, influenceCount)
+}

--- a/internal/parser/model.go
+++ b/internal/parser/model.go
@@ -3,12 +3,21 @@ package parser
 // Model is the in-memory representation of a parsed ArchiMate model.
 // It is format-agnostic — produced by both the AOEF and AJX parsers.
 type Model struct {
-	Name           string
-	Elements       []Element
-	Relationships  []Relationship
-	Diagrams       []Diagram
-	ViewFolders    []ViewFolder    // folder hierarchy from <views> organization
-	DiagramFolders []DiagramFolder // diagram → folder assignments
+	Name                string
+	Version             string
+	Elements            []Element
+	Relationships       []Relationship
+	Diagrams            []Diagram
+	ViewFolders         []ViewFolder         // folder hierarchy from <organizations>
+	DiagramFolders      []DiagramFolder      // diagram → folder assignments
+	PropertyDefinitions []PropertyDefinition // typed property definitions
+}
+
+// PropertyDefinition mirrors an OEF <propertyDefinition> with its data type.
+type PropertyDefinition struct {
+	ID       string // source identifier from AOEF
+	Name     string
+	DataType string // string|boolean|currency|date|time|number
 }
 
 // ViewFolder represents a folder node in the diagram view hierarchy.
@@ -44,10 +53,14 @@ type Property struct {
 type Relationship struct {
 	ID            string
 	Type          string
-	Source        string // element ID
-	Target        string // element ID
+	Source        string // element source_id
+	Target        string // element source_id
 	Name          string
 	Documentation string
+	// Type-specific semantic attributes (OEF standard).
+	AccessType string // Access relationship: Access|Read|Write|ReadWrite
+	IsDirected bool   // Association relationship: directed flag
+	Modifier   string // Influence relationship: strength/sign e.g. "+", "--", "5"
 }
 
 // Diagram represents an ArchiMate view (AOEF <view>).
@@ -55,6 +68,8 @@ type Diagram struct {
 	ID            string
 	Name          string
 	Documentation string
+	Viewpoint     string // viewpoint attribute (named or free-form)
+	ViewpointRef  string // identifierRef to a defined viewpoint
 	Layout        DiagramLayout
 }
 
@@ -64,18 +79,52 @@ type DiagramLayout struct {
 	Connections []ConnectionLayout
 }
 
-// NodeLayout holds the position and size of an element within a diagram.
+// NodeLayout holds the position, size, and optional style of a node within a diagram.
 type NodeLayout struct {
 	ElementID       string
 	ParentElementID string // empty if top-level node
+	NodeType        string // xsi:type: Element|Container|Label|etc. (empty = Element)
 	X, Y            int
 	W, H            int
+	Style           *NodeStyle
 }
 
-// ConnectionLayout holds the visual path of a relationship within a diagram.
+// ConnectionLayout holds the visual path and optional style of a connection.
 type ConnectionLayout struct {
 	RelationshipID string
+	Label          string // override label shown on the connection in this diagram
 	Bendpoints     []Point
+	Style          *ConnStyle
+}
+
+// NodeStyle captures visual styling from OEF <style> on a node.
+type NodeStyle struct {
+	FillColor *RGBColor
+	LineColor *RGBColor
+	Font      *FontStyle
+	LineWidth int // 0 means not set
+}
+
+// ConnStyle captures visual styling from OEF <style> on a connection.
+type ConnStyle struct {
+	LineColor *RGBColor
+	Font      *FontStyle
+	LineWidth int // 0 means not set
+}
+
+// RGBColor is an RGBA colour value from OEF.
+// Alpha is 0–100 (0 = transparent, 100 = opaque); nil means not specified.
+type RGBColor struct {
+	R, G, B int
+	A       *int
+}
+
+// FontStyle captures font metadata from OEF <font>.
+type FontStyle struct {
+	Name  string    // font family name
+	Size  string    // size in points (stored as string to preserve half-granularity)
+	Style string    // space-separated: plain|bold|italic|underline
+	Color *RGBColor // text colour
 }
 
 // Point is a 2D coordinate.

--- a/migrations/011_relationship_attributes.sql
+++ b/migrations/011_relationship_attributes.sql
@@ -1,0 +1,7 @@
+-- Migration 011: relationship_attributes
+-- Captures OEF relationship type-specific attributes that carry semantic meaning.
+
+ALTER TABLE relationships
+    ADD COLUMN IF NOT EXISTS access_type  TEXT,                          -- Access: Access|Read|Write|ReadWrite
+    ADD COLUMN IF NOT EXISTS is_directed  BOOLEAN NOT NULL DEFAULT false, -- Association: directed or undirected
+    ADD COLUMN IF NOT EXISTS modifier     TEXT;                          -- Influence: strength/sign (+, -, ++, etc.)

--- a/migrations/012_diagram_viewpoint.sql
+++ b/migrations/012_diagram_viewpoint.sql
@@ -1,0 +1,6 @@
+-- Migration 012: diagram_viewpoint
+-- Stores the ArchiMate viewpoint associated with each view/diagram.
+
+ALTER TABLE diagrams
+    ADD COLUMN IF NOT EXISTS viewpoint     TEXT, -- e.g. "Layered", "Application Usage", free-form or enum value
+    ADD COLUMN IF NOT EXISTS viewpoint_ref TEXT; -- identifierRef to a viewpoint defined in <viewpoints>

--- a/migrations/013_property_definitions.sql
+++ b/migrations/013_property_definitions.sql
@@ -1,0 +1,15 @@
+-- Migration 013: property_definitions
+-- Stores OEF <propertyDefinition> entries with their data type per workspace.
+-- This is the schema-level definition; actual values live in element_properties.
+
+CREATE TABLE IF NOT EXISTS property_definitions (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id    UUID NOT NULL REFERENCES workspaces (id) ON DELETE CASCADE,
+    source_id       TEXT NOT NULL,          -- original identifier from AOEF file
+    name            TEXT NOT NULL DEFAULT '',
+    data_type       TEXT NOT NULL DEFAULT 'string', -- string|boolean|currency|date|time|number
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (workspace_id, source_id)
+);
+
+CREATE INDEX IF NOT EXISTS property_definitions_workspace_idx ON property_definitions (workspace_id);


### PR DESCRIPTION
## Summary

- **Parser**: captura completa del estándar OEF — atributos semánticos de relaciones (`accessType`, `isDirected`, `modifier`), estilos visuales por nodo y conexión (`fillColor`, `lineColor`, `font`, `lineWidth`), viewpoint por diagrama, tipos de propiedad, multi-idioma, versión del modelo
- **DB**: 3 nuevas migraciones — atributos en `relationships` (011), viewpoint en `diagrams` (012), tabla `property_definitions` con `data_type` (013)
- **Frontend**: marcadores de `Access` varían según `accessType` (Read/Write/ReadWrite), `Association` dirigidas muestran flecha, labels e `Influence` modifier se renderizan sobre el edge
- **Docs**: `docs/schema.md` con diagrama ER en Mermaid, estructura del JSON `layout`, y referencia de atributos semánticos

## Test plan

- [ ] `go test ./...` pasa sin errores
- [ ] `golangci-lint run ./...` sin nuevos warnings
- [ ] Frontend build limpio (`npm run build`)
- [ ] Migraciones 011–013 idempotentes (`IF NOT EXISTS`)
- [ ] Re-importar `ArchiMetal.xml` — verificar `access_type` en 57 relaciones Access
- [ ] Diagramas con relaciones `Access` muestran flechas correctas según `accessType`
- [ ] `docs/schema.md` renderiza el ER diagram en GitHub