### PR TITLE
feat(import): two-step preview before confirming model import

### DIFF
--- a/cmd/archipulse/ui/package-lock.json
+++ b/cmd/archipulse/ui/package-lock.json
@@ -17,6 +17,7 @@
         "d3-scale": "^4.0.2",
         "dagre": "^0.8.5",
         "layerchart": "^2.0.0-next.48",
+        "svelte-sonner": "^1.1.0",
         "svelte-spa-router": "^4.0.1",
         "tailwind-merge": "^3.5.0",
         "tailwind-variants": "^3.2.2",
@@ -3791,6 +3792,34 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/svelte-sonner": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/svelte-sonner/-/svelte-sonner-1.1.0.tgz",
+      "integrity": "sha512-3lYM6ZIqWe+p9vwwWHGWP/ZdvHiUtzURsud2quIxivrX4rvpXh6i+geBGn0m3JS6KwW6W8VgbOl3xQMcDuh6gg==",
+      "license": "MIT",
+      "dependencies": {
+        "runed": "^0.28.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0"
+      }
+    },
+    "node_modules/svelte-sonner/node_modules/runed": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/runed/-/runed-0.28.0.tgz",
+      "integrity": "sha512-k2xx7RuO9hWcdd9f+8JoBeqWtYrm5CALfgpkg2YDB80ds/QE4w0qqu34A7fqiAwiBBSBQOid7TLxwxVC27ymWQ==",
+      "funding": [
+        "https://github.com/sponsors/huntabyte",
+        "https://github.com/sponsors/tglide"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "esm-env": "^1.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.7.0"
       }
     },
     "node_modules/svelte-spa-router": {

--- a/cmd/archipulse/ui/package.json
+++ b/cmd/archipulse/ui/package.json
@@ -22,6 +22,7 @@
     "d3-scale": "^4.0.2",
     "dagre": "^0.8.5",
     "layerchart": "^2.0.0-next.48",
+    "svelte-sonner": "^1.1.0",
     "svelte-spa-router": "^4.0.1",
     "tailwind-merge": "^3.5.0",
     "tailwind-variants": "^3.2.2",

--- a/cmd/archipulse/ui/src/App.svelte
+++ b/cmd/archipulse/ui/src/App.svelte
@@ -16,8 +16,10 @@
   import WorkspaceSettings from './routes/WorkspaceSettings.svelte';
   import WorkspaceHistory from './routes/WorkspaceHistory.svelte';
 
+  import { Toaster, toast } from 'svelte-sonner';
   import { api } from './lib/api.js';
   import { VIEWS } from './lib/views.js';
+  import { importRevision } from './lib/workspace-events.js';
   import { user, fetchMe } from './lib/auth.js';
   import { onMount } from 'svelte';
 
@@ -110,8 +112,18 @@
 
   $: viewLabel = viewName ? (VIEWS[viewName] ? VIEWS[viewName].label : viewName) : null;
 
-  function handleImported() {
-    if (wsId) loadWs(wsId);
+  function handleImported(e) {
+    if (wsId) {
+      loadWs(wsId);
+      push('/ws/' + wsId);
+      importRevision.update(n => n + 1);
+      const d = e?.detail;
+      if (d) {
+        toast.success('Import complete', {
+          description: `${d.elements} elements · ${d.relationships} relationships · ${d.diagrams} diagrams`,
+        });
+      }
+    }
   }
 
   function routeEvent(e) {
@@ -161,3 +173,5 @@
     {/if}
   </div>
 {/if}
+
+<Toaster richColors position="bottom-right" />

--- a/cmd/archipulse/ui/src/components/Sidebar.svelte
+++ b/cmd/archipulse/ui/src/components/Sidebar.svelte
@@ -54,11 +54,17 @@
     'dot-mot':   '#7c3aed',
   };
 
-  let importResult = null;
   let importing = false;
   let dropOver = false;
   let importError = null;
   let showErrorDialog = false;
+
+  // Preview state
+  let pendingFile = null;
+  let preview = null;
+  let showPreview = false;
+  let confirming = false;
+  let expandedCategories = {};
 
   $: showErrorDialog = !!importError;
 
@@ -68,7 +74,7 @@
 
   function handleFileInput(e) {
     const file = e.target.files[0];
-    if (file) doImport(file);
+    if (file) doPreview(file);
     e.target.value = '';
   }
 
@@ -85,25 +91,57 @@
     e.preventDefault();
     dropOver = false;
     const file = e.dataTransfer.files[0];
-    if (file) doImport(file);
+    if (file) doPreview(file);
   }
 
-  async function doImport(file) {
+  async function doPreview(file) {
     importing = true;
-    importResult = null;
+    preview = null;
+    pendingFile = file;
+    expandedCategories = {};
     try {
       const fd = new FormData();
       fd.append('file', file);
-      const data = await api.upload('/workspaces/' + wsId + '/import', fd);
-      importResult = { ok: true, msg: `✓ ${data.elements} elements · ${data.relationships} relationships` };
-      setTimeout(() => {
-        dispatch('imported');
-      }, 1400);
+      preview = await api.upload('/workspaces/' + wsId + '/import/preview', fd);
+      showPreview = true;
     } catch (e) {
       importError = e.message;
     } finally {
       importing = false;
     }
+  }
+
+  async function confirmImport() {
+    confirming = true;
+    try {
+      const fd = new FormData();
+      fd.append('file', pendingFile);
+      const data = await api.upload('/workspaces/' + wsId + '/import', fd);
+      showPreview = false;
+      preview = null;
+      pendingFile = null;
+      dispatch('imported', data);
+    } catch (e) {
+      showPreview = false;
+      importError = e.message;
+    } finally {
+      confirming = false;
+    }
+  }
+
+  function cancelPreview() {
+    showPreview = false;
+    preview = null;
+    pendingFile = null;
+  }
+
+  function toggleCategory(key) {
+    expandedCategories[key] = !expandedCategories[key];
+    expandedCategories = expandedCategories;
+  }
+
+  function categoryLabel(key) {
+    return { elements: 'Elements', relationships: 'Relationships', diagrams: 'Diagrams', property_definitions: 'Property definitions' }[key] || key;
   }
 </script>
 
@@ -117,8 +155,8 @@
 
   <div
     class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm cursor-pointer transition-colors mx-2 mt-2 {loc === '/ws/' + wsId ? 'bg-white text-foreground font-medium shadow-sm' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
-    on:click={() => push('/ws/' + wsId)}
-    on:keydown={e => e.key === 'Enter' && push('/ws/' + wsId)}
+    onclick={() => push('/ws/' + wsId)}
+    onkeydown={e => e.key === 'Enter' && push('/ws/' + wsId)}
     role="button"
     tabindex="0"
   >
@@ -126,8 +164,8 @@
   </div>
   <div
     class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm cursor-pointer transition-colors mx-2 mt-0.5 {loc === '/ws/' + wsId + '/history' ? 'bg-white text-foreground font-medium shadow-sm' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
-    on:click={() => push('/ws/' + wsId + '/history')}
-    on:keydown={e => e.key === 'Enter' && push('/ws/' + wsId + '/history')}
+    onclick={() => push('/ws/' + wsId + '/history')}
+    onkeydown={e => e.key === 'Enter' && push('/ws/' + wsId + '/history')}
     role="button"
     tabindex="0"
   >
@@ -147,8 +185,8 @@
           {@const active = loc === base || loc.startsWith(base + '/')}
           <div
             class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm cursor-pointer transition-colors {active ? 'bg-white text-foreground font-medium shadow-sm' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
-            on:click={() => push('/ws/' + wsId + '/view/' + navTarget(key, v))}
-            on:keydown={e => e.key === 'Enter' && push('/ws/' + wsId + '/view/' + navTarget(key, v))}
+            onclick={() => push('/ws/' + wsId + '/view/' + navTarget(key, v))}
+            onkeydown={e => e.key === 'Enter' && push('/ws/' + wsId + '/view/' + navTarget(key, v))}
             role="button"
             tabindex="0"
           >
@@ -172,8 +210,8 @@
       {@const active = loc === item.path || loc.startsWith(item.path + '/')}
       <div
         class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm cursor-pointer transition-colors {active ? 'bg-white text-foreground font-medium shadow-sm' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
-        on:click={() => push(item.path)}
-        on:keydown={e => e.key === 'Enter' && push(item.path)}
+        onclick={() => push(item.path)}
+        onkeydown={e => e.key === 'Enter' && push(item.path)}
         role="button"
         tabindex="0"
       >
@@ -189,8 +227,8 @@
   <div class="px-2 pt-3 pb-1">
     <div
       class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm cursor-pointer transition-colors {loc === '/ws/' + wsId + '/settings' ? 'bg-white text-foreground font-medium shadow-sm' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
-      on:click={() => push('/ws/' + wsId + '/settings')}
-      on:keydown={e => e.key === 'Enter' && push('/ws/' + wsId + '/settings')}
+      onclick={() => push('/ws/' + wsId + '/settings')}
+      onkeydown={e => e.key === 'Enter' && push('/ws/' + wsId + '/settings')}
       role="button"
       tabindex="0"
     >
@@ -201,13 +239,13 @@
   <div class="mt-auto px-2 py-3 border-t border-border">
     <div
       class="border-2 border-dashed border-border rounded-lg p-3.5 text-center text-muted-foreground cursor-pointer transition-colors {dropOver ? 'border-primary text-foreground' : 'hover:border-primary hover:text-foreground'}"
-      on:click={() => document.getElementById('sb-file-input-' + wsId).click()}
-      on:dragover={handleDragOver}
-      on:dragleave={handleDragLeave}
-      on:drop={handleDrop}
+      onclick={() => document.getElementById('sb-file-input-' + wsId).click()}
+      ondragover={handleDragOver}
+      ondragleave={handleDragLeave}
+      ondrop={handleDrop}
       role="button"
       tabindex="0"
-      on:keydown={e => e.key === 'Enter' && document.getElementById('sb-file-input-' + wsId).click()}
+      onkeydown={e => e.key === 'Enter' && document.getElementById('sb-file-input-' + wsId).click()}
     >
       <div class="text-2xl mb-1.5">↑</div>
       <p class="text-xs">Import model</p>
@@ -218,15 +256,11 @@
       id="sb-file-input-{wsId}"
       accept=".xml,.ajx,.json"
       style="display:none"
-      on:change={handleFileInput}
+      onchange={handleFileInput}
     />
     {#if importing}
       <div class="flex items-center gap-2 text-muted-foreground py-2 mt-2">
         <div class="size-4 rounded-full border-2 border-border border-t-primary animate-spin flex-shrink-0"></div>
-      </div>
-    {:else if importResult}
-      <div class="mt-2 text-[12px] px-3 py-2 rounded-md bg-success/10 border border-success/30 text-success">
-        {importResult.msg}
       </div>
     {/if}
   </div>
@@ -240,6 +274,78 @@
     </Dialog.Header>
     <Dialog.Footer>
       <Button onclick={() => importError = null}>OK</Button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>
+
+<Dialog.Root bind:open={showPreview} onOpenChange={(o) => { if (!o) cancelPreview(); }}>
+  <Dialog.Content class="max-w-lg">
+    <Dialog.Header>
+      <Dialog.Title>Import preview</Dialog.Title>
+      <Dialog.Description>Review what will change before confirming the import.</Dialog.Description>
+    </Dialog.Header>
+    {#if preview}
+      <div class="space-y-2 max-h-[50vh] overflow-y-auto pr-1">
+        {#each Object.entries(preview) as [key, cat]}
+          {#if cat.added > 0 || cat.modified > 0 || cat.unchanged > 0}
+            <div class="border border-border rounded-md overflow-hidden">
+              <div
+                class="flex items-center justify-between px-3 py-2 bg-muted/40 cursor-pointer select-none"
+                role="button"
+                tabindex="0"
+                onclick={() => toggleCategory(key)}
+                onkeydown={e => e.key === 'Enter' && toggleCategory(key)}
+              >
+                <span class="text-[13px] font-medium">{categoryLabel(key)}</span>
+                <div class="flex items-center gap-2 text-[12px]">
+                  {#if cat.added > 0}
+                    <span class="text-green-600 font-medium">+{cat.added}</span>
+                  {/if}
+                  {#if cat.modified > 0}
+                    <span class="text-amber-600 font-medium">~{cat.modified}</span>
+                  {/if}
+                  {#if cat.unchanged > 0}
+                    <span class="text-muted-foreground">{cat.unchanged} unchanged</span>
+                  {/if}
+                  {#if cat.added > 0 || cat.modified > 0}
+                    <span class="text-muted-foreground text-[11px] ml-1">{expandedCategories[key] ? '▲' : '▼'}</span>
+                  {/if}
+                </div>
+              </div>
+              {#if expandedCategories[key] && cat.details?.length > 0}
+                <div class="divide-y divide-border max-h-48 overflow-y-auto">
+                  {#each cat.details as item, i}
+                    <div class="flex items-start gap-2 px-3 py-1.5 text-[12px]">
+                      {#if i < cat.added}
+                        <span class="flex-shrink-0 w-4 text-center text-green-600 font-bold">+</span>
+                      {:else}
+                        <span class="flex-shrink-0 w-4 text-center text-amber-600 font-bold">~</span>
+                      {/if}
+                      <span class="flex-1 truncate text-foreground">{item.name || item.source_id}</span>
+                      {#if item.type}
+                        <span class="text-muted-foreground flex-shrink-0">{item.type}</span>
+                      {/if}
+                    </div>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+          {/if}
+        {/each}
+      </div>
+    {/if}
+    <Dialog.Footer class="gap-2">
+      <Button variant="outline" onclick={cancelPreview} disabled={confirming}>Cancel</Button>
+      <Button onclick={confirmImport} disabled={confirming}>
+        {#if confirming}
+          <span class="flex items-center gap-1.5">
+            <span class="size-3.5 rounded-full border-2 border-white/40 border-t-white animate-spin"></span>
+            Importing…
+          </span>
+        {:else}
+          Confirm import
+        {/if}
+      </Button>
     </Dialog.Footer>
   </Dialog.Content>
 </Dialog.Root>

--- a/cmd/archipulse/ui/src/lib/workspace-events.js
+++ b/cmd/archipulse/ui/src/lib/workspace-events.js
@@ -1,0 +1,5 @@
+import { writable } from 'svelte/store';
+
+// Incremented each time a model is successfully imported.
+// Components that display model data subscribe to this to trigger a reload.
+export const importRevision = writable(0);

--- a/cmd/archipulse/ui/src/routes/WorkspaceOverview.svelte
+++ b/cmd/archipulse/ui/src/routes/WorkspaceOverview.svelte
@@ -3,6 +3,7 @@
   import { push } from 'svelte-spa-router';
   import { api } from '../lib/api.js';
   import { VIEWS } from '../lib/views.js';
+  import { importRevision } from '../lib/workspace-events.js';
 
   export let params = {};
 
@@ -17,6 +18,9 @@
   onMount(async () => {
     await load();
   });
+
+  // Reload when a new model is imported (even if we're already on this route).
+  $: if ($importRevision >= 0 && wsId) load();
 
   async function load() {
     loading = true;

--- a/internal/api/import_handler.go
+++ b/internal/api/import_handler.go
@@ -458,4 +458,5 @@ func ImportModel(db *sql.DB, wsID uuid.UUID, m *parser.Model) (*ImportResult, er
 func registerImportRoutes(r chi.Router, db *sql.DB, svc *auth.Service, auditStore *audit.Store, snapStore *snapshot.Store) {
 	h := &importHandler{db: db, audit: auditStore, snaps: snapStore}
 	r.With(svc.RequireWorkspaceAccess(auth.RoleEditor)).Post("/workspaces/{id}/import", h.importModel)
+	r.With(svc.RequireWorkspaceAccess(auth.RoleEditor)).Post("/workspaces/{id}/import/preview", h.previewImport)
 }

--- a/internal/api/import_preview_handler.go
+++ b/internal/api/import_preview_handler.go
@@ -1,0 +1,337 @@
+package api
+
+import (
+	"database/sql"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/DisruptiveWorks/archipulse/internal/parser"
+	"github.com/DisruptiveWorks/archipulse/internal/workspace"
+)
+
+// PreviewItem describes a single added or modified entity.
+type PreviewItem struct {
+	SourceID string `json:"source_id"`
+	Name     string `json:"name"`
+	Type     string `json:"type,omitempty"`
+}
+
+// PreviewCategory summarises changes for one category of entities.
+type PreviewCategory struct {
+	Added     int           `json:"added"`
+	Modified  int           `json:"modified"`
+	Unchanged int           `json:"unchanged"`
+	Details   []PreviewItem `json:"details"` // only added + modified items
+}
+
+// ImportPreview is the full diff returned by the preview endpoint.
+type ImportPreview struct {
+	Elements            PreviewCategory `json:"elements"`
+	Relationships       PreviewCategory `json:"relationships"`
+	Diagrams            PreviewCategory `json:"diagrams"`
+	PropertyDefinitions PreviewCategory `json:"property_definitions"`
+}
+
+func (h *importHandler) previewImport(w http.ResponseWriter, r *http.Request) {
+	wsID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		respondError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	if _, err := workspace.NewStore(h.db).Get(wsID); err != nil {
+		if isNotFound(err) {
+			respondError(w, http.StatusNotFound, err)
+		} else {
+			respondError(w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+
+	if err := r.ParseMultipartForm(maxUploadSize); err != nil {
+		respondError(w, http.StatusBadRequest, errorf("parse multipart form: %v", err))
+		return
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		respondError(w, http.StatusBadRequest, errorf("file field required"))
+		return
+	}
+	defer func() { _ = file.Close() }()
+
+	name := strings.ToLower(header.Filename)
+	var m *parser.Model
+	switch {
+	case strings.HasSuffix(name, ".xml"):
+		m, err = parser.ParseAOEF(file)
+	case strings.HasSuffix(name, ".ajx"), strings.HasSuffix(name, ".json"):
+		m, err = parser.ParseAJX(file)
+	default:
+		respondError(w, http.StatusBadRequest, errorf("unsupported file format: use .xml (AOEF) or .ajx/.json (AJX)"))
+		return
+	}
+	if err != nil {
+		respondError(w, http.StatusUnprocessableEntity, errorf("parse error: %v", err))
+		return
+	}
+
+	preview, err := buildImportPreview(h.db, wsID, m)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
+	respondJSON(w, http.StatusOK, preview)
+}
+
+// buildImportPreview compares the incoming model against the current workspace
+// state and returns a diff without writing anything to the database.
+func buildImportPreview(db *sql.DB, wsID uuid.UUID, m *parser.Model) (*ImportPreview, error) {
+	preview := &ImportPreview{}
+	var err error
+
+	preview.Elements, err = diffElements(db, wsID, m)
+	if err != nil {
+		return nil, err
+	}
+	preview.Relationships, err = diffRelationships(db, wsID, m)
+	if err != nil {
+		return nil, err
+	}
+	preview.Diagrams, err = diffDiagrams(db, wsID, m)
+	if err != nil {
+		return nil, err
+	}
+	preview.PropertyDefinitions, err = diffPropertyDefinitions(db, wsID, m)
+	if err != nil {
+		return nil, err
+	}
+	return preview, nil
+}
+
+// diffElements compares incoming elements against the workspace DB.
+func diffElements(db *sql.DB, wsID uuid.UUID, m *parser.Model) (PreviewCategory, error) {
+	rows, err := db.Query(`
+		SELECT e.source_id, COALESCE(n.value, e.name, ''), e.type
+		FROM elements e
+		LEFT JOIN element_names n ON n.element_id = e.id AND n.field = 'name'
+		WHERE e.workspace_id = $1`, wsID)
+	if err != nil {
+		return PreviewCategory{}, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	type existing struct{ name, typ string }
+	current := make(map[string]existing)
+	for rows.Next() {
+		var sid, name, typ string
+		if err := rows.Scan(&sid, &name, &typ); err != nil {
+			return PreviewCategory{}, err
+		}
+		current[sid] = existing{name, typ}
+	}
+	if err := rows.Err(); err != nil {
+		return PreviewCategory{}, err
+	}
+
+	var cat PreviewCategory
+	for _, el := range m.Elements {
+		ex, exists := current[el.ID]
+		displayName := el.Name
+		if displayName == "" {
+			displayName = firstLangValue(el.Names)
+		}
+		if !exists {
+			cat.Added++
+			cat.Details = append(cat.Details, PreviewItem{
+				SourceID: el.ID,
+				Name:     displayName,
+				Type:     el.Type,
+			})
+		} else if ex.typ != el.Type || nameChanged(ex.name, displayName) {
+			cat.Modified++
+			cat.Details = append(cat.Details, PreviewItem{
+				SourceID: el.ID,
+				Name:     displayName,
+				Type:     el.Type,
+			})
+		} else {
+			cat.Unchanged++
+		}
+	}
+	return cat, nil
+}
+
+// diffRelationships compares incoming relationships against the workspace DB.
+func diffRelationships(db *sql.DB, wsID uuid.UUID, m *parser.Model) (PreviewCategory, error) {
+	rows, err := db.Query(`
+		SELECT source_id, type, source_element, target_element
+		FROM relationships
+		WHERE workspace_id = $1`, wsID)
+	if err != nil {
+		return PreviewCategory{}, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	type existing struct{ typ, src, tgt string }
+	current := make(map[string]existing)
+	for rows.Next() {
+		var sid, typ, src, tgt string
+		if err := rows.Scan(&sid, &typ, &src, &tgt); err != nil {
+			return PreviewCategory{}, err
+		}
+		current[sid] = existing{typ, src, tgt}
+	}
+	if err := rows.Err(); err != nil {
+		return PreviewCategory{}, err
+	}
+
+	var cat PreviewCategory
+	for _, rel := range m.Relationships {
+		ex, exists := current[rel.ID]
+		displayName := rel.Name
+		if displayName == "" {
+			displayName = firstLangValue(rel.Names)
+		}
+		if !exists {
+			cat.Added++
+			cat.Details = append(cat.Details, PreviewItem{
+				SourceID: rel.ID,
+				Name:     displayName,
+				Type:     rel.Type,
+			})
+		} else if ex.typ != rel.Type || ex.src != rel.Source || ex.tgt != rel.Target {
+			cat.Modified++
+			cat.Details = append(cat.Details, PreviewItem{
+				SourceID: rel.ID,
+				Name:     displayName,
+				Type:     rel.Type,
+			})
+		} else {
+			cat.Unchanged++
+		}
+	}
+	return cat, nil
+}
+
+// diffDiagrams compares incoming diagrams against the workspace DB.
+func diffDiagrams(db *sql.DB, wsID uuid.UUID, m *parser.Model) (PreviewCategory, error) {
+	rows, err := db.Query(`
+		SELECT d.source_id, COALESCE(n.value, d.name, '')
+		FROM diagrams d
+		LEFT JOIN diagram_names n ON n.diagram_id = d.id AND n.field = 'name'
+		WHERE d.workspace_id = $1`, wsID)
+	if err != nil {
+		return PreviewCategory{}, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	current := make(map[string]string)
+	for rows.Next() {
+		var sid, name string
+		if err := rows.Scan(&sid, &name); err != nil {
+			return PreviewCategory{}, err
+		}
+		current[sid] = name
+	}
+	if err := rows.Err(); err != nil {
+		return PreviewCategory{}, err
+	}
+
+	var cat PreviewCategory
+	for _, d := range m.Diagrams {
+		existingName, exists := current[d.ID]
+		displayName := d.Name
+		if displayName == "" {
+			displayName = firstLangValue(d.Names)
+		}
+		if !exists {
+			cat.Added++
+			cat.Details = append(cat.Details, PreviewItem{
+				SourceID: d.ID,
+				Name:     displayName,
+			})
+		} else if nameChanged(existingName, displayName) {
+			cat.Modified++
+			cat.Details = append(cat.Details, PreviewItem{
+				SourceID: d.ID,
+				Name:     displayName,
+			})
+		} else {
+			cat.Unchanged++
+		}
+	}
+	return cat, nil
+}
+
+// diffPropertyDefinitions compares incoming property definitions against the workspace DB.
+func diffPropertyDefinitions(db *sql.DB, wsID uuid.UUID, m *parser.Model) (PreviewCategory, error) {
+	rows, err := db.Query(`
+		SELECT source_id, name, data_type FROM property_definitions WHERE workspace_id = $1`, wsID)
+	if err != nil {
+		return PreviewCategory{}, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	type existing struct{ name, typ string }
+	current := make(map[string]existing)
+	for rows.Next() {
+		var sid, name, typ string
+		if err := rows.Scan(&sid, &name, &typ); err != nil {
+			return PreviewCategory{}, err
+		}
+		current[sid] = existing{name, typ}
+	}
+	if err := rows.Err(); err != nil {
+		return PreviewCategory{}, err
+	}
+
+	var cat PreviewCategory
+	for _, pd := range m.PropertyDefinitions {
+		ex, exists := current[pd.ID]
+		if !exists {
+			cat.Added++
+			cat.Details = append(cat.Details, PreviewItem{
+				SourceID: pd.ID,
+				Name:     pd.Name,
+				Type:     pd.DataType,
+			})
+		} else if ex.name != pd.Name || ex.typ != pd.DataType {
+			cat.Modified++
+			cat.Details = append(cat.Details, PreviewItem{
+				SourceID: pd.ID,
+				Name:     pd.Name,
+				Type:     pd.DataType,
+			})
+		} else {
+			cat.Unchanged++
+		}
+	}
+	return cat, nil
+}
+
+// firstLangValue returns the first non-empty value from a []parser.LangString.
+func firstLangValue(langs []parser.LangString) string {
+	for _, l := range langs {
+		if l.Value != "" {
+			return l.Value
+		}
+	}
+	return ""
+}
+
+// nameChanged returns true if the names differ, ignoring empty values.
+func nameChanged(existing, incoming string) bool {
+	if incoming == "" {
+		return false
+	}
+	return existing != incoming
+}
+
+// isNotFound checks for workspace not-found errors.
+func isNotFound(err error) bool {
+	return err != nil && err.Error() == "workspace not found"
+}


### PR DESCRIPTION
## Summary

- Adds `POST /workspaces/{id}/import/preview` endpoint (editor role) that diffs the incoming model against the current workspace state — no DB writes
- Returns added/modified/unchanged counts for elements, relationships, diagrams, and property definitions, plus a detail list of added+modified items
- Sidebar import flow replaced with a two-step preview modal: shows summary with expandable per-category lists (+/~ indicators per item), then user confirms
- On confirm: navigates to workspace overview, triggers reactive reload via `importRevision` store, shows a toast with import stats
- Replaced inline success message (hidden at bottom of sidebar) with `svelte-sonner` toast notification

## Test plan

- [ ] Drop or select a model file in the sidebar → preview modal appears with correct counts
- [ ] Expand each category → added items show `+`, modified show `~`
- [ ] Click "Confirm import" → modal closes, navigates to overview, overview refreshes, toast appears
- [ ] Click "Cancel" → modal closes, nothing is imported
- [ ] Re-import same file → all counts show as unchanged (0 added/modified)
- [ ] Import as viewer role → 403 (preview and import both require editor)