### PR TITLE
fix(diagram): replace context-stroke markers with hardcoded color variants

### DIFF
--- a/cmd/archipulse/ui/src/components/diagram/ArchiMateEdge.svelte
+++ b/cmd/archipulse/ui/src/components/diagram/ArchiMateEdge.svelte
@@ -9,7 +9,7 @@
   // Props passed by XY Flow: id, sourceX, sourceY, targetX, targetY, data, ...
   // We only use `data`.
 
-  import { getRelationshipStyle, intersectNodeBoundary } from './archimate-edges.js';
+  import { getRelationshipStyle, markerColorKey, intersectNodeBoundary } from './archimate-edges.js';
 
   export let data;
 
@@ -46,7 +46,14 @@
     hasBps,
   );
 
-  $: allPts = [startPt, ...bps, endPt];
+  // Remove consecutive duplicate points to avoid NaN in smoothPath (Archi sometimes emits them).
+  function dedupePts(pts) {
+    return pts.filter((p, i) =>
+      i === 0 || p.x !== pts[i - 1].x || p.y !== pts[i - 1].y
+    );
+  }
+
+  $: allPts = dedupePts([startPt, ...bps, endPt]);
 
   // Build a smooth polyline with small rounded corners at intermediate bendpoints.
   function smoothPath(pts) {
@@ -84,14 +91,20 @@
   })();
 
   $: reversed    = data?.reversed || false;
+  $: ck          = markerColorKey(style.stroke);
+
+  // Build a marker URL with the color suffix (e.g. "am-open-arrow-light").
+  // The open-arrow-rev marker only exists in 'light' — force it regardless of ck.
+  function markerId(type) {
+    if (!type) return undefined;
+    const suffix = type === 'open-arrow-rev' ? 'light' : ck;
+    return `url(#am-${type}-${suffix})`;
+  }
+
   // When the connection is drawn opposite to the semantic relationship direction,
   // swap the markers so the arrowhead stays at the semantic target.
-  $: markerEnd   = reversed
-    ? (style.start ? `url(#am-${style.start})` : undefined)
-    : (style.end   ? `url(#am-${style.end})`   : undefined);
-  $: markerStart = reversed
-    ? (style.end   ? `url(#am-${style.end})`   : undefined)
-    : (style.start ? `url(#am-${style.start})` : undefined);
+  $: markerEnd   = reversed ? markerId(style.start) : markerId(style.end);
+  $: markerStart = reversed ? markerId(style.end)   : markerId(style.start);
 </script>
 
 <!-- Invisible wider stroke for hover/selection interactions -->

--- a/cmd/archipulse/ui/src/components/diagram/archimate-edges.js
+++ b/cmd/archipulse/ui/src/components/diagram/archimate-edges.js
@@ -15,6 +15,14 @@
 //   Write     → open-arrow at end  (towards target = data flows from source to target)
 //   ReadWrite → open-arrow at both ends
 
