### PR TITLE
fix(model-editor): resolve relationship names for MCP-created elements

### DIFF
--- a/cmd/archipulse/ui/src/routes/ModelEditor.svelte
+++ b/cmd/archipulse/ui/src/routes/ModelEditor.svelte
@@ -70,7 +70,10 @@
   let relSearch      = '';
   let activeRelType  = '';  // '' = all
 
-  $: elementsById = Object.fromEntries(elements.map(e => [e.source_id, e]));
+  $: elementsById = Object.fromEntries([
+    ...elements.map(e => [e.id, e]),
+    ...elements.filter(e => e.source_id).map(e => [e.source_id, e]),
+  ]);
 
   $: relTypes = [...new Set(relationships.map(r => r.type))].sort();
 


### PR DESCRIPTION
## Summary

- `elementsById` was indexed by `source_id` only, which works for AOEF-imported elements (where `source_element` references the ArchiMate identifier) but not for MCP-created elements (where `source_element` references the database UUID)
- Fix: index by both `id` and `source_id` so lookups work regardless of origin

## Test plan

- [ ] Open Model Editor on a workspace created via MCP — relationships should show element names, not UUIDs
- [ ] Open Model Editor on an AOEF-imported workspace (e.g. Archisurance) — relationships should still show element names correctly