### PR TITLE
feat(ui): ArchiMate icons, inline legend, header layout, view renames

### DIFF
--- a/cmd/archipulse/ui/src/components/flow/AppNode.svelte
+++ b/cmd/archipulse/ui/src/components/flow/AppNode.svelte
@@ -1,5 +1,6 @@
 <script>
   import { Handle, Position } from '@xyflow/svelte';
+  import { getIcon } from '../diagram/archimate-icons.js';
 
   let { data = {} } = $props();
 
@@ -19,9 +20,11 @@
     data.tier === 'service'   ? 'dashed' :
     data.tier === 'interface' || data.tier === 'function' ? 'dotted' : 'solid'
   );
+  const icon = $derived(getIcon(data.elementType ?? ''));
 </script>
 
 <div style="
+  position:relative;
   background:{style.bg};
   border:{bw} {bs} {style.border};
   color:{style.text};
@@ -29,7 +32,7 @@
   font-size:{isComponent ? '12px' : '11px'};
   min-width:{isComponent ? '148px' : '118px'};
   max-width:{isComponent ? '190px' : '160px'};
-  padding:{isComponent ? '10px 14px' : '7px 11px'};
+  padding:{isComponent ? '10px 28px 10px 14px' : '7px 24px 7px 11px'};
   border-radius:8px;
   text-align:center;
   line-height:1.35;
@@ -38,6 +41,13 @@
   user-select:none;
 ">
   <Handle type="target" position={Position.Left}  style="background:{style.border}; width:9px; height:9px; border:none; border-radius:50%;" />
