### PR TITLE
feat: one-click public demo via ?try=demo URL parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 Built on ArchiMate · Powered by Go · PostgreSQL · Open Source
 
+[![Try the live demo](https://img.shields.io/badge/▶%20Try%20the%20live%20demo-E85D3A?style=for-the-badge&logoColor=white)](https://demo.archipulse.org/#/login?try=demo)
+
 [![Build](https://img.shields.io/github/actions/workflow/status/DisruptiveWorks/archipulse/ci.yml?branch=main&style=flat-square)](https://github.com/DisruptiveWorks/archipulse/actions)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](./LICENSE)
 [![Go Version](https://img.shields.io/badge/go-1.24%2B-00ADD8?style=flat-square&logo=go)](https://go.dev)
@@ -17,13 +19,13 @@ Built on ArchiMate · Powered by Go · PostgreSQL · Open Source
 [![ArchiMate](https://img.shields.io/badge/ArchiMate-3.2-orange?style=flat-square)](https://www.opengroup.org/archimate-forum)
 [![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen?style=flat-square)](./CONTRIBUTING.md)
 
-[Live Demo](https://demo.archipulse.org) · [Getting Started](#getting-started) · [Features](#features) · [How It Works](#how-it-works) · [Roadmap](#roadmap) · [Contributing](#contributing) · [Support](#support)
+[Live Demo](https://demo.archipulse.org/#/login?try=demo) · [Getting Started](#getting-started) · [Features](#features) · [How It Works](#how-it-works) · [Roadmap](#roadmap) · [Contributing](#contributing) · [Support](#support)
 
 </div>
 
 ---
 
-> **Try it:** [demo.archipulse.org](https://demo.archipulse.org) — pre-loaded with the ArchiSurance example model. No sign-up required.
+> **Try it:** [demo.archipulse.org](https://demo.archipulse.org/#/login?try=demo) — pre-loaded with ArchiSurance and ArchiMetal example models. One click, no sign-up required.
 
 ---
 
@@ -129,7 +131,7 @@ flowchart TD
 <!-- Replace VIDEO_ID with the YouTube video ID once the demo is published -->
 <!-- [![ArchiPulse Demo](https://img.youtube.com/vi/VIDEO_ID/maxresdefault.jpg)](https://www.youtube.com/watch?v=VIDEO_ID) -->
 
-> Demo video coming soon. In the meantime, try the [live demo](https://demo.archipulse.org) — no sign-up required.
+> Demo video coming soon. In the meantime, try the [live demo](https://demo.archipulse.org/#/login?try=demo) — one click, no sign-up required.
 
 ---
 

--- a/cmd/archipulse/ui/src/routes/Login.svelte
+++ b/cmd/archipulse/ui/src/routes/Login.svelte
@@ -20,6 +20,13 @@
     demoMode = cfg.demo_mode ?? false;
     demoEmail = cfg.demo_email ?? '';
     demoPassword = cfg.demo_password ?? '';
+
+    const hashParams = new URLSearchParams(window.location.hash.split('?')[1] || '');
+    const searchParams = new URLSearchParams(window.location.search);
+    const tryParam = hashParams.get('try') || searchParams.get('try');
+    if (demoMode && tryParam === 'demo') {
+      await loginAsDemo();
+    }
   });
 
   async function handleSubmit(e) {

--- a/website/index.html
+++ b/website/index.html
@@ -565,7 +565,7 @@
     </span>
   </a>
   <ul class="nav-links">
-    <li><a href="https://demo.archipulse.org" target="_blank">Live Demo</a></li>
+    <li><a href="https://demo.archipulse.org/#/login?try=demo" target="_blank">Live Demo</a></li>
     <li><a href="#screenshots">Screenshots</a></li>
     <li><a href="#how-it-works">How it works</a></li>
     <li><a href="#features">Features</a></li>
@@ -596,7 +596,7 @@
   </p>
 
   <div class="hero-actions fade-up delay-3">
-    <a href="https://demo.archipulse.org" class="btn-primary" target="_blank">
+    <a href="https://demo.archipulse.org/#/login?try=demo" class="btn-primary" target="_blank">
       Live Demo →
     </a>
     <a href="https://github.com/DisruptiveWorks/archipulse" class="btn-secondary" target="_blank">
@@ -621,7 +621,7 @@
     <strong>Try ArchiPulse live</strong>
     <span>Explore fully loaded ArchiSurance and ArchiMetal models — application dashboard, capability landscape, dependency graph, and AOEF export. No sign-up, no install.</span>
   </div>
-  <a href="https://demo.archipulse.org" class="btn-primary" target="_blank">
+  <a href="https://demo.archipulse.org/#/login?try=demo" class="btn-primary" target="_blank">
     Open Live Demo →
   </a>
 </div>


### PR DESCRIPTION
## Summary
Removes friction from the public demo entry path. Visitors arriving from external surfaces (marketing site, README, LinkedIn, Reddit) land directly in the workspace list — no form to fill, no credentials to copy.

## Changes
- **`Login.svelte`**: in `onMount`, when demo mode is enabled and the URL carries `?try=demo` (in either hash or search), auto-invoke `loginAsDemo()` and redirect to the home route. Existing sessions take priority — real users with an active session are sent to `/` before the demo branch runs.
- **`website/index.html`**: the three "Live Demo" CTAs (nav link, hero banner, demo banner) now point at `https://demo.archipulse.org/#/login?try=demo`.
- **`README.md`**: prominent brand-coloured "Try the live demo" badge added at the top of the badge block; all in-body demo links updated to the one-click URL.

## Security notes
- No new attack surface. Demo credentials are already public (shown on the login screen).
- Existing CSRF/session protections from the manual login path apply unchanged.
- Real users with active sessions are protected by the existing `if (u) push('/')` guard before any demo logic runs.
- `?try=demo` is a trigger string, not a secret.

## Deploy note
The marketing site (Cloudflare Pages) and README update take effect on merge. The `Login.svelte` change requires the demo deployment (Railway) to rebuild the embedded SPA — confirm that auto-build is configured or trigger manually after merge.

## Test plan
- [ ] Cloudflare preview of website shows updated demo links
- [ ] README badge renders correctly on GitHub
- [ ] After demo redeploy: visiting `https://demo.archipulse.org/#/login?try=demo` lands directly on workspace list
- [ ] Manual sign-in flow still works for real users (existing form unchanged)
- [ ] Already-logged-in users hitting the demo URL stay logged in as themselves (not switched to demo)