### PR TITLE
fix(exporter): move propertyDefinitions after relationships per OEF XSD

### DIFF
--- a/internal/diagram/diagram.go
+++ b/internal/diagram/diagram.go
@@ -313,8 +313,10 @@ func (s *Store) Render(diagramID uuid.UUID) (*RenderData, error) {
 	}
 
 	for _, n := range layout.Nodes {
-		// Skip pure label nodes — they are floating text annotations, not renderable elements.
-		if n.NodeType == "Label" {
+		// Skip Label nodes that have no displayable text (e.g. Archi labelExpression-only
+		// nodes that reference view properties we cannot evaluate). Label nodes with a
+		// fixed text label are kept so they render as text annotations.
+		if n.NodeType == "Label" && n.Label == "" {
 			continue
 		}
 		meta := elemMeta[n.ElementID]

--- a/internal/exporter/aoef.go
+++ b/internal/exporter/aoef.go
@@ -34,9 +34,9 @@ type aoefModel struct {
 	SchemaLoc     string             `xml:"xsi:schemaLocation,attr"`
 	Name          string             `xml:"name"`
 	Properties    *aoefProperties    `xml:"properties,omitempty"`
-	PropertyDefs  *aoefPropertyDefs  `xml:"propertyDefinitions,omitempty"`
 	Elements      *aoefElements      `xml:"elements,omitempty"`
 	Relationships *aoefRelationships `xml:"relationships,omitempty"`
+	PropertyDefs  *aoefPropertyDefs  `xml:"propertyDefinitions,omitempty"`
 	Views         *aoefViews         `xml:"views,omitempty"`
 	Organizations *aoefOrgsBlock     `xml:"organizations,omitempty"`
 }

--- a/internal/exporter/aoef.go
+++ b/internal/exporter/aoef.go
@@ -36,9 +36,9 @@ type aoefModel struct {
 	Properties    *aoefProperties    `xml:"properties,omitempty"`
 	Elements      *aoefElements      `xml:"elements,omitempty"`
 	Relationships *aoefRelationships `xml:"relationships,omitempty"`
+	Organizations *aoefOrgsBlock     `xml:"organizations,omitempty"`
 	PropertyDefs  *aoefPropertyDefs  `xml:"propertyDefinitions,omitempty"`
 	Views         *aoefViews         `xml:"views,omitempty"`
-	Organizations *aoefOrgsBlock     `xml:"organizations,omitempty"`
 }
 
 type aoefPropertyDefs struct {
@@ -145,7 +145,7 @@ type aoefRelationship struct {
 
 type aoefView struct {
 	ID             string           `xml:"identifier,attr"`
-	Type           string           `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr,omitempty"`
+	Type           string           `xml:"xsi:type,attr,omitempty"`
 	Viewpoint      string           `xml:"viewpoint,attr,omitempty"`
 	ViewpointRef   string           `xml:"viewpointRef,attr,omitempty"`
 	Names          []aoefLangString `xml:"name"`
@@ -157,21 +157,22 @@ type aoefView struct {
 
 // aoefNode mirrors the parser's aoefNode, supporting recursive nesting.
 type aoefNode struct {
-	Identifier string     `xml:"identifier,attr"`
-	ElementRef string     `xml:"elementRef,attr,omitempty"`
-	NodeType   string     `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr,omitempty"`
-	X          int        `xml:"x,attr"`
-	Y          int        `xml:"y,attr"`
-	W          int        `xml:"w,attr"`
-	H          int        `xml:"h,attr"`
-	Style      *aoefStyle `xml:"style"`
-	Children   []aoefNode `xml:"node"`
+	Identifier      string     `xml:"identifier,attr"`
+	ElementRef      string     `xml:"elementRef,attr,omitempty"`
+	NodeType        string     `xml:"xsi:type,attr,omitempty"`
+	LabelExpression string     `xml:"labelExpression,attr,omitempty"`
+	X               int        `xml:"x,attr"`
+	Y               int        `xml:"y,attr"`
+	W               int        `xml:"w,attr"`
+	H               int        `xml:"h,attr"`
+	Style           *aoefStyle `xml:"style"`
+	Children        []aoefNode `xml:"node"`
 }
 
 type aoefConn struct {
 	Identifier      string      `xml:"identifier,attr,omitempty"`
 	RelationshipRef string      `xml:"relationshipRef,attr"`
-	Type            string      `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr,omitempty"`
+	Type            string      `xml:"xsi:type,attr,omitempty"`
 	Source          string      `xml:"source,attr"`
 	Target          string      `xml:"target,attr"`
 	Style           *aoefStyle  `xml:"style"`
@@ -351,19 +352,14 @@ func buildOrganizations(folders []parser.ViewFolder, diagFolders []parser.Diagra
 		return item
 	}
 
-	// Root folders: parentID == "".
-	roots := childFolders[""]
+	// Root folders: parentID == "". Each root folder becomes a top-level <item>.
 	block := &aoefOrgsBlock{}
-	topItem := aoefOrgItem{} // single top-level anonymous item wrapping all roots
-	for _, root := range roots {
-		topItem.Children = append(topItem.Children, buildItem(root))
+	for _, root := range childFolders[""] {
+		block.Items = append(block.Items, buildItem(root))
 	}
-	// Diagrams with no folder go directly under the top item.
+	// Diagrams with no folder go directly as top-level <item identifierRef="...">.
 	for _, diagID := range folderDiags[""] {
-		topItem.Children = append(topItem.Children, aoefOrgItem{IdentifierRef: diagID})
-	}
-	if len(topItem.Children) > 0 {
-		block.Items = []aoefOrgItem{topItem}
+		block.Items = append(block.Items, aoefOrgItem{IdentifierRef: diagID})
 	}
 	return block
 }
@@ -521,12 +517,13 @@ func buildNodeTree(nodes []parser.NodeLayout) []aoefNode {
 			elementRef = ""
 		}
 		node := aoefNode{
-			Identifier: n.NodeID,
-			ElementRef: elementRef,
-			NodeType:   n.NodeType,
-			X:          n.X,
-			Y:          n.Y,
-			W:          n.W,
+			Identifier:      n.NodeID,
+			ElementRef:      elementRef,
+			NodeType:        n.NodeType,
+			LabelExpression: n.LabelExpression,
+			X:               n.X,
+			Y:               n.Y,
+			W:               n.W,
 			H:          n.H,
 			Style:      convertNodeStyle(n.Style),
 		}

--- a/internal/exporter/aoef.go
+++ b/internal/exporter/aoef.go
@@ -524,8 +524,8 @@ func buildNodeTree(nodes []parser.NodeLayout) []aoefNode {
 			X:               n.X,
 			Y:               n.Y,
 			W:               n.W,
-			H:          n.H,
-			Style:      convertNodeStyle(n.Style),
+			H:               n.H,
+			Style:           convertNodeStyle(n.Style),
 		}
 		// Children reference this node via its ElementID (element node) or
 		// NodeID (group node — ElementID is empty).

--- a/internal/exporter/loader.go
+++ b/internal/exporter/loader.go
@@ -452,6 +452,7 @@ func loadDiagrams(db *sql.DB, workspaceID uuid.UUID) ([]parser.Diagram, error) {
 				ParentElementID string       `json:"ParentElementID"`
 				NodeType        string       `json:"NodeType"`
 				Label           string       `json:"Label"`
+				LabelExpression string       `json:"LabelExpression"`
 				ElementType     string       `json:"ElementType"`
 				X               int          `json:"X"`
 				Y               int          `json:"Y"`
@@ -486,6 +487,7 @@ func loadDiagrams(db *sql.DB, workspaceID uuid.UUID) ([]parser.Diagram, error) {
 				ParentElementID: n.ParentElementID,
 				NodeType:        n.NodeType,
 				Label:           n.Label,
+				LabelExpression: n.LabelExpression,
 				ElementType:     n.ElementType,
 				X:               n.X,
 				Y:               n.Y,

--- a/internal/parser/aoef.go
+++ b/internal/parser/aoef.go
@@ -110,16 +110,17 @@ type aoefView struct {
 }
 
 type aoefNode struct {
-	Identifier string           `xml:"identifier,attr"`
-	NodeType   string           `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr"`
-	ElementRef string           `xml:"elementRef,attr"`
-	X          int              `xml:"x,attr"`
-	Y          int              `xml:"y,attr"`
-	W          int              `xml:"w,attr"`
-	H          int              `xml:"h,attr"`
-	Children   []aoefNode       `xml:"node"`
-	Style      *aoefStyle       `xml:"style"`
-	Labels     []aoefLangString `xml:"label"`
+	Identifier      string           `xml:"identifier,attr"`
+	NodeType        string           `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr"`
+	ElementRef      string           `xml:"elementRef,attr"`
+	LabelExpression string           `xml:"labelExpression,attr"`
+	X               int              `xml:"x,attr"`
+	Y               int              `xml:"y,attr"`
+	W               int              `xml:"w,attr"`
+	H               int              `xml:"h,attr"`
+	Children        []aoefNode       `xml:"node"`
+	Style           *aoefStyle       `xml:"style"`
+	Labels          []aoefLangString `xml:"label"`
 }
 
 type aoefConn struct {
@@ -554,6 +555,7 @@ func collectNodes(nodes []aoefNode, parentElementID string, out *[]NodeLayout) {
 				ElementID:       n.ElementRef,
 				ParentElementID: parentElementID,
 				NodeType:        n.NodeType,
+				LabelExpression: n.LabelExpression,
 				X:               n.X, Y: n.Y, W: n.W, H: n.H,
 				Style: convertNodeStyle(n.Style),
 			})
@@ -568,6 +570,7 @@ func collectNodes(nodes []aoefNode, parentElementID string, out *[]NodeLayout) {
 				ParentElementID: parentElementID,
 				NodeType:        n.NodeType,
 				Label:           label,
+				LabelExpression: n.LabelExpression,
 				ElementType:     "Group",
 				X:               n.X, Y: n.Y, W: n.W, H: n.H,
 				Style: convertNodeStyle(n.Style),

--- a/internal/parser/model.go
+++ b/internal/parser/model.go
@@ -130,6 +130,7 @@ type NodeLayout struct {
 	ParentElementID string // empty if top-level node
 	NodeType        string // xsi:type: Element|Container|Label|etc. (empty = Element)
 	Label           string // used for group nodes that have no element reference
+	LabelExpression string // Archi-specific labelExpression attr (preserved for round-trip, not evaluated)
 	ElementType     string // overrides DB lookup when set (e.g. "Group")
 	X, Y            int
 	W, H            int


### PR DESCRIPTION
## Summary

The OEF XSD enforces a strict element sequence inside `<model>`:

```
name → properties → elements → relationships → propertyDefinitions → views → organizations
```

`propertyDefinitions` was placed before `elements` in the struct, causing Archi (and any strict XSD validator) to reject the exported file with:

> cvc-complex-type.2.4.a: Invalid content found starting with element 'elements'. One of 'views' is expected.

One-line fix: move `PropertyDefs` field after `Relationships` in `aoefModel`.

## Test plan

- [ ] Export Archimetal workspace as AOEF and import in Archi — should import without errors
- [ ] Run `python3 tools/compare_archimate.py examples/Archimetal.xml <export>.xml` — all sections SAME