### PR TITLE
fix(diagram): use OEF node identifiers for exact edge-instance resolution

### DIFF
--- a/cmd/archipulse/ui/src/components/views/DiagramView.svelte
+++ b/cmd/archipulse/ui/src/components/views/DiagramView.svelte
@@ -58,15 +58,44 @@
         return c === 0 ? n.element_id : `${n.element_id}_${c}`;
       });
 
-      // Build a lookup of raw node data by element_id (first occurrence wins — used for edges).
+      // Build a lookup of raw node data by element_id (first occurrence wins — used for edge bounds).
       const nodeById = {};
       for (const n of rawNodes) {
         if (!nodeById[n.element_id]) nodeById[n.element_id] = n;
       }
 
-      // Also build lookup by instance ID for parent resolution.
-      const nodeByInstanceId = {};
-      rawNodes.forEach((n, i) => { nodeByInstanceId[nodeInstanceId[i]] = n; });
+      // Build a lookup of raw node data by node_id (OEF diagram identifier — always unique).
+      const nodeByNodeId = {};
+      for (const n of rawNodes) {
+        if (n.node_id) nodeByNodeId[n.node_id] = n;
+      }
+
+      // Build a map of element_id → all instances [{iid, idx, node}] for parent resolution.
+      // When the same element appears multiple times, spatial containment picks the right parent.
+      const instancesByElemId = {};
+      rawNodes.forEach((n, i) => {
+        const iid = nodeInstanceId[i];
+        if (!instancesByElemId[n.element_id]) instancesByElemId[n.element_id] = [];
+        instancesByElemId[n.element_id].push({ iid, idx: i, node: n });
+      });
+
+      // Given a child node, return the correct parent instance ({iid, node}) using spatial containment.
+      function resolveParentInstance(child) {
+        if (!child.parent_element_id) return null;
+        const candidates = instancesByElemId[child.parent_element_id];
+        if (!candidates || candidates.length === 0) return null;
+        if (candidates.length === 1) return candidates[0];
+        // Multiple parent instances: find the one whose bounds contain the child.
+        for (const c of candidates) {
+          const p = c.node;
+          if (child.x >= p.x && child.y >= p.y &&
+              child.x + child.w <= p.x + p.w &&
+              child.y + child.h <= p.y + p.h) {
+            return c;
+          }
+        }
+        return candidates[0]; // fallback
+      }
 
       // Nodes that appear as a parent_element_id of another node are containers.
       const containerIds = new Set(
@@ -83,13 +112,9 @@
         if (seenInstances.has(iid)) return;
         const n = rawNodes[idx];
         if (n.parent_element_id) {
-          // Find the parent instance — prefer the one with matching parent_element_id
-          const parentIdx = rawNodes.findIndex((p, pi) =>
-            p.element_id === n.parent_element_id && !seenInstances.has(nodeInstanceId[pi])
-              ? false : p.element_id === n.parent_element_id
-          );
-          if (parentIdx >= 0 && !seenInstances.has(nodeInstanceId[parentIdx])) {
-            visit(parentIdx);
+          const parentInst = resolveParentInstance(n);
+          if (parentInst && !seenInstances.has(parentInst.iid)) {
+            visit(parentInst.idx);
           }
         }
         seenInstances.add(iid);
@@ -100,8 +125,9 @@
       nodes = sortedIndices.map(i => {
         const n = rawNodes[i];
         const iid = nodeInstanceId[i];
-        const parentId = n.parent_element_id || null;
-        const parent = parentId ? nodeById[parentId] : null;
+        const parentInst = resolveParentInstance(n);
+        const parentIid = parentInst?.iid || null;
+        const parent = parentInst?.node || null;
         const isContainer = containerIds.has(n.element_id);
         const isVS = n.element_type === 'ValueStream';
 
@@ -114,7 +140,7 @@
           id: iid,
           type: isVS ? 'valuestream' : 'archimate',
           position,
-          ...(parentId ? { parentId, extent: 'parent' } : {}),
+          ...(parentIid ? { parentId: parentIid, extent: 'parent' } : {}),
           data: { label: n.element_name, elementType: n.element_type, isContainer },
           style: `width:${n.w}px;height:${n.h}px;`,
           draggable: false,
@@ -123,15 +149,25 @@
         };
       });
 
+      // Build an exact map from OEF node_id → XY Flow instance id.
+      // This lets edges resolve the correct instance without any heuristic.
+      const nodeIdToIid = {};
+      rawNodes.forEach((n, i) => {
+        if (n.node_id) nodeIdToIid[n.node_id] = nodeInstanceId[i];
+      });
+
       // Edges: pass raw bounds (absolute coords) and bendpoints so ArchiMateEdge
       // can compute the path without relying on XY Flow's handle positions.
       edges = (data.connections || []).map(c => {
-        const src = nodeById[c.source_element_id];
-        const tgt = nodeById[c.target_element_id];
+        // Use OEF node_id for exact instance resolution; fall back to element_id for old layouts.
+        const srcIid = (c.source_node_id && nodeIdToIid[c.source_node_id]) || c.source_element_id;
+        const tgtIid = (c.target_node_id && nodeIdToIid[c.target_node_id]) || c.target_element_id;
+        const src = (c.source_node_id && nodeByNodeId[c.source_node_id]) || nodeById[c.source_element_id];
+        const tgt = (c.target_node_id && nodeByNodeId[c.target_node_id]) || nodeById[c.target_element_id];
         return {
           id: c.relationship_id,
-          source: c.source_element_id,
-          target: c.target_element_id,
+          source: srcIid,
+          target: tgtIid,
           type: 'archimate',
           data: {
             relationshipType: c.relationship_type,

--- a/internal/diagram/diagram.go
+++ b/internal/diagram/diagram.go
@@ -145,6 +145,7 @@ type ConnStyle struct {
 
 // RenderNode is a node enriched with element metadata for rendering.
 type RenderNode struct {
+	NodeID          string     `json:"node_id,omitempty"`           // OEF diagram node identifier (unique within view)
 	ElementID       string     `json:"element_id"`
 	ParentElementID string     `json:"parent_element_id,omitempty"`
 	NodeType        string     `json:"node_type,omitempty"`
@@ -161,6 +162,8 @@ type RenderNode struct {
 type RenderConnection struct {
 	RelationshipID   string     `json:"relationship_id"`
 	RelationshipType string     `json:"relationship_type"`
+	SourceNodeID     string     `json:"source_node_id,omitempty"`  // OEF diagram node identifier
+	TargetNodeID     string     `json:"target_node_id,omitempty"`  // OEF diagram node identifier
 	SourceElementID  string     `json:"source_element_id"`
 	TargetElementID  string     `json:"target_element_id"`
 	Reversed         bool       `json:"reversed,omitempty"` // true when the connection is drawn opposite to the semantic relationship direction
@@ -197,6 +200,7 @@ func (s *Store) Render(diagramID uuid.UUID) (*RenderData, error) {
 	// Parse the stored layout JSON.
 	var layout struct {
 		Nodes []struct {
+			NodeID          string     `json:"NodeID"`
 			ElementID       string     `json:"ElementID"`
 			ParentElementID string     `json:"ParentElementID"`
 			NodeType        string     `json:"NodeType"`
@@ -210,6 +214,8 @@ func (s *Store) Render(diagramID uuid.UUID) (*RenderData, error) {
 		} `json:"Nodes"`
 		Connections []struct {
 			RelationshipID  string `json:"RelationshipID"`
+			SourceNodeID    string `json:"SourceNodeID"`
+			TargetNodeID    string `json:"TargetNodeID"`
 			SourceElementID string `json:"SourceElementID"`
 			TargetElementID string `json:"TargetElementID"`
 			Label           string `json:"Label"`
@@ -322,6 +328,7 @@ func (s *Store) Render(diagramID uuid.UUID) (*RenderData, error) {
 			name = n.Label
 		}
 		rd.Nodes = append(rd.Nodes, RenderNode{
+			NodeID:          n.NodeID,
 			ElementID:       n.ElementID,
 			ParentElementID: n.ParentElementID,
 			NodeType:        n.NodeType,
@@ -361,6 +368,8 @@ func (s *Store) Render(diagramID uuid.UUID) (*RenderData, error) {
 		rd.Connections = append(rd.Connections, RenderConnection{
 			RelationshipID:   c.RelationshipID,
 			RelationshipType: meta.typ,
+			SourceNodeID:     c.SourceNodeID,
+			TargetNodeID:     c.TargetNodeID,
 			SourceElementID:  srcElem,
 			TargetElementID:  tgtElem,
 			Reversed:         reversed,

--- a/internal/diagram/diagram.go
+++ b/internal/diagram/diagram.go
@@ -145,7 +145,7 @@ type ConnStyle struct {
 
 // RenderNode is a node enriched with element metadata for rendering.
 type RenderNode struct {
-	NodeID          string     `json:"node_id,omitempty"`           // OEF diagram node identifier (unique within view)
+	NodeID          string     `json:"node_id,omitempty"` // OEF diagram node identifier (unique within view)
 	ElementID       string     `json:"element_id"`
 	ParentElementID string     `json:"parent_element_id,omitempty"`
 	NodeType        string     `json:"node_type,omitempty"`
@@ -162,8 +162,8 @@ type RenderNode struct {
 type RenderConnection struct {
 	RelationshipID   string     `json:"relationship_id"`
 	RelationshipType string     `json:"relationship_type"`
-	SourceNodeID     string     `json:"source_node_id,omitempty"`  // OEF diagram node identifier
-	TargetNodeID     string     `json:"target_node_id,omitempty"`  // OEF diagram node identifier
+	SourceNodeID     string     `json:"source_node_id,omitempty"` // OEF diagram node identifier
+	TargetNodeID     string     `json:"target_node_id,omitempty"` // OEF diagram node identifier
 	SourceElementID  string     `json:"source_element_id"`
 	TargetElementID  string     `json:"target_element_id"`
 	Reversed         bool       `json:"reversed,omitempty"` // true when the connection is drawn opposite to the semantic relationship direction

--- a/internal/parser/aoef.go
+++ b/internal/parser/aoef.go
@@ -240,6 +240,8 @@ func (m *aoefModel) toModel() *Model {
 		for _, c := range v.Connections {
 			cl := ConnectionLayout{
 				RelationshipID:  c.RelationshipRef,
+				SourceNodeID:    c.Source,
+				TargetNodeID:    c.Target,
 				SourceElementID: nodeToElem[c.Source],
 				TargetElementID: nodeToElem[c.Target],
 				Label:           firstLang(c.Labels, ""),
@@ -407,6 +409,7 @@ func collectNodes(nodes []aoefNode, parentElementID string, out *[]NodeLayout) {
 	for _, n := range nodes {
 		if n.ElementRef != "" {
 			*out = append(*out, NodeLayout{
+				NodeID:          n.Identifier,
 				ElementID:       n.ElementRef,
 				ParentElementID: parentElementID,
 				NodeType:        n.NodeType,
@@ -419,6 +422,7 @@ func collectNodes(nodes []aoefNode, parentElementID string, out *[]NodeLayout) {
 			// Only emit if it has actual dimensions (skip degenerate placeholder nodes).
 			label := firstLang(n.Labels, "")
 			*out = append(*out, NodeLayout{
+				NodeID:          n.Identifier,
 				ElementID:       n.Identifier,
 				ParentElementID: parentElementID,
 				NodeType:        n.NodeType,

--- a/internal/parser/model.go
+++ b/internal/parser/model.go
@@ -81,6 +81,7 @@ type DiagramLayout struct {
 
 // NodeLayout holds the position, size, and optional style of a node within a diagram.
 type NodeLayout struct {
+	NodeID          string // diagram-level node identifier from OEF (unique within the view)
 	ElementID       string
 	ParentElementID string // empty if top-level node
 	NodeType        string // xsi:type: Element|Container|Label|etc. (empty = Element)
@@ -94,6 +95,8 @@ type NodeLayout struct {
 // ConnectionLayout holds the visual path and optional style of a connection.
 type ConnectionLayout struct {
 	RelationshipID  string
+	SourceNodeID    string // OEF node identifier of the visual source node
+	TargetNodeID    string // OEF node identifier of the visual target node
 	SourceElementID string // element ID of the connection's visual source node
 	TargetElementID string // element ID of the connection's visual target node
 	Label           string // override label shown on the connection in this diagram


### PR DESCRIPTION
## Summary

- **Root cause**: OEF `<connection>` source/target reference diagram node identifiers (unique per view), not element IDs. When the same element appears multiple times, the previous centroid heuristic routed edges to the wrong instance.
- **Fix**: Preserve OEF node identifiers through the full stack (parser → DB → render API → frontend) for exact instance lookup with no guesswork.
- Parent-child resolution (spatial containment) is retained — it remains geometrically correct.

## Test plan

- [ ] Re-import ArchiMetal — verify Figure32 edges connect to the correct instances
- [ ] Verify all other diagrams are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)