### PR TITLE
fix(saved-views): fix false-positive change detection in SaveViewUpdateBar

### DIFF
--- a/cmd/archipulse/ui/src/components/views/SaveViewUpdateBar.svelte
+++ b/cmd/archipulse/ui/src/components/views/SaveViewUpdateBar.svelte
@@ -4,12 +4,28 @@
 
   const { wsId, savedViewId, savedViewName, currentFilters, initialFilters } = $props();
 
-  // Track the last successfully saved filter state for change detection.
-  let lastSaved = $state(JSON.stringify(initialFilters ?? {}));
+  // Deep-sort object keys so key-order differences between API response and
+  // derived state don't trigger false positives. Arrays are preserved as-is.
+  function stable(v) {
+    if (v == null) return 'null';
+    return JSON.stringify(v, (_, val) => {
+      if (val !== null && typeof val === 'object' && !Array.isArray(val)) {
+        return Object.fromEntries(Object.entries(val).sort(([a], [b]) => a < b ? -1 : 1));
+      }
+      return val;
+    });
+  }
+
+  // Reset baseline whenever the saved view is (re)loaded with new initialFilters.
+  let lastSaved = $state('null');
+  $effect(() => {
+    lastSaved = stable(initialFilters);
+  });
+
   let showConfirm = $state(false);
   let saving = $state(false);
 
-  const changed = $derived(JSON.stringify(currentFilters ?? {}) !== lastSaved);
+  const changed = $derived(stable(currentFilters) !== lastSaved);
 
   async function doUpdate() {
     saving = true;


### PR DESCRIPTION
## Summary

- `stable()` now uses a deep-sort **function** replacer instead of `JSON.stringify(v, arrayOfKeys)` — the array form silently drops array elements, causing inconsistent serialisation between the API-returned `initialFilters` and the derived `currentFilters`
- `lastSaved` is reset via `$effect(() => { lastSaved = stable(initialFilters); })` instead of `$state(initialFilters)`, so it reacts correctly whenever the user navigates to a different saved view

## Test plan

- [ ] Open a saved view → confirm no amber bar appears
- [ ] Navigate to a second saved view → still no bar
- [ ] Change a filter → bar appears
- [ ] Click "Update saved view" → confirm → bar disappears, toast shown
- [ ] Re-open the same saved view → no bar