### PR TITLE
feat(saved-views): update filters + async event bus for audit

### DIFF
--- a/cmd/archipulse/ui/src/components/views/ApplicationDashboard.svelte
+++ b/cmd/archipulse/ui/src/components/views/ApplicationDashboard.svelte
@@ -3,10 +3,12 @@
   import { api } from '../../lib/api.js';
   import { ArcChart } from 'layerchart';
   import SaveViewDialog from './SaveViewDialog.svelte';
+  import SaveViewUpdateBar from './SaveViewUpdateBar.svelte';
 
   export let params = {};
   export let initialFilters = null;
   export let savedViewName = null;
+  export let savedViewId = null;
 
   $: wsId = params.wsId;
 
@@ -196,6 +198,7 @@
       viewType="application-dashboard"
       filters={saveFilters}
     />
+    <SaveViewUpdateBar {wsId} {savedViewId} {savedViewName} currentFilters={saveFilters} {initialFilters} />
 
     {#if data.total_apps === 0}
       <div class="text-center py-16 px-6 text-muted-foreground">

--- a/cmd/archipulse/ui/src/components/views/ApplicationLandscape.svelte
+++ b/cmd/archipulse/ui/src/components/views/ApplicationLandscape.svelte
@@ -2,10 +2,11 @@
   import { onMount } from 'svelte';
   import { api } from '../../lib/api.js';
   import SaveViewDialog from './SaveViewDialog.svelte';
+  import SaveViewUpdateBar from './SaveViewUpdateBar.svelte';
   import AppDetailPanel from './AppDetailPanel.svelte';
   import ViewInfoDialog from './ViewInfoDialog.svelte';
 
-  const { params = {}, initialFilters = null, savedViewName = null } = $props();
+  const { params = {}, initialFilters = null, savedViewName = null, savedViewId = null } = $props();
 
   const wsId = $derived(params.wsId);
 
@@ -207,6 +208,7 @@
     </div>
 
     <SaveViewDialog bind:open={showSaveDialog} {wsId} viewType="application-landscape" filters={saveFilters} />
+    <SaveViewUpdateBar {wsId} {savedViewId} {savedViewName} currentFilters={saveFilters} {initialFilters} />
 
     {#if !data.domains?.length}
       <div class="text-center py-20 text-muted-foreground">

--- a/cmd/archipulse/ui/src/components/views/CapabilityLandscape.svelte
+++ b/cmd/archipulse/ui/src/components/views/CapabilityLandscape.svelte
@@ -2,10 +2,11 @@
   import { onMount } from 'svelte';
   import { api } from '../../lib/api.js';
   import SaveViewDialog from './SaveViewDialog.svelte';
+  import SaveViewUpdateBar from './SaveViewUpdateBar.svelte';
   import AppDetailPanel from './AppDetailPanel.svelte';
   import ViewInfoDialog from './ViewInfoDialog.svelte';
 
-  const { params = {}, initialFilters = null, savedViewName = null } = $props();
+  const { params = {}, initialFilters = null, savedViewName = null, savedViewId = null } = $props();
 
   const wsId = $derived(params.wsId);
 
@@ -276,6 +277,7 @@
     </div>
 
     <SaveViewDialog bind:open={showSaveDialog} {wsId} viewType="capability-landscape" filters={saveFilters} />
+    <SaveViewUpdateBar {wsId} {savedViewId} {savedViewName} currentFilters={saveFilters} {initialFilters} />
 
     <div class="flex gap-4 items-start">
 

--- a/cmd/archipulse/ui/src/components/views/CapabilityTree.svelte
+++ b/cmd/archipulse/ui/src/components/views/CapabilityTree.svelte
@@ -15,8 +15,9 @@
   import AppNode       from '../flow/AppNode.svelte';
   import FlowControls  from '../flow/FlowControls.svelte';
   import SaveViewDialog from './SaveViewDialog.svelte';
+  import SaveViewUpdateBar from './SaveViewUpdateBar.svelte';
 
-  let { params = {}, initialFilters = null, savedViewName = null } = $props();
+  let { params = {}, initialFilters = null, savedViewName = null, savedViewId = null } = $props();
   let showSaveDialog = $state(false);
 
   // ── XyFlow state ──────────────────────────────────────────────────────────
@@ -238,6 +239,7 @@
     viewType="capability-tree"
     filters={saveFilters}
   />
+  <SaveViewUpdateBar wsId={params.wsId} {savedViewId} {savedViewName} currentFilters={saveFilters} {initialFilters} />
 
   {#if loading}
     <div class="flex items-center gap-2 text-muted-foreground py-6 px-6">

--- a/cmd/archipulse/ui/src/components/views/DependencyGraphView.svelte
+++ b/cmd/archipulse/ui/src/components/views/DependencyGraphView.svelte
@@ -14,8 +14,9 @@
   import AppNode from '../flow/AppNode.svelte';
   import FlowControls from '../flow/FlowControls.svelte';
   import SaveViewDialog from './SaveViewDialog.svelte';
+  import SaveViewUpdateBar from './SaveViewUpdateBar.svelte';
 
-  let { params = {}, initialFilters = null, savedViewName = null } = $props();
+  let { params = {}, initialFilters = null, savedViewName = null, savedViewId = null } = $props();
   let showSaveDialog = $state(false);
 
   // ── XyFlow state ──────────────────────────────────────────────────────────
@@ -314,6 +315,7 @@
     viewType="application-dependency"
     filters={saveFilters}
   />
+  <SaveViewUpdateBar wsId={params.wsId} {savedViewId} {savedViewName} currentFilters={saveFilters} {initialFilters} />
 
   {#if loading}
     <div class="flex items-center gap-2 text-muted-foreground py-6 px-6">

--- a/cmd/archipulse/ui/src/components/views/ProcessApplication.svelte
+++ b/cmd/archipulse/ui/src/components/views/ProcessApplication.svelte
@@ -3,9 +3,10 @@
   import { api } from '../../lib/api.js';
   import AppDetailPanel from './AppDetailPanel.svelte';
   import SaveViewDialog from './SaveViewDialog.svelte';
+  import SaveViewUpdateBar from './SaveViewUpdateBar.svelte';
   import ViewInfoDialog from './ViewInfoDialog.svelte';
 
-  const { params = {}, initialFilters = null, savedViewName = null } = $props();
+  const { params = {}, initialFilters = null, savedViewName = null, savedViewId = null } = $props();
 
   const wsId = $derived(params.wsId);
 
@@ -152,6 +153,7 @@
     </div>
 
     <SaveViewDialog bind:open={showSaveDialog} {wsId} viewType="process-application" filters={saveFilters} />
+    <SaveViewUpdateBar {wsId} {savedViewId} {savedViewName} currentFilters={saveFilters} {initialFilters} />
 
     {#if !data.processes?.length}
       <div class="text-center py-20 text-muted-foreground">

--- a/cmd/archipulse/ui/src/components/views/SaveViewUpdateBar.svelte
+++ b/cmd/archipulse/ui/src/components/views/SaveViewUpdateBar.svelte
@@ -1,0 +1,61 @@
+<script>
+  import { toast } from 'svelte-sonner';
+  import { api } from '../../lib/api.js';
+
+  const { wsId, savedViewId, savedViewName, currentFilters, initialFilters } = $props();
+
+  // Track the last successfully saved filter state for change detection.
+  let lastSaved = $state(JSON.stringify(initialFilters ?? {}));
+  let showConfirm = $state(false);
+  let saving = $state(false);
+
+  const changed = $derived(JSON.stringify(currentFilters ?? {}) !== lastSaved);
+
+  async function doUpdate() {
+    saving = true;
+    try {
+      await api.put('/workspaces/' + wsId + '/saved-views/' + savedViewId, {
+        name: savedViewName,
+        filters: currentFilters,
+      });
+      lastSaved = JSON.stringify(currentFilters ?? {});
+      showConfirm = false;
+      toast.success('Saved view updated');
+    } catch (e) {
+      toast.error('Could not update: ' + e.message);
+    } finally {
+      saving = false;
+    }
+  }
+
+  function cancel() {
+    showConfirm = false;
+  }
+</script>
+
+{#if savedViewId && changed}
+  <div class="flex items-center gap-2 px-3 py-1.5 mb-4 rounded-lg border border-amber-200 bg-amber-50 text-[12px] text-amber-800 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300">
+    {#if showConfirm}
+      <span class="flex-1">Overwrite filters for <strong>"{savedViewName}"</strong>?</span>
+      <button
+        onclick={doUpdate}
+        disabled={saving}
+        class="px-2.5 py-1 rounded-md bg-amber-600 text-white font-medium hover:bg-amber-700 disabled:opacity-50 transition-colors">
+        {saving ? 'Saving…' : 'Confirm'}
+      </button>
+      <button
+        onclick={cancel}
+        disabled={saving}
+        class="px-2.5 py-1 rounded-md border border-amber-300 hover:bg-amber-100 transition-colors">
+        Cancel
+      </button>
+    {:else}
+      <span class="flex-1">Filters changed from saved view</span>
+      <button
+        onclick={() => showConfirm = true}
+        class="px-2.5 py-1 rounded-md border border-amber-400 font-medium hover:bg-amber-100 transition-colors">
+        Update saved view
+      </button>
+    {/if}
+  </div>
+{/if}

--- a/cmd/archipulse/ui/src/components/views/SavedViewLoader.svelte
+++ b/cmd/archipulse/ui/src/components/views/SavedViewLoader.svelte
@@ -45,19 +45,19 @@
   <div class="p-6 text-sm text-destructive">{error}</div>
 {:else if sv}
   {#if sv.view_type === 'application-dashboard'}
-    <ApplicationDashboard params={childParams} initialFilters={sv.filters} savedViewName={sv.name} />
+    <ApplicationDashboard params={childParams} initialFilters={sv.filters} savedViewName={sv.name} savedViewId={sv.id} />
   {:else if sv.view_type === 'capability-landscape'}
-    <CapabilityLandscape params={childParams} initialFilters={sv.filters} savedViewName={sv.name} />
+    <CapabilityLandscape params={childParams} initialFilters={sv.filters} savedViewName={sv.name} savedViewId={sv.id} />
   {:else if sv.view_type === 'application-landscape'}
-    <ApplicationLandscape params={childParams} initialFilters={sv.filters} savedViewName={sv.name} />
+    <ApplicationLandscape params={childParams} initialFilters={sv.filters} savedViewName={sv.name} savedViewId={sv.id} />
   {:else if sv.view_type === 'capability-tree'}
-    <CapabilityTree params={childParams} initialFilters={sv.filters} savedViewName={sv.name} />
+    <CapabilityTree params={childParams} initialFilters={sv.filters} savedViewName={sv.name} savedViewId={sv.id} />
   {:else if sv.view_type === 'application-dependency'}
-    <DependencyGraphView params={childParams} initialFilters={sv.filters} savedViewName={sv.name} />
+    <DependencyGraphView params={childParams} initialFilters={sv.filters} savedViewName={sv.name} savedViewId={sv.id} />
   {:else if sv.view_type === 'process-application'}
-    <ProcessApplication params={childParams} initialFilters={sv.filters} savedViewName={sv.name} />
+    <ProcessApplication params={childParams} initialFilters={sv.filters} savedViewName={sv.name} savedViewId={sv.id} />
   {:else if sv.view_type === 'technology-stack'}
-    <TechnologyStack params={childParams} initialFilters={sv.filters} savedViewName={sv.name} />
+    <TechnologyStack params={childParams} initialFilters={sv.filters} savedViewName={sv.name} savedViewId={sv.id} />
   {:else}
     <div class="p-6 text-sm text-muted-foreground">Unknown view type: {sv.view_type}</div>
   {/if}

--- a/cmd/archipulse/ui/src/components/views/TechnologyStack.svelte
+++ b/cmd/archipulse/ui/src/components/views/TechnologyStack.svelte
@@ -3,9 +3,10 @@
   import { api } from '../../lib/api.js';
   import AppDetailPanel from './AppDetailPanel.svelte';
   import SaveViewDialog from './SaveViewDialog.svelte';
+  import SaveViewUpdateBar from './SaveViewUpdateBar.svelte';
   import ViewInfoDialog from './ViewInfoDialog.svelte';
 
-  const { params = {}, initialFilters = null, savedViewName = null } = $props();
+  const { params = {}, initialFilters = null, savedViewName = null, savedViewId = null } = $props();
 
   const wsId = $derived(params.wsId);
 
@@ -144,6 +145,7 @@
     </div>
 
     <SaveViewDialog bind:open={showSaveDialog} {wsId} viewType="technology-stack" filters={saveFilters} />
+    <SaveViewUpdateBar {wsId} {savedViewId} {savedViewName} currentFilters={saveFilters} {initialFilters} />
 
     {#if !data.apps?.length && !data.tech?.length}
       <div class="text-center py-20 text-muted-foreground">

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DisruptiveWorks/archipulse/internal/audit"
 	"github.com/DisruptiveWorks/archipulse/internal/auth"
+	"github.com/DisruptiveWorks/archipulse/internal/events"
 	"github.com/DisruptiveWorks/archipulse/internal/snapshot"
 	"github.com/DisruptiveWorks/archipulse/internal/workspace"
 )
@@ -35,6 +36,29 @@ func NewRouter(db *sql.DB, svc *auth.Service, oidc *auth.OIDCProvider, static ..
 			r.Use(svc.RequireAuth)
 			auditStore := audit.NewStore(db)
 			snapStore := snapshot.NewStore(db)
+
+			// Event bus: async dispatcher; audit writes are subscribers.
+			bus := events.New(256)
+			bus.Subscribe(func(e events.Event) {
+				action := map[events.Kind]string{
+					events.KindSavedViewCreated: audit.ActionCreate,
+					events.KindSavedViewUpdated: audit.ActionUpdate,
+					events.KindSavedViewDeleted: audit.ActionDelete,
+				}[e.Kind]
+				if action == "" {
+					return
+				}
+				_ = auditStore.Record(audit.RecordParams{
+					WorkspaceID: e.WorkspaceID,
+					UserID:      e.ActorID,
+					UserEmail:   e.ActorEmail,
+					Action:      action,
+					EntityType:  audit.EntitySavedView,
+					EntityID:    e.ObjectID,
+					EntityName:  e.ObjectName,
+				})
+			})
+
 			registerWorkspaceRoutes(r, workspace.NewStore(db), svc)
 			registerMembershipRoutes(r, svc, auditStore)
 			registerUserRoutes(r, svc)
@@ -45,7 +69,7 @@ func NewRouter(db *sql.DB, svc *auth.Service, oidc *auth.OIDCProvider, static ..
 			registerExportRoutes(r, db, svc)
 			registerImportRoutes(r, db, svc, auditStore, snapStore)
 			registerViewerRoutes(r, db, svc)
-			registerSavedViewsRoutes(r, db, svc)
+			registerSavedViewsRoutes(r, db, svc, bus)
 			registerEventRoutes(r, auditStore, svc)
 			registerSnapshotRoutes(r, db, snapStore, auditStore, svc)
 		})

--- a/internal/api/saved_views_handler.go
+++ b/internal/api/saved_views_handler.go
@@ -9,11 +9,13 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/DisruptiveWorks/archipulse/internal/auth"
+	"github.com/DisruptiveWorks/archipulse/internal/events"
 	"github.com/DisruptiveWorks/archipulse/internal/savedviews"
 )
 
 type savedViewsHandler struct {
 	store *savedviews.Store
+	bus   *events.Bus
 }
 
 func (h *savedViewsHandler) list(w http.ResponseWriter, r *http.Request) {
@@ -82,6 +84,19 @@ func (h *savedViewsHandler) create(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusInternalServerError, err)
 		return
 	}
+	if h.bus != nil {
+		claims := auth.ClaimsFromCtx(r.Context())
+		if claims != nil {
+			h.bus.Publish(events.Event{
+				Kind:        events.KindSavedViewCreated,
+				WorkspaceID: wsID,
+				ActorID:     claims.UserID,
+				ActorEmail:  claims.Email,
+				ObjectID:    sv.ID.String(),
+				ObjectName:  sv.Name,
+			})
+		}
+	}
 	respondJSON(w, http.StatusCreated, sv)
 }
 
@@ -114,6 +129,19 @@ func (h *savedViewsHandler) update(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusNotFound, errorf("saved view not found"))
 		return
 	}
+	if h.bus != nil {
+		claims := auth.ClaimsFromCtx(r.Context())
+		if claims != nil {
+			h.bus.Publish(events.Event{
+				Kind:        events.KindSavedViewUpdated,
+				WorkspaceID: wsID,
+				ActorID:     claims.UserID,
+				ActorEmail:  claims.Email,
+				ObjectID:    sv.ID.String(),
+				ObjectName:  sv.Name,
+			})
+		}
+	}
 	respondJSON(w, http.StatusOK, sv)
 }
 
@@ -136,11 +164,23 @@ func (h *savedViewsHandler) delete(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusInternalServerError, err)
 		return
 	}
+	if h.bus != nil {
+		claims := auth.ClaimsFromCtx(r.Context())
+		if claims != nil {
+			h.bus.Publish(events.Event{
+				Kind:        events.KindSavedViewDeleted,
+				WorkspaceID: wsID,
+				ActorID:     claims.UserID,
+				ActorEmail:  claims.Email,
+				ObjectID:    svID.String(),
+			})
+		}
+	}
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func registerSavedViewsRoutes(r chi.Router, db *sql.DB, svc *auth.Service) {
-	h := &savedViewsHandler{store: savedviews.NewStore(db)}
+func registerSavedViewsRoutes(r chi.Router, db *sql.DB, svc *auth.Service, bus *events.Bus) {
+	h := &savedViewsHandler{store: savedviews.NewStore(db), bus: bus}
 	viewer := svc.RequireWorkspaceAccess(auth.RoleViewer)
 	editor := svc.RequireWorkspaceAccess(auth.RoleEditor)
 

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -31,6 +31,7 @@ const (
 	EntityWorkspace    = "workspace"
 	EntityMember       = "member"
 	EntitySnapshot     = "snapshot"
+	EntitySavedView    = "saved_view"
 )
 
 // Event is a single audit log entry.

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -1,0 +1,100 @@
+// Package events provides an in-process async event bus.
+// Callers publish events without blocking; registered handlers receive them
+// in a dedicated goroutine so multiple subscribers can hook in independently.
+package events
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Kind identifies the type of event.
+type Kind string
+
+const (
+	KindSavedViewCreated Kind = "saved_view.created"
+	KindSavedViewUpdated Kind = "saved_view.updated"
+	KindSavedViewDeleted Kind = "saved_view.deleted"
+)
+
+// Event carries everything a subscriber needs to react to an action.
+type Event struct {
+	Kind        Kind
+	At          time.Time
+	WorkspaceID uuid.UUID
+	ActorID     string
+	ActorEmail  string
+	ObjectID    string
+	ObjectName  string
+	Meta        map[string]any
+}
+
+// Handler is a function called for every event delivered to a subscriber.
+// Handlers run sequentially per event inside the bus goroutine — keep them fast.
+// For slow work (e.g. HTTP webhooks) spawn a goroutine inside the handler.
+type Handler func(Event)
+
+// Bus is a buffered, single-goroutine dispatcher.
+// Publish never blocks the caller — events are dropped when the buffer is full.
+type Bus struct {
+	ch   chan Event
+	subs []Handler
+	mu   sync.RWMutex
+	done chan struct{}
+}
+
+// New creates a Bus with the given buffer size and starts its dispatch loop.
+func New(bufSize int) *Bus {
+	if bufSize <= 0 {
+		bufSize = 256
+	}
+	b := &Bus{
+		ch:   make(chan Event, bufSize),
+		done: make(chan struct{}),
+	}
+	go b.loop()
+	return b
+}
+
+// Subscribe registers h to receive all future events.
+// Safe to call at any time, including after the first Publish.
+func (b *Bus) Subscribe(h Handler) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.subs = append(b.subs, h)
+}
+
+// Publish enqueues e for delivery. If At is zero it is set to now.
+// Returns immediately; never blocks the caller.
+func (b *Bus) Publish(e Event) {
+	if e.At.IsZero() {
+		e.At = time.Now()
+	}
+	select {
+	case b.ch <- e:
+	default:
+		// buffer full — drop rather than stall the HTTP request
+	}
+}
+
+// Shutdown drains the channel and waits for the dispatch loop to finish.
+// No more events should be published after calling Shutdown.
+func (b *Bus) Shutdown() {
+	close(b.ch)
+	<-b.done
+}
+
+func (b *Bus) loop() {
+	defer close(b.done)
+	for e := range b.ch {
+		b.mu.RLock()
+		subs := make([]Handler, len(b.subs))
+		copy(subs, b.subs)
+		b.mu.RUnlock()
+		for _, h := range subs {
+			h(e)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **Saved view filter update** — when browsing a saved view and filters change, a yellow bar appears: _"Filters changed from saved view"_ with an **Update saved view** button. A confirmation step prevents accidental overwrites. On confirm, PUTs the new filters and shows a success toast. Wired into all 7 view components.
- **Async event bus** (`internal/events`) — new `Bus` type backed by a buffered channel (256 slots) and a single dispatch goroutine. `Publish()` never blocks the caller; events are dropped if the buffer is full rather than stalling the HTTP request. Multiple handlers can subscribe independently.
- **Audit for saved views** — `saved_views_handler` now publishes `saved_view.created / .updated / .deleted` events. The audit handler subscribes at startup in `api.go`, writing to `workspace_events` asynchronously. New `EntitySavedView` constant added to the audit package.

## Test plan
- [ ] Open a saved view, change a filter — yellow bar appears
- [ ] Click "Update saved view" → confirmation appears
- [ ] Confirm → toast "Saved view updated", bar disappears
- [ ] Reload the saved view → filters are restored to the updated state
- [ ] Check workspace history — create/update/delete saved view events appear
- [ ] CI passes