### PR TITLE
feat(auth): workspace-level RBAC with membership table

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -28,11 +28,11 @@ func NewRouter(db *sql.DB, svc *auth.Service, oidc *auth.OIDCProvider, static ..
 		// Public auth endpoints — no authentication required.
 		svc.RegisterRoutes(r, oidc)
 
-		// Protected API: require a valid session + RBAC check.
+		// Protected API: require a valid session.
 		r.Group(func(r chi.Router) {
 			r.Use(svc.RequireAuth)
-			r.Use(svc.RequireRole)
-			registerWorkspaceRoutes(r, workspace.NewStore(db))
+			registerWorkspaceRoutes(r, workspace.NewStore(db), svc)
+			registerMembershipRoutes(r, svc)
 			registerElementRoutes(r, db)
 			registerRelationshipRoutes(r, db)
 			registerDiagramRoutes(r, db)

--- a/internal/api/membership_handler.go
+++ b/internal/api/membership_handler.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/DisruptiveWorks/archipulse/internal/auth"
+)
+
+type membershipHandler struct {
+	enforcer *auth.Enforcer
+}
+
+func (h *membershipHandler) list(w http.ResponseWriter, r *http.Request) {
+	wsID := chi.URLParam(r, "id")
+	members, err := h.enforcer.ListMembers(wsID)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
+	if members == nil {
+		members = []auth.WorkspaceMember{}
+	}
+	respondJSON(w, http.StatusOK, members)
+}
+
+func (h *membershipHandler) add(w http.ResponseWriter, r *http.Request) {
+	wsID := chi.URLParam(r, "id")
+	var body struct {
+		UserID string `json:"user_id"`
+		Role   string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		respondError(w, http.StatusBadRequest, errorf("invalid request body"))
+		return
+	}
+	if body.UserID == "" || body.Role == "" {
+		respondError(w, http.StatusBadRequest, errorf("user_id and role are required"))
+		return
+	}
+	caller := auth.ClaimsFromCtx(r.Context())
+	invitedBy := ""
+	if caller != nil {
+		invitedBy = caller.UserID
+	}
+	if err := h.enforcer.AddMember(wsID, body.UserID, body.Role, invitedBy); err != nil {
+		respondError(w, http.StatusBadRequest, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *membershipHandler) updateRole(w http.ResponseWriter, r *http.Request) {
+	wsID := chi.URLParam(r, "id")
+	userID := chi.URLParam(r, "userId")
+	var body struct {
+		Role string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		respondError(w, http.StatusBadRequest, errorf("invalid request body"))
+		return
+	}
+	if body.Role == "" {
+		respondError(w, http.StatusBadRequest, errorf("role is required"))
+		return
+	}
+	if err := h.enforcer.UpdateMemberRole(wsID, userID, body.Role); errors.Is(err, auth.ErrNoMembership) {
+		respondError(w, http.StatusNotFound, err)
+		return
+	} else if err != nil {
+		respondError(w, http.StatusBadRequest, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *membershipHandler) remove(w http.ResponseWriter, r *http.Request) {
+	wsID := chi.URLParam(r, "id")
+	userID := chi.URLParam(r, "userId")
+	if err := h.enforcer.RemoveMember(wsID, userID); errors.Is(err, auth.ErrNoMembership) {
+		respondError(w, http.StatusNotFound, err)
+		return
+	} else if err != nil {
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// registerMembershipRoutes mounts workspace membership endpoints.
+// These routes are nested under /workspaces/{id} and require at least owner access.
+func registerMembershipRoutes(r chi.Router, svc *auth.Service) {
+	h := &membershipHandler{enforcer: svc.Enforcer}
+	// GET /workspaces/{id}/members — viewers can list members
+	r.With(svc.RequireWorkspaceAccess(auth.RoleViewer)).
+		Get("/workspaces/{id}/members", h.list)
+	// POST /workspaces/{id}/members — owners can add members
+	r.With(svc.RequireWorkspaceAccess(auth.RoleOwner)).
+		Post("/workspaces/{id}/members", h.add)
+	// PUT /workspaces/{id}/members/{userId} — owners can update roles
+	r.With(svc.RequireWorkspaceAccess(auth.RoleOwner)).
+		Put("/workspaces/{id}/members/{userId}", h.updateRole)
+	// DELETE /workspaces/{id}/members/{userId} — owners can remove members
+	r.With(svc.RequireWorkspaceAccess(auth.RoleOwner)).
+		Delete("/workspaces/{id}/members/{userId}", h.remove)
+}

--- a/internal/api/workspace_handler.go
+++ b/internal/api/workspace_handler.go
@@ -8,11 +8,13 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 
+	"github.com/DisruptiveWorks/archipulse/internal/auth"
 	"github.com/DisruptiveWorks/archipulse/internal/workspace"
 )
 
 type workspaceHandler struct {
 	store *workspace.Store
+	svc   *auth.Service
 }
 
 func (h *workspaceHandler) list(w http.ResponseWriter, r *http.Request) {
@@ -60,6 +62,10 @@ func (h *workspaceHandler) create(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return
+	}
+	// Seed the creating user as workspace owner.
+	if claims := auth.ClaimsFromCtx(r.Context()); claims != nil {
+		_ = h.svc.Enforcer.SeedOwner(ws.ID.String(), claims.UserID)
 	}
 	respondJSON(w, http.StatusCreated, ws)
 }
@@ -113,8 +119,8 @@ func (h *workspaceHandler) delete(w http.ResponseWriter, r *http.Request) {
 }
 
 // registerWorkspaceRoutes mounts workspace endpoints on the given router.
-func registerWorkspaceRoutes(r chi.Router, store *workspace.Store) {
-	h := &workspaceHandler{store: store}
+func registerWorkspaceRoutes(r chi.Router, store *workspace.Store, svc *auth.Service) {
+	h := &workspaceHandler{store: store, svc: svc}
 	r.Get("/workspaces", h.list)
 	r.Post("/workspaces", h.create)
 	r.Get("/workspaces/{id}", h.get)

--- a/internal/auth/bootstrap.go
+++ b/internal/auth/bootstrap.go
@@ -52,7 +52,7 @@ func bootstrapDemo(svc *Service) error {
 
 	existing, err := svc.Users.GetByEmail(svc.Cfg.DemoEmail)
 	if err == ErrNotFound {
-		_, err = svc.Users.Create(svc.Cfg.DemoEmail, hash, "architect")
+		_, err = svc.Users.Create(svc.Cfg.DemoEmail, hash, "member")
 		if err != nil {
 			return fmt.Errorf("demo bootstrap create: %w", err)
 		}
@@ -67,9 +67,9 @@ func bootstrapDemo(svc *Service) error {
 	if err := svc.Users.UpdatePasswordHash(existing.ID.String(), hash); err != nil {
 		return fmt.Errorf("demo bootstrap update: %w", err)
 	}
-	// Ensure role is architect (may have been created as viewer previously).
-	if existing.Role != "architect" {
-		if err := svc.Users.UpdateRole(existing.ID.String(), "architect"); err != nil {
+	// Ensure org_role is member (may have been created with a legacy role previously).
+	if existing.OrgRole != "member" && existing.OrgRole != "admin" {
+		if err := svc.Users.UpdateRole(existing.ID.String(), "member"); err != nil {
 			return fmt.Errorf("demo bootstrap role: %w", err)
 		}
 	}

--- a/internal/auth/bootstrap_test.go
+++ b/internal/auth/bootstrap_test.go
@@ -43,8 +43,8 @@ func TestBootstrapAdmin_CreatesAdminWhenEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetByEmail: %v", err)
 	}
-	if u.Role != "admin" {
-		t.Errorf("Role: got %q, want admin", u.Role)
+	if u.OrgRole != "admin" {
+		t.Errorf("OrgRole: got %q, want admin", u.OrgRole)
 	}
 }
 
@@ -93,8 +93,8 @@ func TestBootstrapDemo_CreatesOrSyncsDemoUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetByEmail after create: %v", err)
 	}
-	if u.Role != "architect" {
-		t.Errorf("Role: got %q, want architect", u.Role)
+	if u.OrgRole != "member" {
+		t.Errorf("OrgRole: got %q, want member", u.OrgRole)
 	}
 	if !auth.CheckPassword(*u.PasswordHash, "demopass") {
 		t.Error("password hash incorrect after create")

--- a/internal/auth/casbin_adapter.go
+++ b/internal/auth/casbin_adapter.go
@@ -10,6 +10,8 @@ import (
 )
 
 // dbAdapter is a Casbin persist.Adapter backed by PostgreSQL using database/sql.
+// It stores grouping rules (g) with three values: user, role, domain.
+// Policy rules (p) are not used; enforcement logic lives in enforcer.go.
 type dbAdapter struct {
 	db *sql.DB
 }
@@ -34,7 +36,7 @@ func (a *dbAdapter) LoadPolicy(m model.Model) error {
 			return err
 		}
 		parts := []string{ptype.String, v0.String, v1.String, v2.String, v3.String, v4.String, v5.String}
-		// Trim trailing empty strings
+		// Trim trailing empty strings.
 		n := len(parts)
 		for n > 0 && parts[n-1] == "" {
 			n--
@@ -72,13 +74,14 @@ func (a *dbAdapter) SavePolicy(m model.Model) error {
 }
 
 func insertRule(tx *sql.Tx, parts []string) error {
-	// Pad to 7 columns (ptype + v0..v5)
+	// Pad to 7 columns (ptype + v0..v5).
 	for len(parts) < 7 {
 		parts = append(parts, "")
 	}
 	_, err := tx.Exec(
 		`INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, v4, v5)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)
+		 ON CONFLICT DO NOTHING`,
 		parts[0], parts[1], parts[2], parts[3], parts[4], parts[5], parts[6],
 	)
 	return err
@@ -96,9 +99,36 @@ func (a *dbAdapter) AddPolicy(sec, ptype string, rule []string) error {
 	return tx.Commit()
 }
 
-func (a *dbAdapter) RemovePolicy(sec, ptype string, rule []string) error { return nil }
+func (a *dbAdapter) RemovePolicy(sec, ptype string, rule []string) error {
+	if len(rule) < 3 {
+		return nil
+	}
+	// For grouping rules: v0=user, v1=role, v2=domain.
+	_, err := a.db.Exec(
+		`DELETE FROM casbin_rule WHERE ptype = $1 AND v0 = $2 AND v1 = $3 AND v2 = $4`,
+		ptype, rule[0], rule[1], rule[2],
+	)
+	return err
+}
+
 func (a *dbAdapter) RemoveFilteredPolicy(sec, ptype string, fieldIndex int, fieldValues ...string) error {
-	return nil
+	if len(fieldValues) == 0 {
+		return nil
+	}
+	cols := []string{"v0", "v1", "v2", "v3", "v4", "v5"}
+	conds := []string{"ptype = $1"}
+	args := []any{ptype}
+	for i, v := range fieldValues {
+		if v == "" {
+			continue
+		}
+		col := cols[fieldIndex+i]
+		args = append(args, v)
+		conds = append(conds, fmt.Sprintf("%s = $%d", col, len(args)))
+	}
+	q := "DELETE FROM casbin_rule WHERE " + strings.Join(conds, " AND ")
+	_, err := a.db.Exec(q, args...)
+	return err
 }
 
 // Ensure interface compliance.

--- a/internal/auth/casbin_adapter.go
+++ b/internal/auth/casbin_adapter.go
@@ -16,10 +16,6 @@ type dbAdapter struct {
 	db *sql.DB
 }
 
-func newDBAdapter(db *sql.DB) *dbAdapter {
-	return &dbAdapter{db: db}
-}
-
 // LoadPolicy loads all casbin_rule rows into the model.
 func (a *dbAdapter) LoadPolicy(m model.Model) error {
 	rows, err := a.db.Query(

--- a/internal/auth/enforcer.go
+++ b/internal/auth/enforcer.go
@@ -32,11 +32,11 @@ var ErrNoMembership = errors.New("no workspace membership")
 
 // WorkspaceMember represents a single membership row.
 type WorkspaceMember struct {
-	UserID      uuid.UUID  `json:"user_id"`
-	Email       string     `json:"email"`
-	Role        string     `json:"role"`
-	InvitedBy   *uuid.UUID `json:"invited_by,omitempty"`
-	CreatedAt   time.Time  `json:"created_at"`
+	UserID    uuid.UUID  `json:"user_id"`
+	Email     string     `json:"email"`
+	Role      string     `json:"role"`
+	InvitedBy *uuid.UUID `json:"invited_by,omitempty"`
+	CreatedAt time.Time  `json:"created_at"`
 }
 
 // Enforcer provides workspace membership checks and CRUD.

--- a/internal/auth/enforcer.go
+++ b/internal/auth/enforcer.go
@@ -3,97 +3,210 @@ package auth
 import (
 	"database/sql"
 	_ "embed"
+	"errors"
 	"fmt"
+	"time"
 
-	casbinv2 "github.com/casbin/casbin/v2"
-	"github.com/casbin/casbin/v2/model"
+	"github.com/google/uuid"
 )
 
 //go:embed rbac_model.conf
 var rbacModelConf string
 
-// Enforcer wraps the Casbin enforcer and seed policy loading.
+// Workspace roles — ordered from most to least permissive.
+const (
+	RoleOwner  = "owner"
+	RoleEditor = "editor"
+	RoleViewer = "viewer"
+)
+
+// roleRank maps a workspace role to a numeric rank (higher = more permissions).
+var roleRank = map[string]int{
+	RoleOwner:  3,
+	RoleEditor: 2,
+	RoleViewer: 1,
+}
+
+// ErrNoMembership is returned when a user has no membership in a workspace.
+var ErrNoMembership = errors.New("no workspace membership")
+
+// WorkspaceMember represents a single membership row.
+type WorkspaceMember struct {
+	UserID      uuid.UUID  `json:"user_id"`
+	Email       string     `json:"email"`
+	Role        string     `json:"role"`
+	InvitedBy   *uuid.UUID `json:"invited_by,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+}
+
+// Enforcer provides workspace membership checks and CRUD.
+// Enforcement logic is implemented here in Go; the Casbin model is kept
+// only as a schema reference and is not used for active enforcement.
 type Enforcer struct {
-	e *casbinv2.Enforcer
+	db *sql.DB
 }
 
-// NewEnforcer creates and seeds a Casbin enforcer backed by PostgreSQL.
-func NewEnforcer(db *sql.DB, cfg *Config) (*Enforcer, error) {
-	m, err := model.NewModelFromString(rbacModelConf)
+// NewEnforcer creates an Enforcer.
+func NewEnforcer(db *sql.DB, _ *Config) (*Enforcer, error) {
+	return &Enforcer{db: db}, nil
+}
+
+// ── Enforcement ───────────────────────────────────────────────────────────────
+
+// WorkspaceRole returns the role the user holds in the workspace,
+// or ErrNoMembership if there is none.
+func (en *Enforcer) WorkspaceRole(userID, workspaceID string) (string, error) {
+	var role string
+	err := en.db.QueryRow(
+		`SELECT role FROM workspace_members WHERE workspace_id = $1 AND user_id = $2`,
+		workspaceID, userID,
+	).Scan(&role)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", ErrNoMembership
+	}
+	return role, err
+}
+
+// hasRank reports whether the user's role in the workspace satisfies minRole.
+func (en *Enforcer) hasRank(userID, workspaceID, minRole string) (bool, error) {
+	role, err := en.WorkspaceRole(userID, workspaceID)
+	if errors.Is(err, ErrNoMembership) {
+		return false, nil
+	}
 	if err != nil {
-		return nil, fmt.Errorf("casbin model: %w", err)
+		return false, err
 	}
+	return roleRank[role] >= roleRank[minRole], nil
+}
 
-	adapter := newDBAdapter(db)
-	e, err := casbinv2.NewEnforcer(m, adapter)
+// CanView reports whether the user may read from the workspace.
+func (en *Enforcer) CanView(userID, workspaceID string) (bool, error) {
+	return en.hasRank(userID, workspaceID, RoleViewer)
+}
+
+// CanEdit reports whether the user may create/update resources in the workspace.
+func (en *Enforcer) CanEdit(userID, workspaceID string) (bool, error) {
+	return en.hasRank(userID, workspaceID, RoleEditor)
+}
+
+// CanManage reports whether the user may invite/remove members or delete the workspace.
+func (en *Enforcer) CanManage(userID, workspaceID string) (bool, error) {
+	return en.hasRank(userID, workspaceID, RoleOwner)
+}
+
+// ── Membership CRUD ───────────────────────────────────────────────────────────
+
+// ListMembers returns all members of the workspace, joined with their email.
+func (en *Enforcer) ListMembers(workspaceID string) ([]WorkspaceMember, error) {
+	rows, err := en.db.Query(`
+		SELECT wm.user_id, u.email, wm.role, wm.invited_by, wm.created_at
+		FROM   workspace_members wm
+		JOIN   users u ON u.id = wm.user_id
+		WHERE  wm.workspace_id = $1
+		ORDER  BY wm.created_at`, workspaceID)
 	if err != nil {
-		return nil, fmt.Errorf("casbin enforcer: %w", err)
+		return nil, fmt.Errorf("list members: %w", err)
 	}
+	defer func() { _ = rows.Close() }()
 
-	// Load (or refresh) the policy from the DB.
-	if err := e.LoadPolicy(); err != nil {
-		return nil, fmt.Errorf("casbin load policy: %w", err)
+	var out []WorkspaceMember
+	for rows.Next() {
+		var m WorkspaceMember
+		var invBy sql.NullString
+		if err := rows.Scan(&m.UserID, &m.Email, &m.Role, &invBy, &m.CreatedAt); err != nil {
+			return nil, err
+		}
+		if invBy.Valid {
+			id, _ := uuid.Parse(invBy.String)
+			m.InvitedBy = &id
+		}
+		out = append(out, m)
 	}
-
-	// Ensure base role-hierarchy and default policies exist.
-	if err := seedPolicy(e); err != nil {
-		return nil, fmt.Errorf("casbin seed policy: %w", err)
-	}
-
-	return &Enforcer{e: e}, nil
+	return out, rows.Err()
 }
 
-// seedPolicy rewrites the complete policy set from scratch on every startup.
-// This ensures stale policies (e.g. from a previous matcher syntax) are removed.
-func seedPolicy(e *casbinv2.Enforcer) error {
-	// Wipe everything stored, then rebuild from the canonical definition below.
-	e.ClearPolicy()
-
-	// Role hierarchy: admin > architect > viewer
-	roleHierarchy := [][2]string{
-		{"admin", "architect"},
-		{"architect", "viewer"},
+// AddMember upserts a workspace membership.
+// If the user is already a member, their role is updated.
+func (en *Enforcer) AddMember(workspaceID, userID, role, invitedBy string) error {
+	if _, ok := roleRank[role]; !ok {
+		return fmt.Errorf("invalid workspace role %q", role)
 	}
-	for _, r := range roleHierarchy {
-		if _, err := e.AddGroupingPolicy(r[0], r[1]); err != nil {
-			return err
-		}
+	var inv interface{} = nil
+	if invitedBy != "" {
+		inv = invitedBy
 	}
-
-	// Policies: (role, resource_pattern, action)
-	// Uses keyMatch2 syntax: :param matches exactly one path segment.
-	// Multiple patterns cover varying nesting depths.
-	policies := [][3]string{
-		// admin can do everything under /api/v1 (up to 4 segments deep)
-		{"admin", "/api/v1/:p1", "*"},
-		{"admin", "/api/v1/:p1/:p2", "*"},
-		{"admin", "/api/v1/:p1/:p2/:p3", "*"},
-		{"admin", "/api/v1/:p1/:p2/:p3/:p4", "*"},
-
-		// architect: full read+write on workspace resources, no user management
-		{"architect", "/api/v1/workspaces", "GET"},
-		{"architect", "/api/v1/workspaces/:id", "*"},
-		{"architect", "/api/v1/workspaces/:id/:sub", "*"},
-		{"architect", "/api/v1/workspaces/:id/:sub/:p1", "*"},
-		{"architect", "/api/v1/workspaces/:id/:sub/:p1/:p2", "*"},
-
-		// viewer: read-only on workspaces
-		{"viewer", "/api/v1/workspaces", "GET"},
-		{"viewer", "/api/v1/workspaces/:id", "GET"},
-		{"viewer", "/api/v1/workspaces/:id/:sub", "GET"},
-		{"viewer", "/api/v1/workspaces/:id/:sub/:p1", "GET"},
-		{"viewer", "/api/v1/workspaces/:id/:sub/:p1/:p2", "GET"},
+	_, err := en.db.Exec(`
+		INSERT INTO workspace_members (workspace_id, user_id, role, invited_by)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (workspace_id, user_id) DO UPDATE SET role = EXCLUDED.role`,
+		workspaceID, userID, role, inv)
+	if err != nil {
+		return fmt.Errorf("add member: %w", err)
 	}
-	for _, p := range policies {
-		if _, err := e.AddPolicy(p[0], p[1], p[2]); err != nil {
-			return err
-		}
-	}
-
-	return e.SavePolicy()
+	return nil
 }
 
-// Allow reports whether the given role may perform act on obj.
-func (en *Enforcer) Allow(role, obj, act string) (bool, error) {
-	return en.e.Enforce(role, obj, act)
+// UpdateMemberRole changes an existing member's role.
+// Returns ErrNoMembership if the user is not a member.
+func (en *Enforcer) UpdateMemberRole(workspaceID, userID, role string) error {
+	if _, ok := roleRank[role]; !ok {
+		return fmt.Errorf("invalid workspace role %q", role)
+	}
+	res, err := en.db.Exec(`
+		UPDATE workspace_members SET role = $1
+		WHERE workspace_id = $2 AND user_id = $3`,
+		role, workspaceID, userID)
+	if err != nil {
+		return fmt.Errorf("update member role: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNoMembership
+	}
+	return nil
+}
+
+// RemoveMember removes a user from a workspace.
+// Returns ErrNoMembership if the user was not a member.
+func (en *Enforcer) RemoveMember(workspaceID, userID string) error {
+	res, err := en.db.Exec(`
+		DELETE FROM workspace_members WHERE workspace_id = $1 AND user_id = $2`,
+		workspaceID, userID)
+	if err != nil {
+		return fmt.Errorf("remove member: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNoMembership
+	}
+	return nil
+}
+
+// ListUserWorkspaces returns all workspace IDs the user is a member of.
+func (en *Enforcer) ListUserWorkspaces(userID string) ([]string, error) {
+	rows, err := en.db.Query(
+		`SELECT workspace_id FROM workspace_members WHERE user_id = $1`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// SeedOwner adds the user as owner of the workspace if they are not already a member.
+func (en *Enforcer) SeedOwner(workspaceID, userID string) error {
+	_, err := en.db.Exec(`
+		INSERT INTO workspace_members (workspace_id, user_id, role)
+		VALUES ($1, $2, 'owner')
+		ON CONFLICT DO NOTHING`,
+		workspaceID, userID)
+	return err
 }

--- a/internal/auth/enforcer.go
+++ b/internal/auth/enforcer.go
@@ -2,16 +2,12 @@ package auth
 
 import (
 	"database/sql"
-	_ "embed"
 	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 )
-
-//go:embed rbac_model.conf
-var rbacModelConf string
 
 // Workspace roles — ordered from most to least permissive.
 const (

--- a/internal/auth/enforcer_test.go
+++ b/internal/auth/enforcer_test.go
@@ -1,100 +1,210 @@
 package auth_test
 
 import (
+	"database/sql"
+	"fmt"
 	"testing"
+
+	"github.com/DisruptiveWorks/archipulse/internal/auth"
 )
 
-func TestEnforcer_AdminFullAccess(t *testing.T) {
+func TestEnforcer_WorkspaceRole(t *testing.T) {
 	conn := openTestDB(t)
 	svc := newTestService(t, conn)
 
-	cases := []struct{ path, method string }{
-		{"/api/v1/workspaces", "GET"},
-		{"/api/v1/workspaces", "POST"},
-		{"/api/v1/workspaces/123", "DELETE"},
-		{"/api/v1/users", "GET"},
+	email := fmt.Sprintf("enf-role-%s@example.com", t.Name())
+	hash, _ := auth.HashPassword("pass")
+	u, err := svc.Users.Create(email, hash, "member")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
 	}
-	for _, c := range cases {
-		ok, err := svc.Enforcer.Allow("admin", c.path, c.method)
-		if err != nil {
-			t.Errorf("Allow admin %s %s: %v", c.method, c.path, err)
-		}
-		if !ok {
-			t.Errorf("admin should be allowed: %s %s", c.method, c.path)
-		}
+	t.Cleanup(func() { _, _ = conn.Exec("DELETE FROM users WHERE email = $1", email) })
+
+	wsID := mustCreateWorkspace(t, conn)
+
+	// No membership yet.
+	_, err = svc.Enforcer.WorkspaceRole(u.ID.String(), wsID)
+	if err != auth.ErrNoMembership {
+		t.Errorf("expected ErrNoMembership before adding, got %v", err)
+	}
+
+	if err := svc.Enforcer.AddMember(wsID, u.ID.String(), auth.RoleViewer, ""); err != nil {
+		t.Fatalf("AddMember: %v", err)
+	}
+
+	role, err := svc.Enforcer.WorkspaceRole(u.ID.String(), wsID)
+	if err != nil {
+		t.Fatalf("WorkspaceRole: %v", err)
+	}
+	if role != auth.RoleViewer {
+		t.Errorf("role: got %q, want %q", role, auth.RoleViewer)
 	}
 }
 
-func TestEnforcer_ViewerReadOnly(t *testing.T) {
+func TestEnforcer_CanView_CanEdit_CanManage(t *testing.T) {
 	conn := openTestDB(t)
 	svc := newTestService(t, conn)
 
-	allowed := []struct{ path, method string }{
-		{"/api/v1/workspaces", "GET"},
-		{"/api/v1/workspaces/abc", "GET"},
+	email := fmt.Sprintf("enf-perms-%s@example.com", t.Name())
+	hash, _ := auth.HashPassword("pass")
+	u, err := svc.Users.Create(email, hash, "member")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
 	}
-	for _, c := range allowed {
-		ok, err := svc.Enforcer.Allow("viewer", c.path, c.method)
-		if err != nil {
-			t.Errorf("Allow viewer %s %s: %v", c.method, c.path, err)
-		}
-		if !ok {
-			t.Errorf("viewer should be allowed: %s %s", c.method, c.path)
-		}
+	t.Cleanup(func() { _, _ = conn.Exec("DELETE FROM users WHERE email = $1", email) })
+
+	wsID := mustCreateWorkspace(t, conn)
+
+	// viewer: can view, cannot edit or manage.
+	if err := svc.Enforcer.AddMember(wsID, u.ID.String(), auth.RoleViewer, ""); err != nil {
+		t.Fatalf("AddMember viewer: %v", err)
+	}
+	assertCan(t, svc, u.ID.String(), wsID, "viewer", true, false, false)
+
+	// Upgrade to editor.
+	if err := svc.Enforcer.UpdateMemberRole(wsID, u.ID.String(), auth.RoleEditor); err != nil {
+		t.Fatalf("UpdateMemberRole editor: %v", err)
+	}
+	assertCan(t, svc, u.ID.String(), wsID, "editor", true, true, false)
+
+	// Upgrade to owner.
+	if err := svc.Enforcer.UpdateMemberRole(wsID, u.ID.String(), auth.RoleOwner); err != nil {
+		t.Fatalf("UpdateMemberRole owner: %v", err)
+	}
+	assertCan(t, svc, u.ID.String(), wsID, "owner", true, true, true)
+}
+
+func TestEnforcer_RemoveMember(t *testing.T) {
+	conn := openTestDB(t)
+	svc := newTestService(t, conn)
+
+	email := fmt.Sprintf("enf-remove-%s@example.com", t.Name())
+	hash, _ := auth.HashPassword("pass")
+	u, err := svc.Users.Create(email, hash, "member")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { _, _ = conn.Exec("DELETE FROM users WHERE email = $1", email) })
+
+	wsID := mustCreateWorkspace(t, conn)
+
+	if err := svc.Enforcer.AddMember(wsID, u.ID.String(), auth.RoleEditor, ""); err != nil {
+		t.Fatalf("AddMember: %v", err)
 	}
 
-	denied := []struct{ path, method string }{
-		{"/api/v1/workspaces", "POST"},
-		{"/api/v1/workspaces/abc", "DELETE"},
-		{"/api/v1/workspaces/abc", "PUT"},
-		{"/api/v1/users", "GET"},
+	if err := svc.Enforcer.RemoveMember(wsID, u.ID.String()); err != nil {
+		t.Fatalf("RemoveMember: %v", err)
 	}
-	for _, c := range denied {
-		ok, err := svc.Enforcer.Allow("viewer", c.path, c.method)
-		if err != nil {
-			t.Errorf("Allow viewer %s %s: %v", c.method, c.path, err)
-		}
-		if ok {
-			t.Errorf("viewer should be denied: %s %s", c.method, c.path)
-		}
+
+	_, err = svc.Enforcer.WorkspaceRole(u.ID.String(), wsID)
+	if err != auth.ErrNoMembership {
+		t.Errorf("expected ErrNoMembership after remove, got %v", err)
+	}
+
+	// Removing again should return ErrNoMembership.
+	if err := svc.Enforcer.RemoveMember(wsID, u.ID.String()); err != auth.ErrNoMembership {
+		t.Errorf("expected ErrNoMembership on double remove, got %v", err)
 	}
 }
 
-func TestEnforcer_ArchitectWriteWorkspace(t *testing.T) {
+func TestEnforcer_ListMembers(t *testing.T) {
 	conn := openTestDB(t)
 	svc := newTestService(t, conn)
 
-	allowed := []struct{ path, method string }{
-		{"/api/v1/workspaces", "GET"},
-		{"/api/v1/workspaces/abc", "GET"},
-		{"/api/v1/workspaces/abc", "POST"},
-		{"/api/v1/workspaces/abc", "PUT"},
-		{"/api/v1/workspaces/abc", "DELETE"},
-	}
-	for _, c := range allowed {
-		ok, err := svc.Enforcer.Allow("architect", c.path, c.method)
-		if err != nil {
-			t.Errorf("Allow architect %s %s: %v", c.method, c.path, err)
-		}
-		if !ok {
-			t.Errorf("architect should be allowed: %s %s", c.method, c.path)
-		}
-	}
+	email1 := fmt.Sprintf("enf-list1-%s@example.com", t.Name())
+	email2 := fmt.Sprintf("enf-list2-%s@example.com", t.Name())
+	hash, _ := auth.HashPassword("pass")
+	u1, _ := svc.Users.Create(email1, hash, "member")
+	u2, _ := svc.Users.Create(email2, hash, "member")
+	t.Cleanup(func() {
+		_, _ = conn.Exec("DELETE FROM users WHERE email IN ($1, $2)", email1, email2)
+	})
 
-	// architect cannot manage users (admin only)
-	ok, _ := svc.Enforcer.Allow("architect", "/api/v1/users", "GET")
-	if ok {
-		t.Error("architect should not access /api/v1/users")
+	wsID := mustCreateWorkspace(t, conn)
+
+	_ = svc.Enforcer.AddMember(wsID, u1.ID.String(), auth.RoleOwner, "")
+	_ = svc.Enforcer.AddMember(wsID, u2.ID.String(), auth.RoleViewer, "")
+
+	members, err := svc.Enforcer.ListMembers(wsID)
+	if err != nil {
+		t.Fatalf("ListMembers: %v", err)
+	}
+	if len(members) < 2 {
+		t.Errorf("expected at least 2 members, got %d", len(members))
 	}
 }
 
-func TestEnforcer_RoleInheritance(t *testing.T) {
+func TestEnforcer_SeedOwner(t *testing.T) {
 	conn := openTestDB(t)
 	svc := newTestService(t, conn)
 
-	// admin inherits architect which inherits viewer — admin can read workspaces
-	ok, err := svc.Enforcer.Allow("admin", "/api/v1/workspaces/xyz", "GET")
-	if err != nil || !ok {
-		t.Errorf("admin should inherit viewer GET permission: ok=%v err=%v", ok, err)
+	email := fmt.Sprintf("enf-seed-%s@example.com", t.Name())
+	hash, _ := auth.HashPassword("pass")
+	u, err := svc.Users.Create(email, hash, "admin")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
 	}
+	t.Cleanup(func() { _, _ = conn.Exec("DELETE FROM users WHERE email = $1", email) })
+
+	wsID := mustCreateWorkspace(t, conn)
+
+	if err := svc.Enforcer.SeedOwner(wsID, u.ID.String()); err != nil {
+		t.Fatalf("SeedOwner: %v", err)
+	}
+	role, err := svc.Enforcer.WorkspaceRole(u.ID.String(), wsID)
+	if err != nil {
+		t.Fatalf("WorkspaceRole after seed: %v", err)
+	}
+	if role != auth.RoleOwner {
+		t.Errorf("role: got %q, want owner", role)
+	}
+
+	// Second seed call must be a no-op (ON CONFLICT DO NOTHING).
+	if err := svc.Enforcer.SeedOwner(wsID, u.ID.String()); err != nil {
+		t.Fatalf("SeedOwner (idempotent): %v", err)
+	}
+}
+
+// assertCan checks CanView/CanEdit/CanManage against expectations.
+func assertCan(t *testing.T, svc *auth.Service, userID, wsID, label string, wantView, wantEdit, wantManage bool) {
+	t.Helper()
+	canView, err := svc.Enforcer.CanView(userID, wsID)
+	if err != nil {
+		t.Errorf("[%s] CanView error: %v", label, err)
+	}
+	if canView != wantView {
+		t.Errorf("[%s] CanView: got %v, want %v", label, canView, wantView)
+	}
+
+	canEdit, err := svc.Enforcer.CanEdit(userID, wsID)
+	if err != nil {
+		t.Errorf("[%s] CanEdit error: %v", label, err)
+	}
+	if canEdit != wantEdit {
+		t.Errorf("[%s] CanEdit: got %v, want %v", label, canEdit, wantEdit)
+	}
+
+	canManage, err := svc.Enforcer.CanManage(userID, wsID)
+	if err != nil {
+		t.Errorf("[%s] CanManage error: %v", label, err)
+	}
+	if canManage != wantManage {
+		t.Errorf("[%s] CanManage: got %v, want %v", label, canManage, wantManage)
+	}
+}
+
+// mustCreateWorkspace inserts a workspace and returns its UUID string.
+// Cleanup is registered automatically.
+func mustCreateWorkspace(t *testing.T, conn *sql.DB) string {
+	t.Helper()
+	var id string
+	err := conn.QueryRow(
+		`INSERT INTO workspaces (name, purpose) VALUES ($1, 'other') RETURNING id`,
+		fmt.Sprintf("test-ws-%s", t.Name()),
+	).Scan(&id)
+	if err != nil {
+		t.Fatalf("create test workspace: %v", err)
+	}
+	t.Cleanup(func() { _, _ = conn.Exec("DELETE FROM workspaces WHERE id = $1", id) })
+	return id
 }

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -84,8 +84,8 @@ func (svc *Service) handleLogin(w http.ResponseWriter, r *http.Request) {
 
 	claims, _ := ParseToken(svc.Cfg, token)
 	writeJSON(w, http.StatusOK, map[string]string{
-		"email": claims.Email,
-		"role":  claims.Role,
+		"email":    claims.Email,
+		"org_role": claims.OrgRole,
 	})
 }
 
@@ -106,9 +106,9 @@ func (svc *Service) handleMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{
-		"id":    claims.UserID,
-		"email": claims.Email,
-		"role":  claims.Role,
+		"id":       claims.UserID,
+		"email":    claims.Email,
+		"org_role": claims.OrgRole,
 	})
 }
 
@@ -144,12 +144,12 @@ func (svc *Service) handleOIDCCallback(oidc *OIDCProvider) http.HandlerFunc {
 		u, err := svc.Users.GetByEmail(email)
 		if err == ErrNotFound {
 			// First OIDC login — assign admin if email matches bootstrap config,
-			// otherwise provision as viewer.
-			role := "viewer"
+			// otherwise provision as member.
+			orgRole := "member"
 			if svc.Cfg.BootstrapEmail != "" && email == svc.Cfg.BootstrapEmail {
-				role = "admin"
+				orgRole = "admin"
 			}
-			u, err = svc.Users.Create(email, "", role)
+			u, err = svc.Users.Create(email, "", orgRole)
 		}
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "user lookup failed")
@@ -157,14 +157,14 @@ func (svc *Service) handleOIDCCallback(oidc *OIDCProvider) http.HandlerFunc {
 		}
 
 		// If the bootstrap admin logs in via OIDC and was previously provisioned
-		// as viewer (e.g. before bootstrap config was set), promote to admin.
-		if svc.Cfg.BootstrapEmail != "" && email == svc.Cfg.BootstrapEmail && u.Role != "admin" {
+		// as member (e.g. before bootstrap config was set), promote to admin.
+		if svc.Cfg.BootstrapEmail != "" && email == svc.Cfg.BootstrapEmail && u.OrgRole != "admin" {
 			if err := svc.Users.UpdateRole(u.ID.String(), "admin"); err == nil {
-				u.Role = "admin"
+				u.OrgRole = "admin"
 			}
 		}
 
-		token, err := IssueToken(svc.Cfg, u.ID.String(), u.Email, u.Role)
+		token, err := IssueToken(svc.Cfg, u.ID.String(), u.Email, u.OrgRole)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "token issue failed")
 			return

--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -15,5 +15,5 @@ func LoginLocal(svc *Service, email, password string) (string, error) {
 	if u.PasswordHash == nil || !CheckPassword(*u.PasswordHash, password) {
 		return "", errors.New("invalid credentials")
 	}
-	return IssueToken(svc.Cfg, u.ID.String(), u.Email, u.Role)
+	return IssueToken(svc.Cfg, u.ID.String(), u.Email, u.OrgRole)
 }

--- a/internal/auth/login_test.go
+++ b/internal/auth/login_test.go
@@ -36,8 +36,8 @@ func TestLoginLocal_Success(t *testing.T) {
 	if claims.Email != email {
 		t.Errorf("claims.Email: got %q, want %q", claims.Email, email)
 	}
-	if claims.Role != "viewer" {
-		t.Errorf("claims.Role: got %q, want viewer", claims.Role)
+	if claims.OrgRole != "viewer" {
+		t.Errorf("claims.OrgRole: got %q, want viewer", claims.OrgRole)
 	}
 }
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -2,7 +2,10 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"net/http"
+
+	"github.com/go-chi/chi/v5"
 )
 
 type contextKey string
@@ -28,21 +31,63 @@ func (svc *Service) RequireAuth(next http.Handler) http.Handler {
 	})
 }
 
-// RequireRole is middleware that additionally enforces a Casbin RBAC check.
-func (svc *Service) RequireRole(next http.Handler) http.Handler {
+// RequireOrgAdmin is middleware that additionally checks the user has org_role == "admin".
+func (svc *Service) RequireOrgAdmin(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		claims := ClaimsFromCtx(r.Context())
 		if claims == nil {
 			http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
 			return
 		}
-		allowed, err := svc.Enforcer.Allow(claims.Role, r.URL.Path, r.Method)
-		if err != nil || !allowed {
+		if claims.OrgRole != "admin" {
 			http.Error(w, `{"error":"forbidden"}`, http.StatusForbidden)
 			return
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// RequireWorkspaceAccess returns middleware that checks the caller holds at least
+// minRole in the workspace identified by the chi URL param "id".
+func (svc *Service) RequireWorkspaceAccess(minRole string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			claims := ClaimsFromCtx(r.Context())
+			if claims == nil {
+				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+				return
+			}
+			// Org admins bypass workspace-level checks.
+			if claims.OrgRole == "admin" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			wsID := chi.URLParam(r, "id")
+			if wsID == "" {
+				http.Error(w, `{"error":"workspace id required"}`, http.StatusBadRequest)
+				return
+			}
+			var ok bool
+			var err error
+			switch minRole {
+			case RoleOwner:
+				ok, err = svc.Enforcer.CanManage(claims.UserID, wsID)
+			case RoleEditor:
+				ok, err = svc.Enforcer.CanEdit(claims.UserID, wsID)
+			default:
+				ok, err = svc.Enforcer.CanView(claims.UserID, wsID)
+			}
+			if err != nil && !errors.Is(err, ErrNoMembership) {
+				http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
+				return
+			}
+			if !ok {
+				http.Error(w, `{"error":"forbidden"}`, http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 // ClaimsFromCtx retrieves auth Claims stored by RequireAuth.

--- a/internal/auth/rbac_model.conf
+++ b/internal/auth/rbac_model.conf
@@ -1,14 +1,26 @@
+# ArchiPulse RBAC model with domains.
+#
+# Casbin is used as a persistent store for role→domain groupings only.
+# Enforcement logic is implemented in Go (enforcer.go) rather than
+# Casbin matchers, which keeps the model simple and the rules easy to reason about.
+#
+# Grouping table (g):
+#   g(user_id, "admin",  "*")            — org-level admin
+#   g(user_id, "owner",  workspace_id)   — workspace owner
+#   g(user_id, "editor", workspace_id)   — workspace editor
+#   g(user_id, "viewer", workspace_id)   — workspace viewer
+
 [request_definition]
-r = sub, obj, act
+r = sub, dom, obj, act
 
 [policy_definition]
-p = sub, obj, act
+p = sub, dom, obj, act
 
 [role_definition]
-g = _, _
+g = _, _, _
 
 [policy_effect]
 e = some(where (p.eft == allow))
 
 [matchers]
-m = g(r.sub, p.sub) && keyMatch2(r.obj, p.obj) && (r.act == p.act || p.act == "*")
+m = g(r.sub, p.sub, r.dom) && r.obj == p.obj && (r.act == p.act || p.act == "*")

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -9,19 +9,19 @@ import (
 
 // Claims is the JWT payload stored in the ap_session cookie.
 type Claims struct {
-	UserID string `json:"uid"`
-	Email  string `json:"email"`
-	Role   string `json:"role"`
+	UserID  string `json:"uid"`
+	Email   string `json:"email"`
+	OrgRole string `json:"org_role"`
 	jwt.RegisteredClaims
 }
 
 // IssueToken signs a new JWT for the given user.
-func IssueToken(cfg *Config, userID, email, role string) (string, error) {
+func IssueToken(cfg *Config, userID, email, orgRole string) (string, error) {
 	now := time.Now()
 	claims := Claims{
-		UserID: userID,
-		Email:  email,
-		Role:   role,
+		UserID:  userID,
+		Email:   email,
+		OrgRole: orgRole,
 		RegisteredClaims: jwt.RegisteredClaims{
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(cfg.TokenTTL)),

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -35,8 +35,8 @@ func TestIssueToken_RoundTrip(t *testing.T) {
 	if claims.Email != "user@example.com" {
 		t.Errorf("Email: got %q", claims.Email)
 	}
-	if claims.Role != "viewer" {
-		t.Errorf("Role: got %q", claims.Role)
+	if claims.OrgRole != "viewer" {
+		t.Errorf("OrgRole: got %q", claims.OrgRole)
 	}
 }
 

--- a/internal/auth/user_store.go
+++ b/internal/auth/user_store.go
@@ -14,7 +14,7 @@ type User struct {
 	ID           uuid.UUID
 	Email        string
 	PasswordHash *string // nil for OIDC-only users
-	Role         string
+	OrgRole      string
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 }
@@ -32,12 +32,12 @@ func NewUserStore(db *sql.DB) *UserStore {
 	return &UserStore{db: db}
 }
 
-const userCols = "id, email, password_hash, role, created_at, updated_at"
+const userCols = "id, email, password_hash, org_role, created_at, updated_at"
 
 func scanUser(row interface{ Scan(...any) error }) (*User, error) {
 	var u User
 	var hash sql.NullString
-	if err := row.Scan(&u.ID, &u.Email, &hash, &u.Role, &u.CreatedAt, &u.UpdatedAt); err != nil {
+	if err := row.Scan(&u.ID, &u.Email, &hash, &u.OrgRole, &u.CreatedAt, &u.UpdatedAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
 		}
@@ -72,7 +72,7 @@ func (s *UserStore) Create(email, passwordHash, role string) (*User, error) {
 		ph = &passwordHash
 	}
 	row := s.db.QueryRow(
-		`INSERT INTO users (email, password_hash, role)
+		`INSERT INTO users (email, password_hash, org_role)
 		 VALUES ($1, $2, $3)
 		 RETURNING `+userCols,
 		email, ph, role,
@@ -99,10 +99,10 @@ func (s *UserStore) UpdatePasswordHash(id, hash string) error {
 	return err
 }
 
-// UpdateRole changes a user's role.
+// UpdateRole changes a user's org role.
 func (s *UserStore) UpdateRole(id, role string) error {
 	_, err := s.db.Exec(
-		"UPDATE users SET role = $1, updated_at = NOW() WHERE id = $2",
+		"UPDATE users SET org_role = $1, updated_at = NOW() WHERE id = $2",
 		role, id,
 	)
 	return err

--- a/internal/auth/user_store_test.go
+++ b/internal/auth/user_store_test.go
@@ -22,8 +22,8 @@ func TestUserStore_CreateAndGetByEmail(t *testing.T) {
 	if u.Email != email {
 		t.Errorf("Email: got %q, want %q", u.Email, email)
 	}
-	if u.Role != "viewer" {
-		t.Errorf("Role: got %q, want viewer", u.Role)
+	if u.OrgRole != "viewer" {
+		t.Errorf("OrgRole: got %q, want viewer", u.OrgRole)
 	}
 	if u.PasswordHash == nil || *u.PasswordHash != hash {
 		t.Error("PasswordHash not stored correctly")
@@ -54,7 +54,7 @@ func TestUserStore_GetByID(t *testing.T) {
 	email := fmt.Sprintf("store-byid-%s@example.com", t.Name())
 
 	hash, _ := auth.HashPassword("pass")
-	u, err := store.Create(email, hash, "architect")
+	u, err := store.Create(email, hash, "member")
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -145,13 +145,13 @@ func TestUserStore_UpdateRole(t *testing.T) {
 	}
 	t.Cleanup(func() { _, _ = conn.Exec("DELETE FROM users WHERE email = $1", email) })
 
-	if err := store.UpdateRole(u.ID.String(), "architect"); err != nil {
+	if err := store.UpdateRole(u.ID.String(), "admin"); err != nil {
 		t.Fatalf("UpdateRole: %v", err)
 	}
 
 	got, _ := store.GetByEmail(email)
-	if got.Role != "architect" {
-		t.Errorf("Role: got %q, want architect", got.Role)
+	if got.OrgRole != "admin" {
+		t.Errorf("OrgRole: got %q, want admin", got.OrgRole)
 	}
 }
 

--- a/migrations/014_workspace_members.sql
+++ b/migrations/014_workspace_members.sql
@@ -1,0 +1,30 @@
+-- Migration 014: workspace membership RBAC
+--
+-- 1. Rename users.role → users.org_role (admin | member).
+--    Existing admins keep 'admin'; all other roles become 'member'.
+-- 2. Add workspace_members table for per-workspace roles.
+--    Roles: owner | editor | viewer.
+-- 3. Seed the first admin as owner of every existing workspace so
+--    no existing data is left inaccessible.
+
+-- Step 1: rename column and normalise values.
+ALTER TABLE users RENAME COLUMN role TO org_role;
+UPDATE users SET org_role = 'member' WHERE org_role NOT IN ('admin', 'member');
+
+-- Step 2: workspace membership table.
+CREATE TABLE workspace_members (
+    workspace_id UUID        NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    user_id      UUID        NOT NULL REFERENCES users(id)      ON DELETE CASCADE,
+    role         TEXT        NOT NULL CHECK (role IN ('owner', 'editor', 'viewer')),
+    invited_by   UUID        REFERENCES users(id),
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (workspace_id, user_id)
+);
+
+-- Step 3: seed — every org admin becomes owner of every workspace.
+INSERT INTO workspace_members (workspace_id, user_id, role)
+SELECT w.id, u.id, 'owner'
+FROM   workspaces w
+CROSS  JOIN users u
+WHERE  u.org_role = 'admin'
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary

- Adds `workspace_members` table (migration 014) with roles `owner` / `editor` / `viewer` per workspace; renames `users.role` → `users.org_role` (`admin` | `member`)
- Rewrites `enforcer.go` — pure SQL enforcement on `workspace_members`, no Casbin matcher logic
- Replaces flat `RequireRole` middleware with `RequireOrgAdmin` and `RequireWorkspaceAccess(minRole)`; org admins bypass all workspace checks
- New membership API: `GET/POST /workspaces/{id}/members`, `PUT/DELETE /workspaces/{id}/members/{userId}`
- Workspace creator is automatically seeded as `owner`; OIDC users are persisted on first login and can be added as members thereafter
- `Claims.Role` / `User.Role` renamed to `OrgRole` throughout (JWT claim key: `org_role`)
- All auth tests rewritten/updated; `go test ./...` passes

## Test plan

- [ ] Run `go test ./...` — all pass
- [ ] Apply migration 014 locally (`archipulse migrate`)
- [ ] Login as admin, create a workspace — verify you appear in `workspace_members` as owner
- [ ] Login via Dex/OIDC — verify user row is created in `users` table
- [ ] `GET /api/v1/workspaces/{id}/members` returns member list
- [ ] `POST /api/v1/workspaces/{id}/members` adds a member (requires owner)
- [ ] `PUT/DELETE /api/v1/workspaces/{id}/members/{userId}` update/remove (requires owner)
- [ ] Non-member gets 403 on workspace endpoints