### PR TITLE
feat(api): paginate all list endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ RUN go mod download
 
 COPY . .
 COPY --from=ui-builder /src/cmd/archipulse/ui/dist ./cmd/archipulse/ui/dist
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" \
+ARG VERSION=dev
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath \
+    -ldflags="-s -w -X main.version=${VERSION}" \
     -o /archipulse ./cmd/archipulse
 
 # ── Runtime stage ───────────────────────────────────────────────────────────────

--- a/cmd/archipulse/main.go
+++ b/cmd/archipulse/main.go
@@ -17,6 +17,9 @@ import (
 	"github.com/DisruptiveWorks/archipulse/internal/workspace"
 )
 
+// version is set at build time via -ldflags="-X main.version=x.y.z".
+var version = "dev"
+
 func main() {
 	// Load .env if present — errors are intentionally ignored (file is optional).
 	_ = godotenv.Load()
@@ -81,7 +84,7 @@ func runServe() error {
 
 	addr := ":" + port
 	fmt.Printf("listening on %s\n", addr)
-	return http.ListenAndServe(addr, api.NewRouter(conn, svc, oidcProvider, staticFiles))
+	return http.ListenAndServe(addr, api.NewRouter(conn, svc, oidcProvider, version, staticFiles))
 }
 
 func runMigrate() error {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -19,11 +19,15 @@ import (
 )
 
 // NewRouter builds and returns the root HTTP router with all routes registered.
-// Pass an embed.FS as the optional second argument to also serve the frontend SPA.
-func NewRouter(db *sql.DB, svc *auth.Service, oidc *auth.OIDCProvider, static ...embed.FS) http.Handler {
+// Pass an embed.FS as the optional last argument to also serve the frontend SPA.
+func NewRouter(db *sql.DB, svc *auth.Service, oidc *auth.OIDCProvider, version string, static ...embed.FS) http.Handler {
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
+
+	r.Get("/health", func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, map[string]string{"status": "ok", "version": version})
+	})
 
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(middleware.SetHeader("Content-Type", "application/json"))

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -14,6 +15,7 @@ import (
 	"github.com/DisruptiveWorks/archipulse/internal/audit"
 	"github.com/DisruptiveWorks/archipulse/internal/auth"
 	"github.com/DisruptiveWorks/archipulse/internal/events"
+	"github.com/DisruptiveWorks/archipulse/internal/pagination"
 	"github.com/DisruptiveWorks/archipulse/internal/snapshot"
 	"github.com/DisruptiveWorks/archipulse/internal/workspace"
 )
@@ -100,4 +102,11 @@ func respondError(w http.ResponseWriter, status int, err error) {
 
 func errorf(format string, args ...any) error {
 	return fmt.Errorf(format, args...)
+}
+
+// parsePage extracts pagination params from ?page= and ?limit= query params.
+func parsePage(r *http.Request) pagination.Params {
+	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	return pagination.Normalize(page, limit)
 }

--- a/internal/api/diagram_handler.go
+++ b/internal/api/diagram_handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DisruptiveWorks/archipulse/internal/audit"
 	"github.com/DisruptiveWorks/archipulse/internal/auth"
 	"github.com/DisruptiveWorks/archipulse/internal/diagram"
+	"github.com/DisruptiveWorks/archipulse/internal/pagination"
 )
 
 type diagramHandler struct {
@@ -25,12 +26,13 @@ func (h *diagramHandler) list(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}
-	diags, err := h.store.List(wsID)
+	p := parsePage(r)
+	items, total, err := h.store.List(wsID, p)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return
 	}
-	respondJSON(w, http.StatusOK, diags)
+	respondJSON(w, http.StatusOK, pagination.NewPage(items, total, p.Page, p.Limit))
 }
 
 func (h *diagramHandler) get(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/element_handler.go
+++ b/internal/api/element_handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DisruptiveWorks/archipulse/internal/audit"
 	"github.com/DisruptiveWorks/archipulse/internal/auth"
 	"github.com/DisruptiveWorks/archipulse/internal/element"
+	"github.com/DisruptiveWorks/archipulse/internal/pagination"
 	"github.com/DisruptiveWorks/archipulse/internal/parser"
 )
 
@@ -26,12 +27,13 @@ func (h *elementHandler) list(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}
-	elems, err := h.store.List(wsID)
+	p := parsePage(r)
+	items, total, err := h.store.List(wsID, p)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return
 	}
