### PR TITLE
fix(exporter): emit <label> for group/container nodes in OEF export

### DIFF
--- a/internal/exporter/aoef.go
+++ b/internal/exporter/aoef.go
@@ -165,6 +165,7 @@ type aoefNode struct {
 	Y               int        `xml:"y,attr"`
 	W               int        `xml:"w,attr"`
 	H               int        `xml:"h,attr"`
+	Label           string     `xml:"label,omitempty"`
 	Style           *aoefStyle `xml:"style"`
 	Children        []aoefNode `xml:"node"`
 }
@@ -516,6 +517,11 @@ func buildNodeTree(nodes []parser.NodeLayout) []aoefNode {
 		if elementRef == n.NodeID {
 			elementRef = ""
 		}
+		// Group/container nodes (no elementRef) store their display name in Label.
+		label := ""
+		if elementRef == "" {
+			label = n.Label
+		}
 		node := aoefNode{
 			Identifier:      n.NodeID,
 			ElementRef:      elementRef,
@@ -525,6 +531,7 @@ func buildNodeTree(nodes []parser.NodeLayout) []aoefNode {
 			Y:               n.Y,
 			W:               n.W,
 			H:               n.H,
+			Label:           label,
 			Style:           convertNodeStyle(n.Style),
 		}
 		// Children reference this node via its ElementID (element node) or


### PR DESCRIPTION
## Summary

- Group/container nodes (pure visual groupings with no `elementRef`) store their display name in `NodeLayout.Label`
- The `aoefNode` export struct was missing the `Label` field, so names were silently dropped on XML export
- Archi would then show these nodes as unnamed groups
- Fix: added `Label string \`xml:"label,omitempty"\`` to `aoefNode` and wire it in `buildNode` when `elementRef` is empty

## Test plan

- [ ] Import an AOEF file from Archi that contains named group/container nodes
- [ ] Export from ArchiPulse and re-import into Archi — group names should be preserved
- [ ] Nodes with an `elementRef` (real ArchiMate elements) are unaffected