### PR TITLE
fix(auth): prefer {wsID} over {id} in workspace access middleware

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -62,9 +62,9 @@ func (svc *Service) RequireWorkspaceAccess(minRole string) func(http.Handler) ht
 				next.ServeHTTP(w, r)
 				return
 			}
-			wsID := chi.URLParam(r, "id")
+			wsID := chi.URLParam(r, "wsID")
 			if wsID == "" {
-				wsID = chi.URLParam(r, "wsID")
+				wsID = chi.URLParam(r, "id")
 			}
 			if wsID == "" {
 				http.Error(w, `{"error":"workspace id required"}`, http.StatusBadRequest)


### PR DESCRIPTION
## Summary

- Routes like `/workspaces/{wsID}/diagrams/{id}/render` have two URL params: the workspace ID (`wsID`) and the resource ID (`id`)
- The middleware was reading `{id}` first, which resolves to the **diagram ID** — causing the membership lookup to fail for all non-admin users, returning `403 forbidden`
- Fix: prefer `{wsID}`, fall back to `{id}` (for routes that only have one param like `/workspaces/{id}`)

## Test plan

- [ ] As a viewer, open a diagram in ArchiMate editor — should render without forbidden error
- [ ] As a viewer, access capability tree, dependency graph, and other views — should work
- [ ] As a viewer, confirm you cannot edit or delete (403 still enforced for write operations)
- [ ] Org admins bypass unchanged