+// Color keys map stroke colors to marker ID suffixes.
+// Markers are defined with hardcoded colors (no context-stroke) for broad browser support.
+const COLOR_KEY = {
+  '#374151': 'dark',
+  '#6B7280': 'mid',
+  '#9CA3AF': 'light',
+};
+
 export const RELATIONSHIP_STYLES = {
   TriggeringRelationship:     { stroke: '#374151', width: 1.5, dash: null,  end: 'filled-arrow',  start: null },
   FlowRelationship:           { stroke: '#374151', width: 1.5, dash: '8 4', end: 'filled-arrow',  start: null },
@@ -29,6 +37,11 @@ export const RELATIONSHIP_STYLES = {
   InfluenceRelationship:      { stroke: '#9CA3AF', width: 1.2, dash: '6 3', end: 'open-arrow',    start: null },
   SpecializationRelationship: { stroke: '#374151', width: 1.5, dash: null,  end: 'open-triangle', start: null },
 };
+
+/** Returns the marker ID suffix for a given stroke color. */
+export function markerColorKey(stroke) {
+  return COLOR_KEY[stroke] || 'dark';
+}
 
 const DEFAULT_STYLE = { stroke: '#6B7280', width: 1.2, dash: null, end: 'filled-arrow', start: null };
 

--- a/cmd/archipulse/ui/src/components/views/DiagramView.svelte
+++ b/cmd/archipulse/ui/src/components/views/DiagramView.svelte
@@ -193,54 +193,67 @@
 
 <!--
   Global ArchiMate SVG marker definitions.
-  Defined here (outside any SVG) as a hidden SVG so they are accessible
-  via url(#...) from the XY Flow edge SVG on the same page.
-  Markers use `context-stroke` to inherit the edge's stroke color.
+  Colors are hardcoded per variant (dark/mid/light) instead of using context-stroke,
+  which is not reliably supported in Chrome when markers are defined outside the
+  referencing SVG element.
+    dark = #374151  (Triggering, Flow, Assignment, Serving, Composition, Aggregation, Specialization)
+    mid  = #6B7280  (Realization)
+    light= #9CA3AF  (Association, Access, Influence)
 -->
 <svg width="0" height="0" style="position:absolute;overflow:hidden;pointer-events:none;">
   <defs>
-    <!-- Filled arrowhead — Triggering, Flow, Assignment end -->
-    <marker id="am-filled-arrow" viewBox="0 0 8 6" markerWidth="8" markerHeight="6"
+    <!-- Filled arrowhead — dark only (Triggering, Flow, Assignment end) -->
+    <marker id="am-filled-arrow-dark" viewBox="0 0 8 6" markerWidth="8" markerHeight="6"
       refX="8" refY="3" orient="auto">
-      <polygon points="0,0 8,3 0,6" fill="context-stroke" />
+      <polygon points="0,0 8,3 0,6" fill="#374151" />
     </marker>
 
-    <!-- Open V arrowhead — Association, Serving, Access Write, Influence -->
-    <marker id="am-open-arrow" viewBox="0 0 8 8" markerWidth="8" markerHeight="8"
+    <!-- Open V arrowhead — dark (Serving) -->
+    <marker id="am-open-arrow-dark" viewBox="0 0 8 8" markerWidth="8" markerHeight="8"
       refX="7" refY="4" orient="auto">
-      <path d="M 0,0 L 7,4 L 0,8" fill="none" stroke="context-stroke" stroke-width="1.4" />
+      <path d="M 0,0 L 7,4 L 0,8" fill="none" stroke="#374151" stroke-width="1.4" />
     </marker>
 
-    <!-- Open V arrowhead reversed — Access Read (marker-start, points INTO source) -->
-    <marker id="am-open-arrow-rev" viewBox="0 0 8 8" markerWidth="8" markerHeight="8"
+    <!-- Open V arrowhead — light (Association directed, Access Write, Influence) -->
+    <marker id="am-open-arrow-light" viewBox="0 0 8 8" markerWidth="8" markerHeight="8"
+      refX="7" refY="4" orient="auto">
+      <path d="M 0,0 L 7,4 L 0,8" fill="none" stroke="#9CA3AF" stroke-width="1.4" />
+    </marker>
+
+    <!-- Open V arrowhead reversed — light only (Access Read/ReadWrite marker-start) -->
+    <marker id="am-open-arrow-rev-light" viewBox="0 0 8 8" markerWidth="8" markerHeight="8"
       refX="7" refY="4" orient="auto-start-reverse">
-      <path d="M 0,0 L 7,4 L 0,8" fill="none" stroke="context-stroke" stroke-width="1.4" />
+      <path d="M 0,0 L 7,4 L 0,8" fill="none" stroke="#9CA3AF" stroke-width="1.4" />
     </marker>
 
-    <!-- Hollow closed triangle — Realization, Specialization -->
-    <marker id="am-open-triangle" viewBox="0 0 10 8" markerWidth="10" markerHeight="8"
+    <!-- Hollow closed triangle — mid (Realization) -->
+    <marker id="am-open-triangle-mid" viewBox="0 0 10 8" markerWidth="10" markerHeight="8"
       refX="10" refY="4" orient="auto">
-      <polygon points="0,0 10,4 0,8" fill="#F8FAFC" stroke="context-stroke" stroke-width="1.4" />
+      <polygon points="0,0 10,4 0,8" fill="#F8FAFC" stroke="#6B7280" stroke-width="1.4" />
     </marker>
 
-    <!-- Filled diamond at source — Composition -->
-    <!-- refX="12": base of diamond sits at node boundary, tip extends outward into path -->
-    <marker id="am-filled-diamond" viewBox="-1 -1 14 10" markerWidth="14" markerHeight="10"
+    <!-- Hollow closed triangle — dark (Specialization) -->
+    <marker id="am-open-triangle-dark" viewBox="0 0 10 8" markerWidth="10" markerHeight="8"
+      refX="10" refY="4" orient="auto">
+      <polygon points="0,0 10,4 0,8" fill="#F8FAFC" stroke="#374151" stroke-width="1.4" />
+    </marker>
+
+    <!-- Filled diamond at source — dark only (Composition) -->
+    <marker id="am-filled-diamond-dark" viewBox="-1 -1 14 10" markerWidth="14" markerHeight="10"
       refX="12" refY="4" orient="auto-start-reverse">
-      <polygon points="0,4 6,0 12,4 6,8" fill="context-stroke" />
+      <polygon points="0,4 6,0 12,4 6,8" fill="#374151" />
     </marker>
 
-    <!-- Hollow diamond at source — Aggregation -->
-    <marker id="am-open-diamond" viewBox="-1 -1 14 10" markerWidth="14" markerHeight="10"
+    <!-- Hollow diamond at source — dark only (Aggregation) -->
+    <marker id="am-open-diamond-dark" viewBox="-1 -1 14 10" markerWidth="14" markerHeight="10"
       refX="12" refY="4" orient="auto-start-reverse">
-      <polygon points="0,4 6,0 12,4 6,8" fill="#F8FAFC" stroke="context-stroke" stroke-width="1.4" />
+      <polygon points="0,4 6,0 12,4 6,8" fill="#F8FAFC" stroke="#374151" stroke-width="1.4" />
     </marker>
 
-    <!-- Filled circle at source — Assignment -->
-    <!-- refX="8": far edge of circle sits at node boundary, circle extends outward into path -->
-    <marker id="am-filled-circle" viewBox="-1 -1 10 10" markerWidth="8" markerHeight="8"
+    <!-- Filled circle at source — dark only (Assignment) -->
+    <marker id="am-filled-circle-dark" viewBox="-1 -1 10 10" markerWidth="8" markerHeight="8"
       refX="8" refY="4" orient="auto-start-reverse">
-      <circle cx="4" cy="4" r="4" fill="context-stroke" />
+      <circle cx="4" cy="4" r="4" fill="#374151" />
     </marker>
   </defs>
 </svg>


### PR DESCRIPTION
## Summary

`context-stroke` in SVG markers defined in a separate hidden SVG is not reliably supported in Chrome (especially Chrome mobile). This caused open arrowheads (Influence, Association directed, Realization, Access) to render invisibly in Chrome while working correctly in Safari.

**Fix:** define one marker per `(type, color)` combination with hardcoded hex colors:
- `dark` = `#374151` — Triggering, Flow, Assignment, Serving, Composition, Aggregation, Specialization
- `mid` = `#6B7280` — Realization
- `light` = `#9CA3AF` — Association, Access, Influence

`ArchiMateEdge` builds marker IDs as `am-{type}-{colorKey}` based on the relationship stroke color. `open-arrow-rev` is always `light` (only used by Access relationships).

**Also included:** deduplicate consecutive identical bendpoints before computing `smoothPath`, preventing `NaN` when Archi exports duplicate points (fixes stray arrow lines like the one in Figure15).

## Test plan

- [ ] Open Figure07 in Chrome and Chrome mobile — verify all arrowheads are visible on dashed lines
- [ ] Open Figure07 in Safari — verify unchanged
- [ ] Open Figure15 — verify no stray floating arrows
- [ ] Verify Realization (mid/gray triangle), Serving (dark open arrow), and Composition/Aggregation/Assignment markers still render correctly