### PR TITLE
feat(website): embed anchor demo video between hero and demo banner

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -204,6 +204,30 @@
       margin: 0 auto;
     }
 
+    /* ── Video section ───────────────────────────────────────────────── */
+    #video {
+      padding: 24px 24px 8px;
+      max-width: 1100px;
+      margin: 0 auto;
+    }
+    .video-wrap {
+      position: relative;
+      padding-bottom: 56.25%; /* 16:9 aspect ratio */
+      height: 0;
+      max-width: 900px;
+      margin: 0 auto;
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 8px 32px rgba(15, 23, 42, 0.08);
+    }
+    .video-wrap iframe {
+      position: absolute;
+      top: 0; left: 0;
+      width: 100%;
+      height: 100%;
+      border: 0;
+    }
+
     /* ── Demo banner ─────────────────────────────────────────────────── */
     .demo-banner {
       background: var(--brand-lt);
@@ -610,6 +634,21 @@
     <div class="tech-badge"><span class="dot dot-pg"></span> PostgreSQL 17+</div>
     <div class="tech-badge"><span class="dot dot-open"></span> ArchiMate 3.2</div>
     <div class="tech-badge"><span class="dot dot-mit"></span> Apache 2.0</div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ── Video ─────────────────────────────────────────────────────────── -->
+<section id="video">
+  <div class="video-wrap">
+    <iframe
+      src="https://www.youtube.com/embed/TjIFE7yhzrg"
+      title="ArchiPulse — AI-native Enterprise Architecture (demo)"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+      referrerpolicy="strict-origin-when-cross-origin"
+      allowfullscreen
+    ></iframe>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
Embeds the 2-minute anchor demo video directly on archipulse.org so visitors can watch it without leaving the site.

- Placement: right after the hero, before the demo banner — highest visibility spot.
- Responsive 16:9 wrapper with a subtle shadow and rounded corners.
- YouTube iframe embed (video hosted on Disruptive Works channel, unlisted).

## Preview flow
Hero pitch → Watch video → Click Live Demo → Try it themselves.

## Test plan
- [ ] Cloudflare Pages preview shows the video playing inline
- [ ] Responsive layout works on mobile (video maintains 16:9)
- [ ] No layout shift when video loads