-	respondJSON(w, http.StatusOK, elems)
+	respondJSON(w, http.StatusOK, pagination.NewPage(items, total, p.Page, p.Limit))
 }
 
 func (h *elementHandler) get(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/event_handler.go
+++ b/internal/api/event_handler.go
@@ -2,13 +2,13 @@ package api
 
 import (
 	"net/http"
-	"strconv"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 
 	"github.com/DisruptiveWorks/archipulse/internal/audit"
 	"github.com/DisruptiveWorks/archipulse/internal/auth"
+	"github.com/DisruptiveWorks/archipulse/internal/pagination"
 )
 
 type eventHandler struct {
@@ -21,16 +21,13 @@ func (h *eventHandler) list(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, errorf("invalid workspace id"))
 		return
 	}
-	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
-	events, err := h.store.List(wsID, limit)
+	p := parsePage(r)
+	items, total, err := h.store.List(wsID, p)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return
 	}
-	if events == nil {
-		events = []audit.Event{}
-	}
-	respondJSON(w, http.StatusOK, events)
+	respondJSON(w, http.StatusOK, pagination.NewPage(items, total, p.Page, p.Limit))
 }
 
 func registerEventRoutes(r chi.Router, store *audit.Store, svc *auth.Service) {

--- a/internal/api/relationship_handler.go
+++ b/internal/api/relationship_handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DisruptiveWorks/archipulse/internal/audit"
 	"github.com/DisruptiveWorks/archipulse/internal/auth"
+	"github.com/DisruptiveWorks/archipulse/internal/pagination"
 	"github.com/DisruptiveWorks/archipulse/internal/relationship"
 )
 
@@ -25,12 +26,13 @@ func (h *relationshipHandler) list(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}
-	rels, err := h.store.List(wsID)
+	p := parsePage(r)
+	items, total, err := h.store.List(wsID, p)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return
 	}
-	respondJSON(w, http.StatusOK, rels)
+	respondJSON(w, http.StatusOK, pagination.NewPage(items, total, p.Page, p.Limit))
 }
 
 func (h *relationshipHandler) get(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/saved_views_handler.go
+++ b/internal/api/saved_views_handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DisruptiveWorks/archipulse/internal/auth"
 	"github.com/DisruptiveWorks/archipulse/internal/events"
+	"github.com/DisruptiveWorks/archipulse/internal/pagination"
 	"github.com/DisruptiveWorks/archipulse/internal/savedviews"
 )
 
@@ -24,15 +25,13 @@ func (h *savedViewsHandler) list(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}
-	views, err := h.store.List(wsID)
+	p := parsePage(r)
+	items, total, err := h.store.List(wsID, p)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return
 	}
-	if views == nil {
-		views = []savedviews.SavedView{}
-	}
-	respondJSON(w, http.StatusOK, views)
+	respondJSON(w, http.StatusOK, pagination.NewPage(items, total, p.Page, p.Limit))
 }
 
 func (h *savedViewsHandler) get(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/snapshot_handler.go
+++ b/internal/api/snapshot_handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DisruptiveWorks/archipulse/internal/audit"
 	"github.com/DisruptiveWorks/archipulse/internal/auth"
 	"github.com/DisruptiveWorks/archipulse/internal/exporter"
+	"github.com/DisruptiveWorks/archipulse/internal/pagination"
 	"github.com/DisruptiveWorks/archipulse/internal/parser"
 	"github.com/DisruptiveWorks/archipulse/internal/snapshot"
 )
@@ -30,15 +31,13 @@ func (h *snapshotHandler) list(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, errorf("invalid workspace id"))
 		return
 	}
-	snaps, err := h.store.List(wsID)
+	p := parsePage(r)
+	items, total, err := h.store.List(wsID, p)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return
 	}
-	if snaps == nil {
-		snaps = []snapshot.Snapshot{}
-	}
-	respondJSON(w, http.StatusOK, snaps)
+	respondJSON(w, http.StatusOK, pagination.NewPage(items, total, p.Page, p.Limit))
 }
 
 func (h *snapshotHandler) create(w http.ResponseWriter, r *http.Request) {

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -8,9 +8,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/DisruptiveWorks/archipulse/internal/pagination"
 )
 
 // Action constants.
