### PR TITLE
feat(api): GET /health endpoint with version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ RUN go mod download
 
 COPY . .
 COPY --from=ui-builder /src/cmd/archipulse/ui/dist ./cmd/archipulse/ui/dist
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" \
+ARG VERSION=dev
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath \
+    -ldflags="-s -w -X main.version=${VERSION}" \
     -o /archipulse ./cmd/archipulse
 
 # ── Runtime stage ───────────────────────────────────────────────────────────────

--- a/cmd/archipulse/main.go
+++ b/cmd/archipulse/main.go
@@ -17,6 +17,9 @@ import (
 	"github.com/DisruptiveWorks/archipulse/internal/workspace"
 )
 
+// version is set at build time via -ldflags="-X main.version=x.y.z".
+var version = "dev"
+
 func main() {
 	// Load .env if present — errors are intentionally ignored (file is optional).
 	_ = godotenv.Load()
@@ -81,7 +84,7 @@ func runServe() error {
 
 	addr := ":" + port
 	fmt.Printf("listening on %s\n", addr)
-	return http.ListenAndServe(addr, api.NewRouter(conn, svc, oidcProvider, staticFiles))
+	return http.ListenAndServe(addr, api.NewRouter(conn, svc, oidcProvider, version, staticFiles))
 }
 
 func runMigrate() error {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -19,11 +19,15 @@ import (
 )
 
 // NewRouter builds and returns the root HTTP router with all routes registered.
-// Pass an embed.FS as the optional second argument to also serve the frontend SPA.
-func NewRouter(db *sql.DB, svc *auth.Service, oidc *auth.OIDCProvider, static ...embed.FS) http.Handler {
+// Pass an embed.FS as the optional last argument to also serve the frontend SPA.
+func NewRouter(db *sql.DB, svc *auth.Service, oidc *auth.OIDCProvider, version string, static ...embed.FS) http.Handler {
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
+
+	r.Get("/health", func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, map[string]string{"status": "ok", "version": version})
+	})
 
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(middleware.SetHeader("Content-Type", "application/json"))

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -54,7 +54,7 @@ func testAuthService(t *testing.T, conn *sql.DB) *auth.Service {
 func testRouter(t *testing.T, conn *sql.DB) http.Handler {
 	t.Helper()
 	svc := testAuthService(t, conn)
-	return api.NewRouter(conn, svc, nil)
+	return api.NewRouter(conn, svc, nil, "test")
 }
 
 // addAuthCookie attaches a signed admin JWT cookie to req, so that the


### PR DESCRIPTION
## Summary

- `GET /health` — public endpoint, no auth required, responds `{"status":"ok","version":"x.y.z"}`
- `version` var in `main.go` injectable at build time via `-ldflags="-X main.version=..."`
- Dockerfile updated with `ARG VERSION=dev` passed through to ldflags
- Integration test helper updated to match new `NewRouter` signature

## Test plan

- [ ] `GET /health` returns 200 with `{"status":"ok","version":"dev"}` locally
- [ ] Railway healthcheck can point to `/health`
- [ ] All existing integration tests pass