+  {#if icon}
+    <svg viewBox="0 0 16 16" width="13" height="13"
+      style="position:absolute; top:4px; right:4px; stroke:{style.border}; fill:none; opacity:0.75; pointer-events:none; overflow:visible;">
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+      {@html icon}
+    </svg>
+  {/if}
   <div style="word-break:break-word;">{data.label}</div>
   {#if data.badge}
     <div style="font-size:9px; opacity:0.6; margin-top:3px; font-weight:400; letter-spacing:0.3px;">{data.badge}</div>

--- a/cmd/archipulse/ui/src/components/flow/CapabilityNode.svelte
+++ b/cmd/archipulse/ui/src/components/flow/CapabilityNode.svelte
@@ -1,10 +1,14 @@
 <script>
   import { Handle, Position } from '@xyflow/svelte';
+  import { getIcon } from '../diagram/archimate-icons.js';
 
   let { data = {} } = $props();
+
+  const icon = getIcon('Capability');
 </script>
 
 <div style="
+  position:relative;
   background:#fffbeb;
   border:2px solid #d97706;
   color:#78350f;
@@ -12,7 +16,7 @@
   font-size:12px;
   min-width:160px;
   max-width:210px;
-  padding:10px 14px;
+  padding:10px 28px 10px 14px;
   border-radius:8px;
   text-align:center;
   line-height:1.35;
@@ -21,6 +25,13 @@
   user-select:none;
 ">
   <Handle type="target" position={Position.Left}  style="background:#d97706; width:9px; height:9px; border:none; border-radius:50%;" />
+  {#if icon}
+    <svg viewBox="0 0 16 16" width="13" height="13"
+      style="position:absolute; top:4px; right:4px; stroke:#d97706; fill:none; opacity:0.75; pointer-events:none; overflow:visible;">
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+      {@html icon}
+    </svg>
+  {/if}
   <div style="word-break:break-word;">{data.label}</div>
   {#if data.appCount > 0}
     <div style="font-size:9px; opacity:0.55; margin-top:3px; font-weight:400; letter-spacing:0.3px;">{data.appCount} app{data.appCount > 1 ? 's' : ''}</div>

--- a/cmd/archipulse/ui/src/components/views/ApplicationLandscape.svelte
+++ b/cmd/archipulse/ui/src/components/views/ApplicationLandscape.svelte
@@ -111,26 +111,38 @@
   {:else if data}
 
     <!-- Header -->
-    <div class="flex items-center justify-between gap-4 mb-5 flex-wrap">
-      <div>
-        <h1 class="text-[18px] font-semibold">{savedViewName ?? 'Application Landscape'}</h1>
-        <div class="text-muted-foreground text-[13px] mt-0.5">Applications grouped by business domain</div>
-      </div>
-      <div class="flex items-center gap-2 flex-wrap">
-        <span class="text-[12px] text-muted-foreground">Color by</span>
-        <select bind:value={colorBy}
-          class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-primary">
-          <option value="criticality">Business Criticality</option>
-          <option value="lifecycle_status">Lifecycle Status</option>
-          <option value="deployment_model">Deployment Model</option>
-        </select>
-        {#if !savedViewName}
-          <button onclick={() => showSaveDialog = true}
-            class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-border text-[12px] text-muted-foreground hover:text-foreground hover:border-primary transition-colors">
-            ⊕ Save view
-          </button>
-        {/if}
-        <ViewInfoDialog title="Application Landscape — setup guide" bind:open={showInfo}>
+    <div class="mb-5">
+      <h1 class="text-[18px] font-semibold">{savedViewName ?? 'Landscape by Domain'}</h1>
+      <div class="text-muted-foreground text-[13px] mt-0.5 mb-3">Applications grouped by business domain</div>
+      <div class="flex items-center justify-between gap-4 flex-wrap">
+        <!-- Left: Color by + legend -->
+        <div class="flex items-center gap-2 flex-wrap">
+          <span class="text-[12px] text-muted-foreground">Color by</span>
+          <select bind:value={colorBy}
+            class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-primary">
+            <option value="criticality">Business Criticality</option>
+            <option value="lifecycle_status">Lifecycle Status</option>
+            <option value="deployment_model">Deployment Model</option>
+          </select>
+          {#if legendEntries.length > 0}
+            <span class="w-px h-4 bg-border self-center flex-shrink-0"></span>
+            {#each legendEntries as entry}
+              <div class="flex items-center gap-1 text-[11px]">
+                <span class="size-2.5 rounded flex-shrink-0" style="background:{entry.c}"></span>
+                <span class="text-muted-foreground">{entry.v}</span>
+              </div>
+            {/each}
+          {/if}
+        </div>
+        <!-- Right: Save + Info -->
+        <div class="flex items-center gap-2">
+          {#if !savedViewName}
+            <button onclick={() => showSaveDialog = true}
+              class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-border text-[12px] text-muted-foreground hover:text-foreground hover:border-primary transition-colors">
+              ⊕ Save view
+            </button>
+          {/if}
+          <ViewInfoDialog title="Application Landscape — setup guide" bind:open={showInfo}>
           <p>This view groups <strong>ApplicationComponent</strong> and <strong>ApplicationService</strong> elements by their <strong>business domain</strong>, letting you see which apps belong to each area of the business.</p>
 
           <div>
@@ -204,6 +216,7 @@
 </element>`}</pre>
           </div>
         </ViewInfoDialog>
+        </div>
       </div>
     </div>
 
@@ -292,16 +305,6 @@
             {/each}
           </div>
 
-          {#if legendEntries.length > 0}
-            <div class="mt-5 flex flex-wrap gap-x-4 gap-y-1.5 px-1">
-              {#each legendEntries as entry}
-                <div class="flex items-center gap-1.5 text-[12px]">
-                  <span class="size-3 rounded flex-shrink-0" style="background:{entry.c}"></span>
-                  <span class="text-muted-foreground">{entry.v}</span>
-                </div>
-              {/each}
-            </div>
-          {/if}
         </div>
       </div>
     {/if}

--- a/cmd/archipulse/ui/src/components/views/ApplicationLandscapeMap.svelte
+++ b/cmd/archipulse/ui/src/components/views/ApplicationLandscapeMap.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onMount } from 'svelte';
   import { api } from '../../lib/api.js';
+  import { getIcon } from '../diagram/archimate-icons.js';
   import SaveViewDialog from './SaveViewDialog.svelte';
 
   export let params = {};
@@ -50,23 +51,26 @@
   const UNSET_COLOR = '#94a3b8';
 
   // Per-overlay, assign consistent colours to each distinct value
+  function allApps(l1List) {
+    const apps = [];
+    for (const l1 of l1List) {
+      for (const a of (l1.apps ?? [])) apps.push(a);
+      for (const l2 of l1.l2) for (const a of l2.apps) apps.push(a);
+    }
+    return apps;
+  }
+
   function buildColorMap(overlay, l1List) {
     const known = KNOWN_COLORS[overlay] ?? {};
-    const seen = new Set(Object.keys(known));
     let idx = 0;
     const map = { ...known };
 
-    for (const l1 of l1List) {
-      for (const l2 of l1.l2) {
-        for (const app of l2.apps) {
-          const v = app.properties?.[overlay] ?? '';
-          if (v && !map[v]) {
-            // skip palette slots already used by known values
-            while (PALETTE[idx] && Object.values(known).includes(PALETTE[idx])) idx++;
-            map[v] = PALETTE[idx % PALETTE.length];
-            idx++;
-          }
-        }
+    for (const app of allApps(l1List)) {
+      const v = app.properties?.[overlay] ?? '';
+      if (v && !map[v]) {
+        while (PALETTE[idx] && Object.values(known).includes(PALETTE[idx])) idx++;
+        map[v] = PALETTE[idx % PALETTE.length];
+        idx++;
       }
     }
     return map;
@@ -86,14 +90,10 @@
   $: legendEntries = (() => {
     if (!data) return [];
     const seen = new Map();
-    for (const l1 of data.l1) {
-      for (const l2 of l1.l2) {
-        for (const app of l2.apps) {
-          const v = app.properties?.[overlay] ?? '(unset)';
-          const c = v === '(unset)' ? UNSET_COLOR : (colorMap[v] ?? '#6b7280');
-          if (!seen.has(v)) seen.set(v, c);
-        }
-      }
+    for (const app of allApps(data.l1)) {
+      const v = app.properties?.[overlay] ?? '(unset)';
+      const c = v === '(unset)' ? UNSET_COLOR : (colorMap[v] ?? '#6b7280');
+      if (!seen.has(v)) seen.set(v, c);
     }
     // Sort: known order first if lifecycle, then alpha, (unset) last
     return [...seen.entries()]
@@ -173,33 +173,44 @@
   {:else if data}
 
     <!-- Header -->
-    <div class="flex items-center justify-between gap-4 mb-5 flex-wrap">
-      <div>
-        <h1 class="text-[18px] font-semibold">{savedViewName ?? 'Application Landscape'}</h1>
-        <div class="text-muted-foreground text-[13px] mt-0.5">Capabilities mapped to realizing applications</div>
-      </div>
-
-      <div class="flex items-center gap-2 flex-wrap">
-        <!-- Overlay selector -->
-        {#if data.properties?.length > 0}
-          <span class="text-[12px] text-muted-foreground">Overlay</span>
-          <select
-            bind:value={overlay}
-            class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
-          >
-            {#each data.properties as p}
-              <option value={p}>{propLabel(p)}</option>
-            {/each}
-          </select>
-        {/if}
-        {#if !savedViewName}
-          <button
-            onclick={() => showSaveDialog = true}
-            class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-border text-[12px] text-muted-foreground hover:text-foreground hover:border-primary transition-colors"
-          >
-            ⊕ Save view
-          </button>
-        {/if}
+    <div class="mb-5">
+      <h1 class="text-[18px] font-semibold">{savedViewName ?? 'Application Landscape'}</h1>
+      <div class="text-muted-foreground text-[13px] mt-0.5 mb-3">Capabilities mapped to realizing applications</div>
+      <div class="flex items-center justify-between gap-4 flex-wrap">
+        <!-- Left: Overlay + legend -->
+        <div class="flex items-center gap-2 flex-wrap">
+          {#if data.properties?.length > 0}
+            <span class="text-[12px] text-muted-foreground">Overlay</span>
+            <select
+              bind:value={overlay}
+              class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+            >
+              {#each data.properties as p}
+                <option value={p}>{propLabel(p)}</option>
+              {/each}
+            </select>
+            {#if legendEntries.length > 0}
+              <span class="w-px h-4 bg-border self-center flex-shrink-0"></span>
+              {#each legendEntries as entry}
+                <div class="flex items-center gap-1 text-[11px]">
+                  <span class="size-2.5 rounded flex-shrink-0" style="background:{entry.color}"></span>
+                  <span class="text-muted-foreground">{entry.value}</span>
+                </div>
+              {/each}
+            {/if}
+          {/if}
+        </div>
+        <!-- Right: Save view -->
+        <div class="flex items-center gap-2">
+          {#if !savedViewName}
+            <button
+              onclick={() => showSaveDialog = true}
+              class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-border text-[12px] text-muted-foreground hover:text-foreground hover:border-primary transition-colors"
+            >
+              ⊕ Save view
+            </button>
+          {/if}
+        </div>
       </div>
     </div>
 
@@ -210,18 +221,6 @@
       filters={saveFilters}
     />
 
-    <!-- Colour legend -->
-    {#if legendEntries.length > 0}
-      <div class="flex flex-wrap gap-x-4 gap-y-1.5 mb-5 px-1">
-        {#each legendEntries as entry}
-          <div class="flex items-center gap-1.5 text-[12px]">
-            <span class="size-3 rounded flex-shrink-0" style="background:{entry.color}"></span>
-            <span class="text-muted-foreground">{entry.value}</span>
-          </div>
-        {/each}
-      </div>
-    {/if}
-
     <!-- Landscape grid -->
     {#if data.l1.length === 0}
       <div class="text-center py-16 text-muted-foreground">
@@ -231,22 +230,51 @@
     {:else}
       <div class="space-y-4">
         {#each data.l1 as l1}
-          {@const totalApps = l1.l2.reduce((s, l2) => s + l2.apps.length, 0)}
+          {@const totalApps = (l1.apps?.length ?? 0) + l1.l2.reduce((s, l2) => s + l2.apps.length, 0)}
           <div class="border border-slate-300 rounded-xl overflow-hidden" style="box-shadow: 0 1px 3px rgba(0,0,0,0.08), 0 0 0 1px rgba(0,0,0,0.04);">
             <!-- L1 header -->
-            <div class="bg-slate-100 border-b border-slate-200 px-4 py-2.5 flex items-center gap-3">
+            <div class="bg-slate-100 border-b border-slate-200 px-4 py-2.5 flex items-center gap-2">
+              <svg viewBox="0 0 16 16" width="12" height="12" style="flex-shrink:0; stroke:#d97706; fill:none; opacity:0.8; overflow:visible;">{@html getIcon('Capability')}</svg>
               <span class="text-[12px] font-bold text-slate-600 tracking-[0.8px] uppercase">{l1.name}</span>
               <span class="text-[11px] text-slate-400 ml-auto">{totalApps} app{totalApps !== 1 ? 's' : ''}</span>
             </div>
 
             <!-- L2 rows -->
             <div class="divide-y divide-slate-200">
+              <!-- General row: apps linked directly to L1 -->
+              {#if (l1.apps ?? []).length > 0}
+                <div class="flex items-start gap-3 px-4 py-2.5 bg-muted/20 hover:bg-muted/30 transition-colors">
+                  <div class="w-52 flex-shrink-0 pt-0.5 flex items-start gap-1.5">
+                    <svg viewBox="0 0 16 16" width="11" height="11" style="flex-shrink:0; margin-top:1px; stroke:#d97706; fill:none; opacity:0.7; overflow:visible;">{@html getIcon('Capability')}</svg>
+                    <span class="text-[12px] text-muted-foreground font-medium italic">General</span>
+                    <span class="ml-1 text-[11px] text-muted-foreground">{l1.apps.length}</span>
+                  </div>
+                  <div class="flex flex-wrap gap-1.5 flex-1">
+                    {#each l1.apps as app}
+                      <button
+                        class="inline-flex items-center gap-1 px-2.5 py-1 rounded text-[11px] font-medium transition-opacity hover:opacity-80 cursor-default"
+                        style="{chipStyle(app, overlay)}"
+                        onmouseenter={(e) => showTooltip(e, app)}
+                        onmouseleave={hideTooltip}
+                        onfocus={(e) => showTooltip(e, app)}
+                        onblur={hideTooltip}
+                      >
+                        {app.name}
+                        {#if getIcon(app.type)}
+                          <svg viewBox="0 0 16 16" width="10" height="10" style="flex-shrink:0; stroke:currentColor; fill:none; opacity:0.6; overflow:visible;">{@html getIcon(app.type)}</svg>
+                        {/if}
+                      </button>
+                    {/each}
+                  </div>
+                </div>
+              {/if}
               {#each l1.l2 as l2}
                 <div class="flex items-start gap-3 px-4 py-2.5 hover:bg-muted/20 transition-colors">
                   <!-- L2 name + count -->
-                  <div class="w-52 flex-shrink-0 pt-0.5">
+                  <div class="w-52 flex-shrink-0 pt-0.5 flex items-start gap-1.5">
+                    <svg viewBox="0 0 16 16" width="11" height="11" style="flex-shrink:0; margin-top:1px; stroke:#d97706; fill:none; opacity:0.7; overflow:visible;">{@html getIcon('Capability')}</svg>
                     <span class="text-[12px] text-foreground font-medium">{l2.name}</span>
-                    <span class="ml-1.5 text-[11px] text-muted-foreground">{l2.apps.length}</span>
+                    <span class="ml-1 text-[11px] text-muted-foreground">{l2.apps.length}</span>
                   </div>
 
                   <!-- App chips -->
@@ -256,7 +284,7 @@
                     {:else}
                       {#each l2.apps as app}
                         <button
-                          class="inline-flex items-center px-2.5 py-1 rounded text-[11px] font-medium transition-opacity hover:opacity-80 cursor-default"
+                          class="inline-flex items-center gap-1 px-2.5 py-1 rounded text-[11px] font-medium transition-opacity hover:opacity-80 cursor-default"
                           style="{chipStyle(app, overlay)}"
                           onmouseenter={(e) => showTooltip(e, app)}
                           onmouseleave={hideTooltip}
@@ -264,6 +292,9 @@
                           onblur={hideTooltip}
                         >
                           {app.name}
+                          {#if getIcon(app.type)}
+                            <svg viewBox="0 0 16 16" width="10" height="10" style="flex-shrink:0; stroke:currentColor; fill:none; opacity:0.6; overflow:visible;">{@html getIcon(app.type)}</svg>
+                          {/if}
                         </button>
                       {/each}
                     {/if}

--- a/cmd/archipulse/ui/src/components/views/CapabilityLandscape.svelte
+++ b/cmd/archipulse/ui/src/components/views/CapabilityLandscape.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onMount } from 'svelte';
   import { api } from '../../lib/api.js';
+  import { getIcon } from '../diagram/archimate-icons.js';
   import SaveViewDialog from './SaveViewDialog.svelte';
   import SaveViewUpdateBar from './SaveViewUpdateBar.svelte';
   import AppDetailPanel from './AppDetailPanel.svelte';
@@ -168,36 +169,48 @@
   {:else if data}
 
     <!-- Header -->
-    <div class="flex items-center justify-between gap-4 mb-5 flex-wrap">
-      <div>
-        <h1 class="text-[18px] font-semibold">{savedViewName ?? 'Capability Landscape'}</h1>
-        <div class="text-muted-foreground text-[13px] mt-0.5">Business capabilities mapped to realizing applications</div>
-      </div>
-      <div class="flex items-center gap-2 flex-wrap">
-        <span class="text-[12px] text-muted-foreground">Overlay</span>
-        <select bind:value={overlay}
-          class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-primary">
-          <option value="none">None</option>
-          <option value="lifecycle_status">Lifecycle Status</option>
-          <option value="criticality">Business Criticality</option>
-          <option value="deployment_model">Deployment Model</option>
-          <option value="fit">Application Fit</option>
-        </select>
-        <span class="text-[12px] text-muted-foreground">Heatmap</span>
-        <select bind:value={heatmap}
-          class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-primary">
-          <option value="none">None</option>
-          <option value="appCount">App Coverage</option>
-          <option value="gap">Gap Analysis</option>
-          <option value="avgCrit">Avg. Criticality</option>
-        </select>
-        {#if !savedViewName}
-          <button onclick={() => showSaveDialog = true}
-            class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-border text-[12px] text-muted-foreground hover:text-foreground hover:border-primary transition-colors">
-            ⊕ Save view
-          </button>
-        {/if}
-        <ViewInfoDialog title="Capability Landscape — setup guide" bind:open={showInfo}>
+    <div class="mb-5">
+      <h1 class="text-[18px] font-semibold">{savedViewName ?? 'Landscape by Capability'}</h1>
+      <div class="text-muted-foreground text-[13px] mt-0.5 mb-3">Applications mapped to realizing capabilities — hierarchical</div>
+      <div class="flex items-center justify-between gap-4 flex-wrap">
+        <!-- Left: Overlay + legend -->
+        <div class="flex items-center gap-2 flex-wrap">
+          <span class="text-[12px] text-muted-foreground">Overlay</span>
+          <select bind:value={overlay}
+            class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-primary">
+            <option value="none">None</option>
+            <option value="lifecycle_status">Lifecycle Status</option>
+            <option value="criticality">Business Criticality</option>
+            <option value="deployment_model">Deployment Model</option>
+            <option value="fit">Application Fit</option>
+          </select>
+          {#if overlay !== 'none' && legendEntries.length > 0}
+            <span class="w-px h-4 bg-border self-center flex-shrink-0"></span>
+            {#each legendEntries as entry}
+              <div class="flex items-center gap-1 text-[11px]">
+                <span class="size-2.5 rounded flex-shrink-0" style="background:{entry.c}"></span>
+                <span class="text-muted-foreground">{entry.l}</span>
+              </div>
+            {/each}
+          {/if}
+        </div>
+        <!-- Right: Heatmap + Save + Info -->
+        <div class="flex items-center gap-2">
+          <span class="text-[12px] text-muted-foreground">Heatmap</span>
+          <select bind:value={heatmap}
+            class="bg-card border border-border rounded-md px-3 py-1.5 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-primary">
+            <option value="none">None</option>
+            <option value="appCount">App Coverage</option>
+            <option value="gap">Gap Analysis</option>
+            <option value="avgCrit">Avg. Criticality</option>
+          </select>
+          {#if !savedViewName}
+            <button onclick={() => showSaveDialog = true}
+              class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-border text-[12px] text-muted-foreground hover:text-foreground hover:border-primary transition-colors">
+              ⊕ Save view
+            </button>
+          {/if}
+          <ViewInfoDialog title="Capability Landscape — setup guide" bind:open={showInfo}>
           <p>This view maps <strong>business capabilities</strong> (L1 groups → L2 capabilities) to the applications that realize them, showing coverage, gaps, and overlaps across your capability model.</p>
 
           <div>
@@ -280,11 +293,13 @@
             </table>
           </div>
         </ViewInfoDialog>
+        </div>
       </div>
     </div>
 
     <SaveViewDialog bind:open={showSaveDialog} {wsId} viewType="capability-landscape" filters={saveFilters} />
     <SaveViewUpdateBar {wsId} {savedViewId} {savedViewName} currentFilters={saveFilters} {initialFilters} />
+
 
     <div class="flex gap-4 items-start">
 
@@ -354,6 +369,7 @@
                   role="button" tabindex="0"
                   onkeydown={e => e.key === 'Enter' && toggleCollapsed(l1.id)}>
                   <span class="text-muted-foreground text-[12px] transition-transform {isCollapsed ? '' : 'rotate-90'}" style="display:inline-block">▶</span>
+                  <svg viewBox="0 0 16 16" width="12" height="12" style="flex-shrink:0; stroke:#d97706; fill:none; opacity:0.8; overflow:visible;">{@html getIcon('Capability')}</svg>
                   <span class="text-[12px] font-bold text-foreground tracking-[0.6px] uppercase">{l1.name}</span>
                   {#if heatmap === 'gap' && stats.gaps > 0}
                     <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-red-50 text-red-700 border border-dashed border-red-200">
@@ -385,6 +401,13 @@
                               onclick={() => selectedApp = app}>
                               <span class="absolute left-0 top-0 bottom-0 w-[3px] rounded-l" style="background:{col.border}"></span>
                               {app.name}
+                              {#if getIcon(app.type)}
+                                <svg viewBox="0 0 16 16" width="11" height="11"
+                                  style="flex-shrink:0; margin-left:4px; stroke:{col.border}; fill:none; opacity:0.65; overflow:visible;">
+                                  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                                  {@html getIcon(app.type)}
+                                </svg>
+                              {/if}
                             </button>
                           {/each}
                         </div>
@@ -396,9 +419,10 @@
                       {@const isDup = l2.apps.length >= 3}
 
                       <div class="flex items-start gap-3 px-4 py-2 hover:bg-white/40 transition-colors">
-                        <div class="w-52 flex-shrink-0 pt-0.5">
+                        <div class="w-52 flex-shrink-0 pt-0.5 flex items-start gap-1.5">
+                          <svg viewBox="0 0 16 16" width="11" height="11" style="flex-shrink:0; margin-top:2px; stroke:#d97706; fill:none; opacity:0.7; overflow:visible;">{@html getIcon('Capability')}</svg>
                           <span class="text-[12.5px] font-medium text-foreground">{l2.name}</span>
-                          <span class="ml-1.5 text-[11px] {isGap ? 'text-red-600 font-semibold' : 'text-muted-foreground'}">{l2.apps.length}</span>
+                          <span class="ml-1 text-[11px] {isGap ? 'text-red-600 font-semibold' : 'text-muted-foreground'}">{l2.apps.length}</span>
                         </div>
 
                         <div class="flex flex-wrap gap-1.5 flex-1 items-center">
@@ -425,6 +449,13 @@
                               <span class="absolute left-0 top-0 bottom-0 w-[3px] rounded-l"
                                 style="background:{col.border}"></span>
                               {app.name}
+                              {#if getIcon(app.type)}
+                                <svg viewBox="0 0 16 16" width="11" height="11"
+                                  style="flex-shrink:0; margin-left:4px; stroke:{col.border}; fill:none; opacity:0.65; overflow:visible;">
+                                  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                                  {@html getIcon(app.type)}
+                                </svg>
+                              {/if}
                             </button>
                           {/each}
                         </div>
@@ -436,16 +467,6 @@
             {/each}
           </div>
 
-          {#if overlay !== 'none' && legendEntries.length > 0}
-            <div class="mt-5 flex flex-wrap gap-x-4 gap-y-1.5 px-1">
-              {#each legendEntries as entry}
-                <div class="flex items-center gap-1.5 text-[12px]">
-                  <span class="size-3 rounded flex-shrink-0" style="background:{entry.c}"></span>
-                  <span class="text-muted-foreground">{entry.l}</span>
-                </div>
-              {/each}
-            </div>
-          {/if}
         {/if}
       </div>
     </div>

--- a/cmd/archipulse/ui/src/components/views/CapabilityLandscape.svelte
+++ b/cmd/archipulse/ui/src/components/views/CapabilityLandscape.svelte
@@ -97,6 +97,7 @@
   function groupStats(l1) {
     let totalApps = new Set();
     let gaps = 0;
+    for (const a of (l1.apps ?? [])) totalApps.add(a.id);
     for (const l2 of l1.l2) {
       if (l2.apps.length === 0) gaps++;
       for (const a of l2.apps) totalApps.add(a.id);
@@ -319,7 +320,7 @@
         {#if data.l1.length > 0}
           <div class="text-[11px] text-muted-foreground border border-dashed border-border rounded-md px-2 py-1.5">
             {data.l1.reduce((s, l) => s + l.l2.length, 0)} capabilities ·
-            {data.l1.reduce((s, l) => s + l.l2.reduce((ss, l2) => ss + l2.apps.length, 0), 0)} realizations
+            {data.l1.reduce((s, l) => (l.apps?.length ?? 0) + l.l2.reduce((ss, l2) => ss + l2.apps.length, 0) + s, 0)} realizations
           </div>
         {/if}
       </aside>
@@ -366,6 +367,29 @@
 
                 {#if !isCollapsed}
                   <div class="divide-y divide-border">
+                    {#if (l1.apps ?? []).length > 0}
+                      {@const visibleL1Apps = showRetired ? l1.apps : l1.apps.filter(a => !isRetired(a))}
+                      <div class="flex items-start gap-3 px-4 py-2 bg-muted/20 hover:bg-white/40 transition-colors">
+                        <div class="w-52 flex-shrink-0 pt-0.5">
+                          <span class="text-[11.5px] font-medium text-muted-foreground italic">General</span>
+                          <span class="ml-1.5 text-[11px] text-muted-foreground">{l1.apps.length}</span>
+                        </div>
+                        <div class="flex flex-wrap gap-1.5 flex-1 items-center">
+                          {#each visibleL1Apps as app}
+                            {@const col = overlayColor(app)}
+                            {@const retired = isRetired(app)}
+                            <button
+                              class="inline-flex items-center relative px-2.5 py-1 pl-[14px] rounded text-[11.5px] font-medium transition-shadow hover:shadow-sm cursor-pointer {retired ? 'opacity-45 line-through' : ''}"
+                              style="background:{col.bg}; border:1px solid {col.border}; color:#0b2936;"
+                              title="{app.name} · {app.properties?.lifecycle_status ?? ''} · {app.properties?.criticality ?? ''}"
+                              onclick={() => selectedApp = app}>
+                              <span class="absolute left-0 top-0 bottom-0 w-[3px] rounded-l" style="background:{col.border}"></span>
+                              {app.name}
+                            </button>
+                          {/each}
+                        </div>
+                      </div>
+                    {/if}
                     {#each l1.l2.filter(l2 => !search || l2.name.toLowerCase().includes(search.toLowerCase())) as l2}
                       {@const visibleApps = showRetired ? l2.apps : l2.apps.filter(a => !isRetired(a))}
                       {@const isGap = l2.apps.length === 0}

--- a/cmd/archipulse/ui/src/components/views/CapabilityTree.svelte
+++ b/cmd/archipulse/ui/src/components/views/CapabilityTree.svelte
@@ -143,7 +143,7 @@
         type:      'appNode',
         draggable: false,
         position:  gn ? { x: gn.x - APP_W / 2, y: gn.y - APP_H / 2 } : { x: 0, y: 0 },
-        data:      { label: app.name, badge: app.type.replace('Application', ''), tier, lifecycle: app.lifecycle_status },
+        data:      { label: app.name, badge: app.type.replace('Application', ''), tier, lifecycle: app.lifecycle_status, elementType: app.type },
       });
     });
 

--- a/cmd/archipulse/ui/src/components/views/DependencyGraphView.svelte
+++ b/cmd/archipulse/ui/src/components/views/DependencyGraphView.svelte
@@ -167,7 +167,7 @@
           type:     'appNode',
           draggable: false,
           position: gn ? { x: gn.x - nw(tier) / 2, y: gn.y - nh(tier) / 2 } : { x: 0, y: 0 },
-          data:     { label: n.name, badge: n.type.replace('Application', ''), tier, lifecycle: n.lifecycle_status },
+          data:     { label: n.name, badge: n.type.replace('Application', ''), tier, lifecycle: n.lifecycle_status, elementType: n.type },
         };
       });
 

--- a/cmd/archipulse/ui/src/lib/views.js
+++ b/cmd/archipulse/ui/src/lib/views.js
@@ -1,9 +1,9 @@
 export const VIEWS = {
   'element-catalogue':      { icon: '◈', label: 'Element Catalogue',        desc: 'All elements across layers',                                   layer: 'cross', catalogue: 'element' },
   'capability-tree':        { icon: '◈', label: 'Capability Tree',           desc: 'Business capability hierarchy',                                layer: 'business', tree: true },
-  'capability-landscape':   { icon: '◈', label: 'Landscape by Capability',   desc: 'Applications mapped to realizing capabilities — hierarchical',  layer: 'application', map: true },
   'process-application':    { icon: '◈', label: 'Process–App Usage',         desc: 'Which applications support each business process',              layer: 'business', matrix: true },
   'application-dashboard':  { icon: '◉', label: 'Application Dashboard',     desc: 'Lifecycle status & type distribution charts',                  layer: 'application', dashboard: true },
+  'capability-landscape':   { icon: '◈', label: 'Landscape by Capability',   desc: 'Applications mapped to realizing capabilities — hierarchical',  layer: 'application', map: true },
   'application-landscape':  { icon: '◈', label: 'Landscape by Domain',       desc: 'Applications grouped by business domain',                      layer: 'application', map: true },
   'application-dependency': { icon: '◈', label: 'Dependency Graph',          desc: 'Interactive dependency graph',                                 layer: 'application', graph: true },
   'technology-stack':       { icon: '◈', label: 'Technology Stack',          desc: 'Applications mapped to the technology they run on',            layer: 'technology', matrix: true },

--- a/cmd/archipulse/ui/src/lib/views.js
+++ b/cmd/archipulse/ui/src/lib/views.js
@@ -1,10 +1,10 @@
 export const VIEWS = {
   'element-catalogue':      { icon: '◈', label: 'Element Catalogue',        desc: 'All elements across layers',                                   layer: 'cross', catalogue: 'element' },
   'capability-tree':        { icon: '◈', label: 'Capability Tree',           desc: 'Business capability hierarchy',                                layer: 'business', tree: true },
-  'capability-landscape':   { icon: '◈', label: 'Capability Landscape',      desc: 'Capabilities mapped to realizing applications — hierarchical',  layer: 'business', map: true },
+  'capability-landscape':   { icon: '◈', label: 'Landscape by Capability',   desc: 'Applications mapped to realizing capabilities — hierarchical',  layer: 'application', map: true },
   'process-application':    { icon: '◈', label: 'Process–App Usage',         desc: 'Which applications support each business process',              layer: 'business', matrix: true },
   'application-dashboard':  { icon: '◉', label: 'Application Dashboard',     desc: 'Lifecycle status & type distribution charts',                  layer: 'application', dashboard: true },
-  'application-landscape':  { icon: '◈', label: 'Application Landscape',     desc: 'Applications grouped by business domain',                      layer: 'application', map: true },
+  'application-landscape':  { icon: '◈', label: 'Landscape by Domain',       desc: 'Applications grouped by business domain',                      layer: 'application', map: true },
   'application-dependency': { icon: '◈', label: 'Dependency Graph',          desc: 'Interactive dependency graph',                                 layer: 'application', graph: true },
   'technology-stack':       { icon: '◈', label: 'Technology Stack',          desc: 'Applications mapped to the technology they run on',            layer: 'technology', matrix: true },
   'application-catalogue':  { icon: '◈', label: 'Application Catalogue',     desc: 'Application components with properties',                       layer: 'catalogue', catalogue: 'application' },

--- a/internal/viewer/views/application_landscape_map.go
+++ b/internal/viewer/views/application_landscape_map.go
@@ -26,9 +26,10 @@ type LandscapeL2 struct {
 
 // LandscapeL1 is a top-level capability group.
 type LandscapeL1 struct {
-	ID   string        `json:"id"`
-	Name string        `json:"name"`
-	L2   []LandscapeL2 `json:"l2"`
+	ID   string         `json:"id"`
+	Name string         `json:"name"`
+	Apps []LandscapeApp `json:"apps"` // apps linked directly to this L1 (not via an L2 child)
+	L2   []LandscapeL2  `json:"l2"`
 }
 
 // ApplicationLandscapeMapData is the payload for the landscape map view.
@@ -74,6 +75,11 @@ func ApplicationLandscapeMap(db *sql.DB, workspaceID uuid.UUID) (*ApplicationLan
 	l1List := make([]LandscapeL1, 0, len(l1Order))
 	for _, l1ID := range l1Order {
 		l1 := l1Map[l1ID]
+		if apps := appsByCapID[l1ID]; apps != nil {
+			l1.Apps = apps
+		} else {
+			l1.Apps = []LandscapeApp{}
+		}
 		for i, l2 := range l1.L2 {
 			apps := appsByCapID[l2.ID]
 			if apps == nil {


### PR DESCRIPTION
## Summary

- Add ArchiMate SVG icons to app chips in CapabilityTree, DependencyGraph, CapabilityLandscape and ApplicationLandscapeMap; Capability amber icon on L1/L2 row headers
- Move legend from bottom to inline in header across CapabilityLandscape, ApplicationLandscape and ApplicationLandscapeMap
- Fix header layout: title+subtitle on their own lines, controls row with `justify-between` (selector+legend left, actions right) — prevents controls from floating up alongside the title
- Surface L1-direct apps as italic "General" row at top of each capability block
- Rename "Capability Landscape" → "Landscape by Capability" (moved to Application layer)
- Rename "Application Landscape" → "Landscape by Domain" (stays in Application layer)

## Test plan

- [ ] Capability Tree: app nodes show element-type icon top-right; Capability nodes show amber icon
- [ ] Dependency Graph: nodes show element-type icon top-right
- [ ] Landscape by Capability: L1/L2 headers show amber Capability icon; app chips show type icon; legend inline in header; "General" row for apps linked directly to L1
- [ ] Landscape by Domain: legend inline in header (Color by + entries); title reads "Landscape by Domain"
- [ ] ApplicationLandscapeMap: same legend inline; "General" row; Capability icons on headers
- [ ] Sidebar nav shows "Landscape by Capability" and "Landscape by Domain" both under Application layer