+
 const (
 	ActionCreate           = "create"
 	ActionUpdate           = "update"
@@ -94,39 +97,38 @@ func (s *Store) Record(p RecordParams) error {
 	return nil
 }
 
-// List returns the most recent events for a workspace (newest first).
-func (s *Store) List(workspaceID uuid.UUID, limit int) ([]Event, error) {
-	if limit <= 0 || limit > 200 {
-		limit = 50
-	}
+// List returns events for a workspace (newest first).
+func (s *Store) List(workspaceID uuid.UUID, p pagination.Params) ([]Event, int, error) {
 	rows, err := s.db.Query(`
 		SELECT id, workspace_id, user_id, user_email, action, entity_type,
 		       COALESCE(entity_id, ''), COALESCE(entity_name, ''),
-		       meta, created_at
+		       meta, created_at,
+		       COUNT(*) OVER() AS total
 		FROM   workspace_events
 		WHERE  workspace_id = $1
 		ORDER  BY created_at DESC
-		LIMIT  $2`, workspaceID, limit)
+		LIMIT  $2 OFFSET $3`, workspaceID, p.Limit, p.Offset())
 	if err != nil {
-		return nil, fmt.Errorf("audit list: %w", err)
+		return nil, 0, fmt.Errorf("audit list: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
 	var out []Event
+	var total int
 	for rows.Next() {
 		var e Event
 		var meta []byte
 		if err := rows.Scan(&e.ID, &e.WorkspaceID, &e.UserID, &e.UserEmail,
 			&e.Action, &e.EntityType, &e.EntityID, &e.EntityName,
-			&meta, &e.CreatedAt); err != nil {
-			return nil, err
+			&meta, &e.CreatedAt, &total); err != nil {
+			return nil, 0, err
 		}
 		if len(meta) > 0 {
 			e.Meta = json.RawMessage(meta)
 		}
 		out = append(out, e)
 	}
-	return out, rows.Err()
+	return out, total, rows.Err()
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────

--- a/internal/diagram/diagram.go
+++ b/internal/diagram/diagram.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/DisruptiveWorks/archipulse/internal/pagination"
 )
 
 var ErrNotFound = errors.New("diagram not found")
@@ -32,12 +34,38 @@ type Store struct {
 
 func NewStore(db *sql.DB) *Store { return &Store{db: db} }
 
-func (s *Store) List(workspaceID uuid.UUID) ([]Diagram, error) {
+func (s *Store) List(workspaceID uuid.UUID, p pagination.Params) ([]Diagram, int, error) {
+	rows, err := s.db.Query(`
+		SELECT id, workspace_id, source_id, name, documentation, layout, version, created_at, updated_at,
+		       COUNT(*) OVER() AS total
+		FROM diagrams WHERE workspace_id = $1 ORDER BY name
+		LIMIT $2 OFFSET $3`, workspaceID, p.Limit, p.Offset())
+	if err != nil {
+		return nil, 0, fmt.Errorf("list diagrams: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []Diagram
+	var total int
+	for rows.Next() {
+		var d Diagram
+		if err := rows.Scan(&d.ID, &d.WorkspaceID, &d.SourceID, &d.Name,
+			&d.Documentation, &d.Layout, &d.Version, &d.CreatedAt, &d.UpdatedAt, &total); err != nil {
+			return nil, 0, err
+		}
+		out = append(out, d)
+	}
+	return out, total, rows.Err()
+}
+
+// ListAll returns every diagram in a workspace without pagination.
+// Use for internal operations (export, snapshot) that need the full dataset.
+func (s *Store) ListAll(workspaceID uuid.UUID) ([]Diagram, error) {
 	rows, err := s.db.Query(`
 		SELECT id, workspace_id, source_id, name, documentation, layout, version, created_at, updated_at
 		FROM diagrams WHERE workspace_id = $1 ORDER BY name`, workspaceID)
 	if err != nil {
-		return nil, fmt.Errorf("list diagrams: %w", err)
+		return nil, fmt.Errorf("list all diagrams: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 

--- a/internal/element/element.go
+++ b/internal/element/element.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/DisruptiveWorks/archipulse/internal/pagination"
 )
 
 // Property is a key/value pair stored in element_properties.
@@ -43,12 +45,38 @@ type Store struct {
 
 func NewStore(db *sql.DB) *Store { return &Store{db: db} }
 
-func (s *Store) List(workspaceID uuid.UUID) ([]Element, error) {
+func (s *Store) List(workspaceID uuid.UUID, p pagination.Params) ([]Element, int, error) {
+	rows, err := s.db.Query(`
+		SELECT id, workspace_id, source_id, type, layer, name, documentation, version, created_at, updated_at,
+		       COUNT(*) OVER() AS total
+		FROM elements WHERE workspace_id = $1 ORDER BY name
+		LIMIT $2 OFFSET $3`, workspaceID, p.Limit, p.Offset())
+	if err != nil {
+		return nil, 0, fmt.Errorf("list elements: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []Element
+	var total int
+	for rows.Next() {
+		var e Element
+		if err := rows.Scan(&e.ID, &e.WorkspaceID, &e.SourceID, &e.Type, &e.Layer, &e.Name,
+			&e.Documentation, &e.Version, &e.CreatedAt, &e.UpdatedAt, &total); err != nil {
+			return nil, 0, err
+		}
+		out = append(out, e)
+	}
+	return out, total, rows.Err()
+}
+
+// ListAll returns every element in a workspace without pagination.
+// Use for internal operations (export, snapshot) that need the full dataset.
+func (s *Store) ListAll(workspaceID uuid.UUID) ([]Element, error) {
 	rows, err := s.db.Query(`
 		SELECT id, workspace_id, source_id, type, layer, name, documentation, version, created_at, updated_at
 		FROM elements WHERE workspace_id = $1 ORDER BY name`, workspaceID)
 	if err != nil {
-		return nil, fmt.Errorf("list elements: %w", err)
+		return nil, fmt.Errorf("list all elements: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 

--- a/internal/exporter/loader.go
+++ b/internal/exporter/loader.go
@@ -79,12 +79,12 @@ func LoadModel(db *sql.DB, workspaceID uuid.UUID) (*parser.Model, error) {
 		return nil, fmt.Errorf("load workspace: %w", err)
 	}
 
-	elems, err := element.NewStore(db).List(workspaceID)
+	elems, err := element.NewStore(db).ListAll(workspaceID)
 	if err != nil {
 		return nil, fmt.Errorf("load elements: %w", err)
 	}
 
-	rels, err := relationship.NewStore(db).List(workspaceID)
+	rels, err := relationship.NewStore(db).ListAll(workspaceID)
 	if err != nil {
 		return nil, fmt.Errorf("load relationships: %w", err)
 	}

--- a/internal/pagination/pagination.go
+++ b/internal/pagination/pagination.go
@@ -1,0 +1,44 @@
+// Package pagination provides shared types for paginated API list endpoints.
+package pagination
+
+const defaultLimit = 100
+const maxLimit = 500
+
+// Params holds normalized pagination inputs derived from query parameters.
+type Params struct {
+	Page  int
+	Limit int
+}
+
+// Normalize returns a Params with sane defaults and bounds applied.
+func Normalize(page, limit int) Params {
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 {
+		limit = defaultLimit
+	}
+	if limit > maxLimit {
+		limit = maxLimit
+	}
+	return Params{Page: page, Limit: limit}
+}
+
+// Offset returns the SQL OFFSET value for this page.
+func (p Params) Offset() int { return (p.Page - 1) * p.Limit }
+
+// Page is the generic paginated response envelope.
+type Page[T any] struct {
+	Items []T `json:"items"`
+	Total int `json:"total"`
+	Page  int `json:"page"`
+	Limit int `json:"limit"`
+}
+
+// NewPage wraps items in a Page, ensuring Items is never null in JSON.
+func NewPage[T any](items []T, total, page, limit int) Page[T] {
+	if items == nil {
+		items = []T{}
+	}
+	return Page[T]{Items: items, Total: total, Page: page, Limit: limit}
+}

--- a/internal/relationship/relationship.go
+++ b/internal/relationship/relationship.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/DisruptiveWorks/archipulse/internal/pagination"
 )
 
 var ErrNotFound = errors.New("relationship not found")
@@ -36,7 +38,38 @@ type Store struct {
 
 func NewStore(db *sql.DB) *Store { return &Store{db: db} }
 
-func (s *Store) List(workspaceID uuid.UUID) ([]Relationship, error) {
+func (s *Store) List(workspaceID uuid.UUID, p pagination.Params) ([]Relationship, int, error) {
+	rows, err := s.db.Query(`
+		SELECT id, workspace_id, source_id, type, source_element, target_element,
+		       name, documentation,
+		       COALESCE(access_type, ''), is_directed, COALESCE(modifier, ''),
+		       version, created_at, updated_at,
+		       COUNT(*) OVER() AS total
+		FROM relationships WHERE workspace_id = $1 ORDER BY type, name
+		LIMIT $2 OFFSET $3`, workspaceID, p.Limit, p.Offset())
+	if err != nil {
+		return nil, 0, fmt.Errorf("list relationships: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []Relationship
+	var total int
+	for rows.Next() {
+		var rel Relationship
+		if err := rows.Scan(&rel.ID, &rel.WorkspaceID, &rel.SourceID, &rel.Type,
+			&rel.SourceElement, &rel.TargetElement, &rel.Name, &rel.Documentation,
+			&rel.AccessType, &rel.IsDirected, &rel.Modifier,
+			&rel.Version, &rel.CreatedAt, &rel.UpdatedAt, &total); err != nil {
+			return nil, 0, err
+		}
+		out = append(out, rel)
+	}
+	return out, total, rows.Err()
+}
+
+// ListAll returns every relationship in a workspace without pagination.
+// Use for internal operations (export, snapshot) that need the full dataset.
+func (s *Store) ListAll(workspaceID uuid.UUID) ([]Relationship, error) {
 	rows, err := s.db.Query(`
 		SELECT id, workspace_id, source_id, type, source_element, target_element,
 		       name, documentation,
@@ -44,7 +77,7 @@ func (s *Store) List(workspaceID uuid.UUID) ([]Relationship, error) {
 		       version, created_at, updated_at
 		FROM relationships WHERE workspace_id = $1 ORDER BY type, name`, workspaceID)
 	if err != nil {
-		return nil, fmt.Errorf("list relationships: %w", err)
+		return nil, fmt.Errorf("list all relationships: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 

--- a/internal/savedviews/store.go
+++ b/internal/savedviews/store.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/DisruptiveWorks/archipulse/internal/pagination"
 )
 
 // SavedView represents a persisted automatic view with its filter state.
@@ -28,26 +30,29 @@ func NewStore(db *sql.DB) *Store {
 	return &Store{db: db}
 }
 
-func (s *Store) List(wsID uuid.UUID) ([]SavedView, error) {
+func (s *Store) List(wsID uuid.UUID, p pagination.Params) ([]SavedView, int, error) {
 	rows, err := s.db.Query(`
-		SELECT id, workspace_id, view_type, name, filters, created_at, updated_at
+		SELECT id, workspace_id, view_type, name, filters, created_at, updated_at,
+		       COUNT(*) OVER() AS total
 		FROM saved_views
 		WHERE workspace_id = $1
-		ORDER BY name`, wsID)
+		ORDER BY name
+		LIMIT $2 OFFSET $3`, wsID, p.Limit, p.Offset())
 	if err != nil {
-		return nil, fmt.Errorf("list saved views: %w", err)
+		return nil, 0, fmt.Errorf("list saved views: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
 	var out []SavedView
+	var total int
 	for rows.Next() {
 		var sv SavedView
-		if err := rows.Scan(&sv.ID, &sv.WorkspaceID, &sv.ViewType, &sv.Name, &sv.Filters, &sv.CreatedAt, &sv.UpdatedAt); err != nil {
-			return nil, err
+		if err := rows.Scan(&sv.ID, &sv.WorkspaceID, &sv.ViewType, &sv.Name, &sv.Filters, &sv.CreatedAt, &sv.UpdatedAt, &total); err != nil {
+			return nil, 0, err
 		}
 		out = append(out, sv)
 	}
-	return out, rows.Err()
+	return out, total, rows.Err()
 }
 
 func (s *Store) Get(wsID, id uuid.UUID) (*SavedView, error) {

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/DisruptiveWorks/archipulse/internal/pagination"
 )
 
 // ErrNotFound is returned when a snapshot does not exist.
@@ -42,29 +44,32 @@ func NewStore(db *sql.DB) *Store {
 	return &Store{db: db}
 }
 
-// List returns all snapshots for a workspace (newest first), without payload.
-func (s *Store) List(workspaceID uuid.UUID) ([]Snapshot, error) {
+// List returns snapshots for a workspace (newest first), without payload.
+func (s *Store) List(workspaceID uuid.UUID, p pagination.Params) ([]Snapshot, int, error) {
 	rows, err := s.db.Query(`
 		SELECT id, workspace_id, created_by, created_by_email,
-		       COALESCE(label, ''), trigger, created_at
+		       COALESCE(label, ''), trigger, created_at,
+		       COUNT(*) OVER() AS total
 		FROM   workspace_snapshots
 		WHERE  workspace_id = $1
-		ORDER  BY created_at DESC`, workspaceID)
+		ORDER  BY created_at DESC
+		LIMIT  $2 OFFSET $3`, workspaceID, p.Limit, p.Offset())
 	if err != nil {
-		return nil, fmt.Errorf("list snapshots: %w", err)
+		return nil, 0, fmt.Errorf("list snapshots: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
 	var out []Snapshot
+	var total int
 	for rows.Next() {
 		var snap Snapshot
 		if err := rows.Scan(&snap.ID, &snap.WorkspaceID, &snap.CreatedBy,
-			&snap.CreatedByEmail, &snap.Label, &snap.Trigger, &snap.CreatedAt); err != nil {
-			return nil, err
+			&snap.CreatedByEmail, &snap.Label, &snap.Trigger, &snap.CreatedAt, &total); err != nil {
+			return nil, 0, err
 		}
 		out = append(out, snap)
 	}
-	return out, rows.Err()
+	return out, total, rows.Err()
 }
 
 // Get returns a single snapshot including its AOEF XML payload.

--- a/tests/diagram_test.go
+++ b/tests/diagram_test.go
@@ -41,7 +41,7 @@ func TestDiagramStore_CRUD(t *testing.T) {
 	}
 
 	// List
-	list, err := dStore.List(ws.ID)
+	list, err := dStore.ListAll(ws.ID)
 	if err != nil {
 		t.Fatalf("List diagrams: %v", err)
 	}

--- a/tests/element_test.go
+++ b/tests/element_test.go
@@ -38,7 +38,7 @@ func TestElementStore_CRUD(t *testing.T) {
 	}
 
 	// List
-	list, err := eStore.List(ws.ID)
+	list, err := eStore.ListAll(ws.ID)
 	if err != nil {
 		t.Fatalf("List elements: %v", err)
 	}

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -54,7 +54,7 @@ func testAuthService(t *testing.T, conn *sql.DB) *auth.Service {
 func testRouter(t *testing.T, conn *sql.DB) http.Handler {
 	t.Helper()
 	svc := testAuthService(t, conn)
-	return api.NewRouter(conn, svc, nil)
+	return api.NewRouter(conn, svc, nil, "test")
 }
 
 // addAuthCookie attaches a signed admin JWT cookie to req, so that the

--- a/tests/relationship_test.go
+++ b/tests/relationship_test.go
@@ -38,7 +38,7 @@ func TestRelationshipStore_CRUD(t *testing.T) {
 	}
 
 	// List
-	list, err := rStore.List(ws.ID)
+	list, err := rStore.ListAll(ws.ID)
 	if err != nil {
 		t.Fatalf("List relationships: %v", err)
 	}


### PR DESCRIPTION
## Summary

- New `internal/pagination` package: `Params` (page/limit with defaults/bounds), `Page[T]` generic envelope, `Normalize()`, `parsePage()` helper
- All list endpoints now accept `?page=1&limit=50` and return `{"items":[...],"total":N,"page":P,"limit":L}`
- Default limit: 100 · Max limit: 500
- `COUNT(*) OVER()` window function — single query, no extra round-trip for total
- `ListAll()` added to element, relationship, diagram stores for internal callers (exporter, snapshot) that need the full dataset without pagination
- Integration tests updated to use `ListAll` when calling stores directly

## Endpoints affected

`GET /elements` · `GET /relationships` · `GET /diagrams` · `GET /saved-views` · `GET /snapshots` · `GET /events`

## Test plan

- [ ] `GET /workspaces/{id}/elements` returns `{"items":[...],"total":N,"page":1,"limit":100}` by default
- [ ] `?page=2&limit=10` returns correct slice and same total
- [ ] `?limit=600` is clamped to 500
- [ ] Empty workspace returns `{"items":[],"total":0,"page":1,"limit":100}`
- [ ] All integration tests pass