### PR TITLE
feat(demo): cap public demo user at 5 owned workspaces

### DIFF
--- a/internal/api/workspace_handler.go
+++ b/internal/api/workspace_handler.go
@@ -64,6 +64,11 @@ func (h *workspaceHandler) get(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, http.StatusOK, resp)
 }
 
+// demoUserWorkspaceQuota caps how many workspaces the shared public-demo
+// user can own concurrently. Prevents pollution of the demo instance from
+// viral traffic. TODO(#102): replace with proper plans/quotas system.
+const demoUserWorkspaceQuota = 5
+
 func (h *workspaceHandler) create(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Name        string `json:"name"`
@@ -78,13 +83,30 @@ func (h *workspaceHandler) create(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, errorf("name and purpose are required"))
 		return
 	}
+
+	// Enforce demo user workspace quota (see #102 for planned refactor).
+	claims := auth.ClaimsFromCtx(r.Context())
+	if claims != nil && h.svc.Cfg.DemoMode && claims.Email == h.svc.Cfg.DemoEmail {
+		n, err := h.store.CountOwnedByUser(claims.UserID)
+		if err != nil {
+			respondError(w, http.StatusInternalServerError, err)
+			return
+		}
+		if n >= demoUserWorkspaceQuota {
+			respondError(w, http.StatusTooManyRequests, errorf(
+				"demo limit reached (%d workspaces). Deploy your own instance for unlimited workspaces — star us on GitHub: https://github.com/DisruptiveWorks/archipulse",
+				demoUserWorkspaceQuota))
+			return
+		}
+	}
+
 	ws, err := h.store.Create(body.Name, body.Purpose, body.Description)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return
 	}
 	// Seed the creating user as workspace owner.
-	if claims := auth.ClaimsFromCtx(r.Context()); claims != nil {
+	if claims != nil {
 		_ = h.svc.Enforcer.SeedOwner(ws.ID.String(), claims.UserID)
 	}
 	respondJSON(w, http.StatusCreated, ws)

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -89,6 +89,21 @@ func (s *Store) ListForUser(userID string, isAdmin bool) ([]Workspace, error) {
 	return out, rows.Err()
 }
 
+// CountOwnedByUser returns the number of workspaces where the user has the
+// 'owner' role. Used by handlers that need to enforce per-user quotas
+// (e.g. the demo user workspace limit). See issue #102 for the planned
+// refactor to a proper plans/quotas system.
+func (s *Store) CountOwnedByUser(userID string) (int, error) {
+	var n int
+	err := s.db.QueryRow(`
+		SELECT COUNT(*) FROM workspace_members
+		WHERE  user_id = $1 AND role = 'owner'`, userID).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count workspaces owned by user: %w", err)
+	}
+	return n, nil
+}
+
 // Get returns a single workspace by ID.
 func (s *Store) Get(id uuid.UUID) (*Workspace, error) {
 	var w Workspace


### PR DESCRIPTION
## Summary
Pragmatic launch-day protection: the public demo user (\`demo@archipulse.org\`) is capped at 5 owned workspaces. Prevents pollution of the shared demo instance from viral traffic when the anchor video ships on 2026-07-06.

## Behavior

When the demo user tries to create a sixth workspace:
- HTTP 429 Too Many Requests
- Message: *"demo limit reached (5 workspaces). Deploy your own instance for unlimited workspaces — star us on GitHub: https://github.com/DisruptiveWorks/archipulse"*

The message converts the limit into an adoption CTA. Non-demo users are unaffected.

## Changes
- \`workspace.Store\`: new \`CountOwnedByUser(userID)\` method (owner-role only).
- \`workspace_handler.create\`: quota gate before \`Store.Create\` when \`svc.Cfg.DemoMode\` is true and \`claims.Email == svc.Cfg.DemoEmail\`.
- \`demoUserWorkspaceQuota = 5\` package-level constant.

## Explicit tech debt
This hardcodes the demo email in a handler — not the right long-term design. Issue #102 tracks the proper refactor to a Plans + Quotas system that applies to all users.

Marked with a TODO(#102) comment. When #102 lands, the entire \`if claims.Email == ... DemoEmail\` block gets replaced by a generic quota middleware and this constant deleted.

## Also protects
- Cloudflare rate limit already in place at edge (100 req / 10s / IP) → catches bots.
- This PR adds app-level protection → catches human abusers or slow bots that pass the rate limit.

## Test plan
- [ ] After deploy, log in as demo user, create 5 workspaces → all succeed.
- [ ] Try to create 6th → HTTP 429 with CTA message.
- [ ] Delete one demo workspace → creating a new one succeeds again.
- [ ] Non-demo users can still create workspaces without limit.

## Deploy notes
Must be propagated to the \`demo\` branch after merge to main so Railway rebuilds. See [[reference-deploy-branches]] in memory.